### PR TITLE
Introduce custom preprocessor flag for debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,24 @@ target_link_libraries(celerity_runtime PUBLIC
   spdlog::spdlog
 )
 
+# For debug builds, we set the CELERITY_DETAIL_ENABLE_DEBUG preprocessor flag,
+# which allows Celerity to control debug functionality within headers regardless
+# of a user target's build type. (This flag is not intended to be modified by
+# end users directly).
+#
+# To make this work, we need to ensure that user targets also receive this flag
+# whenever they link to a Celerity runtime that was built with the DEBUG
+# configuration. Unfortunately there doesn't seem to be a way of doing this using
+# generator expressions, which is why we have to do it manually within
+# celerity-config.cmake instead.
+target_compile_definitions(celerity_runtime PUBLIC
+  # We still mark this as PUBLIC during builds (but not installation),
+  # so that the examples and tests receive the correct flag as well.
+  $<BUILD_INTERFACE:
+    $<$<CONFIG:Debug>:CELERITY_DETAIL_ENABLE_DEBUG>
+  >
+)
+
 if(CELERITY_SYCL_IMPL STREQUAL "ComputeCpp")
 	target_link_libraries(celerity_runtime PUBLIC ComputeCpp::ComputeCpp)
 endif()

--- a/cmake/celerity-config.cmake.in
+++ b/cmake/celerity-config.cmake.in
@@ -19,6 +19,39 @@ include("${CMAKE_CURRENT_LIST_DIR}/../celerity/vendor/cmake/spdlogConfig.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/celerity-targets.cmake")
 
+# We currently assume that only a single Celerity configuration is installed at a time.
+# Unfortunately CMake doesn't remove old configurations when re-installing a target,
+# so we advise to do a clean install (although it would suffice to just remove the
+# configuration-specific target files).
+# NOTE: This assumption is required for the CELERITY_DETAIL_ENABLE_DEBUG mechanism below.
+get_target_property(
+  CELERITY_IMPORTED_CONFIGS
+  Celerity::celerity_runtime
+  IMPORTED_CONFIGURATIONS
+)
+list(LENGTH CELERITY_IMPORTED_CONFIGS CELERITY_CONFIG_COUNT)
+if(CELERITY_CONFIG_COUNT GREATER 1)
+  message(FATAL_ERROR "More than one Celerity build configuration was found: "
+    "${CELERITY_IMPORTED_CONFIGS}. This is currently unsupported. "
+    "Perform a clean installation to remedy this.")
+endif()
+unset(CELERITY_CONFIG_COUNT)
+
+# Set the CELERITY_DETAIL_ENABLE_DEBUG preprocessor flag if the imported target
+# was built with the debug configuration. This flag is also set during the library
+# build itself, see the respective CMakeLists.txt.
+#
+# If the requirement on having only a single configuration is to be lifted, we also
+# have to take MAP_IMPORTED_CONFIG_DEBUG into account to figure out which configuration
+# will be linked to the user target.
+if("DEBUG" IN_LIST CELERITY_IMPORTED_CONFIGS)
+  target_compile_definitions(
+    Celerity::celerity_runtime INTERFACE
+    CELERITY_DETAIL_ENABLE_DEBUG
+  )
+endif()
+unset(CELERITY_IMPORTED_CONFIGS)
+
 function(add_celerity_to_target)
   set(options)
   set(one_value_args TARGET)

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -126,7 +126,7 @@ namespace detail {
 				buffer_infos[bid] = buffer_info{range, is_host_initialized};
 				newest_data_location.emplace(bid, region_map<data_location>(range, data_location::NOWHERE));
 
-#if !defined(NDEBUG)
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 				buffer_types.emplace(bid, new buffer_type_guard<DataT, Dims>());
 #endif
 			}
@@ -200,7 +200,9 @@ namespace detail {
 		access_info<DataT, Dims, device_buffer> get_device_buffer(
 		    buffer_id bid, cl::sycl::access::mode mode, const cl::sycl::range<3>& range, const cl::sycl::id<3>& offset) {
 			std::unique_lock lock(mutex);
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 			assert((buffer_types.at(bid)->has_type<DataT, Dims>()));
+#endif
 			assert((range_cast<3>(offset + range) <= buffer_infos.at(bid).range) == cl::sycl::range<3>(true, true, true));
 
 			auto& old_buffer = buffers[bid].device_buf;
@@ -237,7 +239,9 @@ namespace detail {
 		access_info<DataT, Dims, host_buffer> get_host_buffer(
 		    buffer_id bid, cl::sycl::access::mode mode, const cl::sycl::range<3>& range, const cl::sycl::id<3>& offset) {
 			std::unique_lock lock(mutex);
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 			assert((buffer_types.at(bid)->has_type<DataT, Dims>()));
+#endif
 			assert((range_cast<3>(offset + range) <= buffer_infos.at(bid).range) == cl::sycl::range<3>(true, true, true));
 
 			auto& old_buffer = buffers[bid].host_buf;
@@ -327,7 +331,7 @@ namespace detail {
 
 		enum class data_location { NOWHERE, HOST, DEVICE, HOST_AND_DEVICE };
 
-#if !defined(NDEBUG)
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 		struct buffer_type_guard_base {
 			virtual ~buffer_type_guard_base(){};
 			template <typename DataT, int Dims>
@@ -362,7 +366,7 @@ namespace detail {
 		std::unordered_map<buffer_id, buffer_lock_info> buffer_lock_infos;
 		std::unordered_map<buffer_lock_id, std::vector<buffer_id>> buffer_locks_by_id;
 
-#if !defined(NDEBUG)
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 		// Since we store buffers without type information (i.e., its data type and dimensionality),
 		// it is the user's responsibility to only request access to a buffer using the correct type.
 		// In debug builds we can help out a bit by remembering the type and asserting it on every access.

--- a/src/buffer_manager.cc
+++ b/src/buffer_manager.cc
@@ -28,7 +28,7 @@ namespace detail {
 			buffers.erase(bid);
 			buffer_infos.erase(bid);
 
-#if !defined(NDEBUG)
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 			buffer_types.erase(bid);
 #endif
 		}
@@ -128,7 +128,7 @@ namespace detail {
 		// Check whether we have any scheduled transfers that overlap with the requested subrange, and if so, apply them.
 		// For this, we are not interested in the retain region (but we need to remember what parts will NOT have to be retained afterwards).
 		auto remaining_region_after_transfers = retain_region;
-#ifdef NDEBUG
+#if !defined(CELERITY_DETAIL_ENABLE_DEBUG)
 		// There should only be queued transfers for this buffer iff this is a consumer mode.
 		// To assert this we check for bogus transfers for other modes in debug builds.
 		if(detail::access::mode_traits::is_consumer(mode))

--- a/src/config.cc
+++ b/src/config.cc
@@ -73,10 +73,10 @@ namespace detail {
 		// ------------------------------- CELERITY_LOG_LEVEL ---------------------------------
 
 		{
-#ifdef NDEBUG
-			log_lvl = log_level::info;
-#else
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 			log_lvl = log_level::trace;
+#else
+			log_lvl = log_level::info;
 #endif
 			const std::vector<std::pair<log_level, std::string>> possible_values = {
 			    {log_level::trace, "trace"},

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -16,14 +16,14 @@ namespace detail {
 	}
 
 	void graph_serializer::flush(const std::vector<task_command*>& cmds) {
-#ifndef NDEBUG
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 		task_id check_tid = task_id(-1);
 #endif
 
 		std::vector<std::pair<task_command*, std::vector<command_id>>> cmds_and_deps;
 		cmds_and_deps.reserve(cmds.size());
 		for(auto cmd : cmds) {
-#ifndef NDEBUG
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 			// Verify that all commands belong to the same task
 			assert(check_tid == task_id(-1) || check_tid == cmd->get_tid());
 			check_tid = cmd->get_tid();

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -54,10 +54,10 @@ namespace detail {
 	}
 
 	const char* get_build_type() {
-#ifdef NDEBUG
-		return "release";
-#else
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 		return "debug";
+#else
+		return "release";
 #endif
 	}
 


### PR DESCRIPTION
This introduces the `CELERITY_DETAIL_ENABLE_DEBUG` flag, which is set for debug builds of the Celerity runtime, regardless of a user target's build type. This is more reliable than using `NDEBUG`, as headers and implementation files are always guaranteed to receive the flag, both during library compilation and when linking to it. Also it means having less of those confusing double-negative `!defined(NDEBUG)` checks.

Unfortunately the implementation turned out to be quite annoying (of course...), as CMake doesn't really expose a mechanism for querying the build configuration of a library target that is being linked (which could then be used e.g. in generator expressions). The workaround for now is to inspect the `IMPORTED_CONFIGURATIONS` of the `Celerity::celerity_runtime` library, and use that to conditionally set the flag. For this to work however we require that only a single build configuration is imported in the first place, as otherwise it becomes more difficult to tell which configuration ends up being linked (albeit not impossible).

While thus far we effectively already only really supported one installed build configuration (as we'd otherwise have to set the `CMAKE_<CONFIG>_POSTFIX` variables), instead of adding support for multiple configurations, I've decided to enforce single config installs with an error for now. While I do see merit in having that feature, I can also see it causing a lot of unnecessary headaches during development, when rebuilding one configuration of the runtime, while some executable still links to the other one... So maybe we could look into e.g. only enabling this for versioned releases.

This should fix #19.