### PR TITLE
Enable SYCL-native kernel profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Celerity's runtime behavior:
   `CELERITY_DEVICES="<platform_id> <first device_id> <second device_id> ... <nth device_id>"`.
   Note that this should normally not be required, as Celerity will attempt to
   automatically assign a unique device to each worker on a host.
-- `CELERITY_PROFILE_OCL` controls whether OpenCL-level profiling information
+- `CELERITY_PROFILE_KERNEL` controls whether SYCL queue profiling information
   should be queried (currently not supported when using hipSYCL).
 
 ## Disclaimer

--- a/src/config.cc
+++ b/src/config.cc
@@ -149,13 +149,17 @@ namespace detail {
 			}
 		}
 
-		// ------------------------------- CELERITY_PROFILE_OCL -------------------------------
-
+		// ----------------------------- CELERITY_PROFILE_KERNEL ------------------------------
 		{
 			const auto result = get_env("CELERITY_PROFILE_OCL");
+			if(result.first) { logger.warn("CELERITY_PROFILE_OCL has been renamed to CELERITY_PROFILE_KERNEL with Celerity 0.3.0."); }
+		}
+
+		{
+			const auto result = get_env("CELERITY_PROFILE_KERNEL");
 			if(result.first) {
 				enable_device_profiling = result.second == "1";
-#if WORKAROUND(HIPSYCL, 0)
+#if WORKAROUND_HIPSYCL
 				if(*enable_device_profiling) {
 					logger.warn("Device profiling is currently not supported on hipSYCL");
 					enable_device_profiling = false;

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -14,7 +14,7 @@ namespace detail {
 		if(device_profiling_enabled) { queue_logger.info("Device profiling enabled."); }
 
 		cl::sycl::property_list props = ([&]() {
-#if !WORKAROUND(HIPSYCL, 0)
+#if !WORKAROUND_HIPSYCL
 			if(device_profiling_enabled) { return cl::sycl::property_list{cl::sycl::property::queue::enable_profiling()}; }
 #endif
 			return cl::sycl::property_list{};


### PR DESCRIPTION
So far, execution times were either measured on the host, which is pretty inaccurate, or through OpenCL, which was only possible for ComputeCpp. Once changes from https://github.com/illuhad/hipSYCL/pull/251 are merged, hipSYCL will support `cl::sycl::event::get_profiling_info<>()`, providing accurate timings for both ComputeCpp and hipSYCL. This PR must not be merged before the upstream hipSYCL PR.