### PR TITLE
Silence tons of warnings from CMake 3.19

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19.0") 
+    cmake_policy(SET CMP0110 NEW) # don't spam about add_test names..
+endif()
+
 include("${PROJECT_SOURCE_DIR}/vendor/Catch2/contrib/ParseAndAddCatchTests.cmake")
 
 # Add includes to library so they show up in IDEs


### PR DESCRIPTION
Since CMake 3.19 added a new [policy](https://cmake.org/cmake/help/latest/policy/CMP0110.html) for CTest names and Catch2 exploiting a somewhat edgy behavior beforehand, CMake spills a looot of warnings about this.. Explicitly setting the policy for CMake 3.19+ silences this. The update of Catch2 to the latest 2.x version (2.13.3) is necessary, as in this Catch2 version, the compatibility with the new behavior is introduced.