### PR TITLE
Add workarounds for Boost 1.69+ hipSYCL/CUDA issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,13 +128,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
   target_compile_options(celerity_runtime PRIVATE -Wall -Wextra -Wno-unused-parameter)
 endif()
 
-if(CELERITY_SYCL_IMPL STREQUAL "hipSYCL")
-  # Boost currently (as of 1.71) does not enable variadic macros
-  # when it detects CUDA compilation.
-  # Since we are using Clang however (via hipSYCL) instead of NVCC,
-  # the macros can and should be enabled.
-  # See https://github.com/boostorg/preprocessor/issues/24
-  target_compile_definitions(celerity_runtime PUBLIC BOOST_PP_VARIADICS=1)
+if(CELERITY_SYCL_IMPL STREQUAL "hipSYCL" AND HIPSYCL_PLATFORM_CANONICAL MATCHES "cuda|rocm")
+  # Boost does not anticipate us compiling CUDA with Clang, so we have to enable several workarounds.
+  target_compile_definitions(celerity_runtime PUBLIC __CELERITY_ENABLE_BOOST_WORKAROUNDS__)
+  target_compile_options(celerity_runtime PRIVATE "-include${CMAKE_CURRENT_SOURCE_DIR}/include/boost_workarounds.h")
 endif()
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ installed first.
 - A supported SYCL implementation, either
   - [hipSYCL](https://github.com/illuhad/hipsycl), or
   - [ComputeCpp](https://www.codeplay.com/products/computesuite/computecpp)
-- [Boost](http://www.boost.org) (we recommended version 1.65 - 1.68)
-  - If you use hipSYCL to target the CUDA platform, you may run into issues
-    with newer versions of Boost.
+- [Boost](http://www.boost.org) (we recommended version 1.65 - 1.73)
 - A MPI 2 implementation (tested with OpenMPI 4.0, MPICH 3.3 should work as well)
 - [CMake](https://www.cmake.org) (3.5.1 or newer)
 - A C++14 compiler

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,9 +8,8 @@ Celerity can be built and installed from
 [source](https://github.com/celerity/celerity-runtime) using
 [CMake](https://cmake.org). It requires the following dependencies:
 
-- [Boost](https://boost.org) (**Note**: There appear to be some issues with
-  newer versions of Boost - pending investigation. In the meantime we
-  recommend using a version ranging from 1.65 to 1.68)
+- [Boost](https://boost.org) (We recommend using a version ranging from 1.65
+  to 1.73)
 - A MPI 2 implementation (for example [OpenMPI 4](https://www.open-mpi.org))
 - A C++14 compiler
 - A supported SYCL implementation (see below)

--- a/include/boost_workarounds.h
+++ b/include/boost_workarounds.h
@@ -1,0 +1,54 @@
+#pragma once
+
+/**
+ * As of April 2020, Boost (1.73) does not have explicit support for CUDA compilation using Clang.
+ * Instead, Boost assumes (in most places) that CUDA code is always compiled with NVIDIA's NVCC.
+ * Detection of CUDA compilation is based on the __CUDACC__ macro. Unfortunately, this macro is also
+ * set by Clang, alongside the __clang__ macro. This combination is not anticipated by Boost, and
+ * thus, chaos ensues.
+ *
+ * This header contains several workarounds for various issues resulting from this. It is very
+ * likely that similar issues exist for other Boost components that have not yet been used in
+ * Celerity. In that case, additional workarounds will have to be added here (if possible)
+ * and ideally the underlying issue is reported upstream.
+ *
+ * All of this is only required when compiling with hipSYCL targeting the CUDA backend
+ * (and possibly HIP). For the Celerity runtime itself, this header is automatically included in
+ * every translation unit (configured through CMake). For users, it is included from within the main
+ * entry header (celerity.h).
+ *
+ * Note that Boost 1.65 is the earliest version considered here (older versions might still work).
+ */
+
+/**
+ * Ensure that the Clang compiler configuration is being used (otherwise GCC is assumed for CUDA).
+ *
+ * Required for Boost 1.69 - 1.73.
+ */
+#define BOOST_COMPILER_CONFIG "boost/config/compiler/clang.hpp"
+
+/**
+ * The __is_base_of intrinsic is used by Boost type_traits,
+ * which in turn is used all over the place internally.
+ *
+ * Bug repro:
+ * ```
+ *  struct bar {};
+ *  boost::optional<bar> foo;
+ *  foo = bar{};
+ * ```
+ *
+ * Unfortunately there is no easy way to enable all Clang intrinsics, as that particular
+ * header (boost/type_traits/intrinsics.hpp) checks for __CUDACC__ directly.
+ *
+ * Required for Boost 1.65 - 1.68 (if using the Clang config above), 1.69 - 1.73 (not fixed yet).
+ */
+#define BOOST_IS_BASE_OF(T, U) (__is_base_of(T, U) && !is_same<T, U>::value)
+
+/**
+ * Enable variadic preprocessor macros. Used by the WORKAROUND macros in workaround.h.
+ *
+ * Required for Boost 1.65, 1.66, 1.69 - 1.72 (fixed in 1.73).
+ * See https://github.com/boostorg/preprocessor/issues/24
+ */
+#define BOOST_PP_VARIADICS 1

--- a/include/celerity.h
+++ b/include/celerity.h
@@ -1,6 +1,10 @@
 #ifndef RUNTIME_INCLUDE_ENTRY_CELERITY
 #define RUNTIME_INCLUDE_ENTRY_CELERITY
 
+#if defined(__CELERITY_ENABLE_BOOST_WORKAROUNDS__)
+#include "boost_workarounds.h"
+#endif
+
 #include "runtime.h"
 
 #include "buffer.h"


### PR DESCRIPTION
For some time now we had some issues compiling against newer versions of Boost (1.69+) when targeting the hipSYCL CUDA backend. The exact issue can vary from version to version (and sometimes there are several), but everything boils down to the fact that Boost is not really aware that CUDA code can also be compiled using Clang (as opposed to NVCC). Since Boost does compiler detection all over the place, it sometimes ends up generating code targeted at NVCC, Clang or both, resulting in chaos and usually some very long template backtraces.

While not very pretty, with these workarounds I was able to compile Celerity against all recent versions of Boost (1.65 - 1.73) using hipSYCL CUDA.