### PR TITLE
Remove SYCL forward decls in device_queue header

### DIFF
--- a/include/device_queue.h
+++ b/include/device_queue.h
@@ -2,6 +2,8 @@
 
 #include <memory>
 
+#include <CL/sycl.hpp>
+
 #include "config.h"
 #include "handler.h"
 #include "logger.h"
@@ -9,14 +11,6 @@
 #include "task.h"
 #include "task_manager.h"
 #include "types.h"
-
-namespace cl {
-namespace sycl {
-	class device;
-	class event;
-	class queue;
-} // namespace sycl
-} // namespace cl
 
 namespace celerity {
 namespace detail {


### PR DESCRIPTION
A recent change in hipSYCL is incompatible with these forward
declarations (and they probably never were such a great idea to begin
with...).