### PR TITLE
Remove dependency on Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ project(celerity_runtime VERSION ${Celerity_VERSION} LANGUAGES CXX)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake")
-find_package(Boost 1.65.0 REQUIRED COMPONENTS atomic container)
 find_package(MPI 2.0 REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -99,12 +98,10 @@ target_include_directories(celerity_runtime PUBLIC
   $<INSTALL_INTERFACE:include/celerity>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor>
   $<INSTALL_INTERFACE:include/celerity/vendor>
-  ${Boost_INCLUDE_DIRS}
 )
 
 target_link_libraries(celerity_runtime PUBLIC
   Threads::Threads
-  ${Boost_LIBRARIES}
   MPI::MPI_CXX
   spdlog::spdlog
 )
@@ -147,15 +144,6 @@ if(MSVC)
   target_compile_options(celerity_runtime PRIVATE /MP /W3 /D_CRT_SECURE_NO_WARNINGS)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
   target_compile_options(celerity_runtime PRIVATE -Wall -Wextra -Wno-unused-parameter -Werror=return-type -Werror=init-self)
-endif()
-
-if(CELERITY_SYCL_IMPL STREQUAL "hipSYCL")
-  # Boost currently (as of 1.71) does not enable variadic macros
-  # when it detects CUDA compilation.
-  # Since we are using Clang however (via hipSYCL) instead of NVCC,
-  # the macros can and should be enabled.
-  # See https://github.com/boostorg/preprocessor/issues/24
-  target_compile_definitions(celerity_runtime PUBLIC BOOST_PP_VARIADICS=1)
 endif()
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -82,9 +82,6 @@ installed first.
 - A supported SYCL implementation, either
   - [hipSYCL](https://github.com/illuhad/hipsycl), or
   - [ComputeCpp](https://www.codeplay.com/products/computesuite/computecpp)
-- [Boost](http://www.boost.org) (we recommended version 1.65 - 1.68)
-  - If you use hipSYCL to target the CUDA platform, you may run into issues
-    with newer versions of Boost.
 - A MPI 2 implementation (tested with OpenMPI 4.0, MPICH 3.3 should work as well)
 - [CMake](https://www.cmake.org) (3.5.1 or newer)
 - A C++17 compiler

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,9 +8,6 @@ Celerity can be built and installed from
 [source](https://github.com/celerity/celerity-runtime) using
 [CMake](https://cmake.org). It requires the following dependencies:
 
-- [Boost](https://boost.org) (**Note**: There appear to be some issues with
-  newer versions of Boost - pending investigation. In the meantime we
-  recommend using a version ranging from 1.65 to 1.68)
 - A MPI 2 implementation (for example [OpenMPI 4](https://www.open-mpi.org))
 - A C++17 compiler
 - A supported SYCL implementation (see below)

--- a/include/accessor.h
+++ b/include/accessor.h
@@ -80,10 +80,25 @@ class host_memory_layout {
 		size_t extent{};
 	};
 
-	/** Since contiguous dimensions can be merged when generating the memory layout, host_memory_layout is not generic over a fixed dimension count */
-	constexpr static size_t max_dimensionality = 4;
+	// TODO: This is a temporary replacement for Boost's static_vector; entire mechanism needs more comprehensive API overhaul.
+	class dimension_vector {
+	  public:
+		dimension_vector(size_t size) : this_size(size) {}
 
-	using dimension_vector = boost::container::static_vector<dimension, max_dimensionality>;
+		dimension& operator[](size_t idx) { return values[idx]; }
+		const dimension& operator[](size_t idx) const { return values[idx]; }
+
+		size_t size() const { return this_size; }
+
+	  private:
+		/**
+		 * Since contiguous dimensions can be merged when generating the memory layout, host_memory_layout is not generic over a fixed dimension count
+		 * TODO: Implement this ^
+		 */
+		constexpr static size_t max_dimensionality = 4;
+		std::array<dimension, max_dimensionality> values;
+		size_t this_size;
+	};
 
 	explicit host_memory_layout(const dimension_vector& dimensions) : dimensions(dimensions) {}
 

--- a/include/command_graph.h
+++ b/include/command_graph.h
@@ -6,9 +6,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <boost/container/flat_map.hpp>
-#include <boost/range.hpp>
-
 #include "command.h"
 #include "types.h"
 
@@ -126,7 +123,7 @@ namespace detail {
 
 		auto all_commands() const {
 			const auto transform = [](auto& uptr) { return uptr.second.get(); };
-			return boost::make_iterator_range(make_transform_iterator(commands.cbegin(), transform), make_transform_iterator(commands.cend(), transform));
+			return iterable_range{make_transform_iterator(commands.cbegin(), transform), make_transform_iterator(commands.cend(), transform)};
 		}
 
 		auto& task_commands(task_id tid) { return by_task.at(tid); }
@@ -157,7 +154,7 @@ namespace detail {
 		std::unordered_map<task_id, std::vector<task_command*>> by_task;
 
 		// Set of per-node commands with no dependents
-		boost::container::flat_map<node_id, std::unordered_set<abstract_command*>> execution_fronts;
+		std::unordered_map<node_id, std::unordered_set<abstract_command*>> execution_fronts;
 
 		// This only (potentially) grows when adding dependencies,
 		// it never shrinks and does not take into account later changes further up in the dependency chain

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -19,6 +19,20 @@ namespace detail {
 	class abstract_command;
 	class horizon_command;
 
+	// TODO: Move to utility header..?
+	// Implementation from Boost.ContainerHash, licensed under the Boost Software License, Version 1.0.
+	inline void hash_combine(std::size_t& seed, std::size_t value) { seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2); }
+
+	struct pair_hash {
+		template <typename U, typename V>
+		std::size_t operator()(const std::pair<U, V>& p) const {
+			std::size_t seed = 0;
+			hash_combine(seed, std::hash<U>{}(p.first));
+			hash_combine(seed, std::hash<V>{}(p.second));
+			return seed;
+		}
+	};
+
 	class graph_generator {
 		friend struct graph_generator_testspy;
 
@@ -81,7 +95,7 @@ namespace detail {
 
 		// Collective host tasks have an implicit dependency on the previous task in the same collective group, which is required in order to guarantee
 		// they are executed in the same order on every node.
-		std::unordered_map<std::pair<node_id, collective_group_id>, command_id, boost::hash<std::pair<node_id, collective_group_id>>> last_collective_commands;
+		std::unordered_map<std::pair<node_id, collective_group_id>, command_id, pair_hash> last_collective_commands;
 
 		// This mutex mainly serves to protect per-buffer data structures, as new buffers might be added at any time.
 		std::mutex buffer_mutex;

--- a/include/host_queue.h
+++ b/include/host_queue.h
@@ -6,7 +6,7 @@
 
 #include <CL/sycl.hpp>
 
-#include <ctpl.h>
+#include <ctpl_stl.h>
 #include <mpi.h>
 
 #include "config.h"

--- a/include/types.h
+++ b/include/types.h
@@ -1,8 +1,5 @@
 #pragma once
 
-// FIXME: Replace this with <boost/container_hash/hash.hpp> once we only support Boost 1.67+
-#include <boost/functional/hash.hpp>
-
 namespace celerity {
 namespace detail {
 
@@ -36,12 +33,6 @@ namespace detail {
 		}                                                                                                                                                      \
 	}                                                                                                                                                          \
 	namespace std {                                                                                                                                            \
-		template <>                                                                                                                                            \
-		struct hash<celerity::detail::TypeName> {                                                                                                              \
-			std::size_t operator()(const celerity::detail::TypeName& t) const noexcept { return std::hash<UnderlyingT>{}(static_cast<UnderlyingT>(t)); }       \
-		};                                                                                                                                                     \
-	}                                                                                                                                                          \
-	namespace boost {                                                                                                                                          \
 		template <>                                                                                                                                            \
 		struct hash<celerity::detail::TypeName> {                                                                                                              \
 			std::size_t operator()(const celerity::detail::TypeName& t) const noexcept { return std::hash<UnderlyingT>{}(static_cast<UnderlyingT>(t)); }       \

--- a/include/workaround.h
+++ b/include/workaround.h
@@ -1,38 +1,38 @@
 #pragma once
 
 #include <CL/sycl.hpp>
-#include <boost/preprocessor/cat.hpp>
-#include <boost/preprocessor/facilities/empty.hpp>
-#include <boost/preprocessor/facilities/overload.hpp>
+
+// TODO: Don't pollute preprocessor namespace with generic "WORKAROUND" names, prefix with "CELERITY".
 
 #if defined(__COMPUTECPP__)
 #define WORKAROUND_COMPUTECPP 1
-#define _WA_VERSION_MAJOR COMPUTECPP_VERSION_MAJOR
-#define _WA_VERSION_MINOR COMPUTECPP_VERSION_MINOR
-#define _WA_VERSION_PATCH COMPUTECPP_VERSION_PATCH
+#define CELERITY_DETAIL_WA_VERSION_MAJOR COMPUTECPP_VERSION_MAJOR
+#define CELERITY_DETAIL_WA_VERSION_MINOR COMPUTECPP_VERSION_MINOR
+#define CELERITY_DETAIL_WA_VERSION_PATCH COMPUTECPP_VERSION_PATCH
 #else
 #define WORKAROUND_COMPUTECPP 0
 #endif
 
-#if defined(__HIPSYCL__) || defined(__HIPSYCL_TRANSFORM__)
+#if defined(__HIPSYCL__)
 #define WORKAROUND_HIPSYCL 1
-#define _WA_VERSION_MAJOR HIPSYCL_VERSION_MAJOR
-#define _WA_VERSION_MINOR HIPSYCL_VERSION_MINOR
-#define _WA_VERSION_PATCH HIPSYCL_VERSION_PATCH
+#define CELERITY_DETAIL_WA_VERSION_MAJOR HIPSYCL_VERSION_MAJOR
+#define CELERITY_DETAIL_WA_VERSION_MINOR HIPSYCL_VERSION_MINOR
+#define CELERITY_DETAIL_WA_VERSION_PATCH HIPSYCL_VERSION_PATCH
 #else
 #define WORKAROUND_HIPSYCL 0
 #endif
 
-#define _WA_CHECK_VERSION_1(major) (_WA_VERSION_MAJOR <= major)
-#define _WA_CHECK_VERSION_2(major, minor) (_WA_VERSION_MAJOR < major) || (_WA_VERSION_MAJOR == major && _WA_VERSION_MINOR <= minor)
-#define _WA_CHECK_VERSION_3(major, minor, patch)                                                                                                               \
-	(_WA_VERSION_MAJOR < major) || (_WA_VERSION_MAJOR == major && _WA_VERSION_MINOR < minor)                                                                   \
-	    || (_WA_VERSION_MAJOR == major && _WA_VERSION_MINOR == minor && _WA_VERSION_PATCH <= patch)
+#define CELERITY_DETAIL_WA_CHECK_VERSION_1(major) (CELERITY_DETAIL_WA_VERSION_MAJOR <= major)
+#define CELERITY_DETAIL_WA_CHECK_VERSION_2(major, minor)                                                                                                       \
+	(CELERITY_DETAIL_WA_VERSION_MAJOR < major) || (CELERITY_DETAIL_WA_VERSION_MAJOR == major && CELERITY_DETAIL_WA_VERSION_MINOR <= minor)
+#define CELERITY_DETAIL_WA_CHECK_VERSION_3(major, minor, patch)                                                                                                \
+	(CELERITY_DETAIL_WA_VERSION_MAJOR < major) || (CELERITY_DETAIL_WA_VERSION_MAJOR == major && CELERITY_DETAIL_WA_VERSION_MINOR < minor)                      \
+	    || (CELERITY_DETAIL_WA_VERSION_MAJOR == major && CELERITY_DETAIL_WA_VERSION_MINOR == minor && CELERITY_DETAIL_WA_VERSION_PATCH <= patch)
 
-#if !BOOST_PP_VARIADICS_MSVC
-#define _WA_CHECK_VERSION(...) BOOST_PP_OVERLOAD(_WA_CHECK_VERSION_, __VA_ARGS__)(__VA_ARGS__)
-#else
-#define _WA_CHECK_VERSION(...) BOOST_PP_CAT(BOOST_PP_OVERLOAD(_WA_CHECK_VERSION_, __VA_ARGS__)(__VA_ARGS__), BOOST_PP_EMPTY())
-#endif
+#define CELERITY_DETAIL_WA_GET_OVERLOAD(_1, _2, _3, NAME, ...) NAME
+#define CELERITY_DETAIL_WA_MSVC_WORKAROUND(x) x // Workaround for MSVC PP expansion behavior of __VA_ARGS__
+#define CELERITY_DETAIL_WA_CHECK_VERSION(...)                                                                                                                  \
+	CELERITY_DETAIL_WA_MSVC_WORKAROUND(CELERITY_DETAIL_WA_GET_OVERLOAD(                                                                                        \
+	    __VA_ARGS__, CELERITY_DETAIL_WA_CHECK_VERSION_3, CELERITY_DETAIL_WA_CHECK_VERSION_2, CELERITY_DETAIL_WA_CHECK_VERSION_1)(__VA_ARGS__))
 
-#define WORKAROUND(impl, ...) (WORKAROUND_##impl == 1 && _WA_CHECK_VERSION(__VA_ARGS__))
+#define WORKAROUND(impl, ...) (WORKAROUND_##impl == 1 && CELERITY_DETAIL_WA_CHECK_VERSION(__VA_ARGS__))

--- a/src/config.cc
+++ b/src/config.cc
@@ -1,11 +1,11 @@
 #include "config.h"
 
 #include <cstdlib>
+#include <iterator>
 #include <sstream>
 #include <thread>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
 #include <mpi.h>
 
 #include "logger.h"
@@ -116,8 +116,8 @@ namespace detail {
 		{
 			const auto result = get_env("CELERITY_DEVICES");
 			if(result.first) {
-				std::vector<std::string> values;
-				boost::split(values, result.second, [](char c) { return c == ' '; });
+				std::istringstream ss{result.second};
+				std::vector<std::string> values{std::istream_iterator<std::string>{ss}, std::istream_iterator<std::string>{}};
 
 				if(static_cast<long>(host_cfg.local_rank) > static_cast<long>(values.size()) - 2) {
 					throw std::runtime_error(

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -1,16 +1,7 @@
 #include "print_graph.h"
 
-// As of Boost 1.70, this includes a header which contains a __noinline__ attribute
-// for __GNUC__ == 4 (which Clang (8) apparently also identifies as).
-// This breaks CUDA compilation with Clang, as the CUDA (10) headers define __noinline__
-// in an incompatible manner. As a workaround we thus simply undefine it altogether.
-// Potentially related to https://svn.boost.org/trac10/ticket/9392
-#if defined(__clang__) && defined(__CUDA__)
-#undef __noinline__
-#endif
-#include <boost/graph/graphviz.hpp>
+#include <regex>
 
-#include <boost/algorithm/string.hpp>
 #include <spdlog/fmt/fmt.h>
 
 #include "command.h"
@@ -49,7 +40,7 @@ namespace detail {
 			const auto tsk = it.second.get();
 
 			std::unordered_map<std::string, std::string> props;
-			props["label"] = boost::escape_dot_string(get_task_label(tsk));
+			props["label"] = get_task_label(tsk);
 
 			ss << tsk->get_id();
 			ss << "[";
@@ -66,8 +57,8 @@ namespace detail {
 
 		ss << "}";
 		auto str = ss.str();
-		boost::replace_all(str, "\n", "\\n");
-		boost::replace_all(str, "\"", "\\\"");
+		str = std::regex_replace(str, std::regex("\n"), "\\n");
+		str = std::regex_replace(str, std::regex("\""), "\\\"");
 		graph_logger.info(logger_map({{"name", "TaskGraph"}, {"data", str}}));
 	}
 
@@ -96,7 +87,7 @@ namespace detail {
 			const char* colors[] = {"black", "crimson", "dodgerblue4", "goldenrod", "maroon4", "springgreen2", "tan1", "chartreuse2"};
 
 			std::unordered_map<std::string, std::string> props;
-			props["label"] = boost::escape_dot_string(get_command_label(cmd));
+			props["label"] = get_command_label(cmd);
 			props["fontcolor"] = colors[cmd->get_nid() % (sizeof(colors) / sizeof(char*))];
 			if(isa<task_command>(cmd)) { props["shape"] = "box"; }
 
@@ -152,8 +143,8 @@ namespace detail {
 		ss << "}";
 
 		auto str = ss.str();
-		boost::replace_all(str, "\n", "\\n");
-		boost::replace_all(str, "\"", "\\\"");
+		str = std::regex_replace(str, std::regex("\n"), "\\n");
+		str = std::regex_replace(str, std::regex("\""), "\\\"");
 		graph_logger.info(logger_map({{"name", "CommandGraph"}, {"data", str}}));
 	}
 

--- a/vendor/ctpl_stl.h
+++ b/vendor/ctpl_stl.h
@@ -1,25 +1,24 @@
-
 /*********************************************************
- *
- *  Copyright (C) 2014 by Vitaliy Vitsentiy
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *********************************************************/
+*
+*  Copyright (C) 2014 by Vitaliy Vitsentiy
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*********************************************************/
 
 
-#ifndef __ctpl_thread_pool_H__
-#define __ctpl_thread_pool_H__
+#ifndef __ctpl_stl_thread_pool_H__
+#define __ctpl_stl_thread_pool_H__
 
 #include <functional>
 #include <thread>
@@ -29,12 +28,8 @@
 #include <exception>
 #include <future>
 #include <mutex>
-#include <boost/lockfree/queue.hpp>
+#include <queue>
 
-
-#ifndef _ctplThreadPoolLength_
-#define _ctplThreadPoolLength_  100
-#endif
 
 
 // thread pool to run user's functors with signature
@@ -45,12 +40,40 @@
 
 namespace ctpl {
 
+    namespace detail {
+        template <typename T>
+        class Queue {
+        public:
+            bool push(T const & value) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                this->q.push(value);
+                return true;
+            }
+            // deletes the retrieved element, do not use for non integral types
+            bool pop(T & v) {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                if (this->q.empty())
+                    return false;
+                v = this->q.front();
+                this->q.pop();
+                return true;
+            }
+            bool empty() {
+                std::unique_lock<std::mutex> lock(this->mutex);
+                return this->q.empty();
+            }
+        private:
+            std::queue<T> q;
+            std::mutex mutex;
+        };
+    }
+
     class thread_pool {
 
     public:
 
-        thread_pool() : q(_ctplThreadPoolLength_) { this->init(); }
-        thread_pool(int nThreads, int queueSize = _ctplThreadPoolLength_) : q(queueSize) { this->init(); this->resize(nThreads); }
+        thread_pool() { this->init(); }
+        thread_pool(int nThreads) { this->init(); this->resize(nThreads); }
 
         // the destructor waits for all the functions in the queue to be finished
         ~thread_pool() {
@@ -99,24 +122,22 @@ namespace ctpl {
         void clear_queue() {
             std::function<void(int id)> * _f;
             while (this->q.pop(_f))
-                delete _f;  // empty the queue
+                delete _f; // empty the queue
         }
 
-        // pops a functional wraper to the original function
+        // pops a functional wrapper to the original function
         std::function<void(int)> pop() {
             std::function<void(int id)> * _f = nullptr;
             this->q.pop(_f);
-            std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
-            
+            std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
             std::function<void(int)> f;
             if (_f)
                 f = *_f;
             return f;
         }
 
-
         // wait for all computing threads to finish and stop all threads
-        // may be called asyncronously to not pause the calling thread while waiting
+        // may be called asynchronously to not pause the calling thread while waiting
         // if isWait == true, all the functions in the queue are run, otherwise the queue is cleared without running the functions
         void stop(bool isWait = false) {
             if (!isWait) {
@@ -138,8 +159,8 @@ namespace ctpl {
                 this->cv.notify_all();  // stop all waiting threads
             }
             for (int i = 0; i < static_cast<int>(this->threads.size()); ++i) {  // wait for the computing threads to finish
-                if (this->threads[i]->joinable())
-                    this->threads[i]->join();
+                    if (this->threads[i]->joinable())
+                        this->threads[i]->join();
             }
             // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
             // therefore delete them here
@@ -152,16 +173,13 @@ namespace ctpl {
         auto push(F && f, Rest&&... rest) ->std::future<decltype(f(0, rest...))> {
             auto pck = std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
                 std::bind(std::forward<F>(f), std::placeholders::_1, std::forward<Rest>(rest)...)
-            );
-
+                );
             auto _f = new std::function<void(int id)>([pck](int id) {
                 (*pck)(id);
             });
             this->q.push(_f);
-
             std::unique_lock<std::mutex> lock(this->mutex);
             this->cv.notify_one();
-
             return pck->get_future();
         }
 
@@ -170,15 +188,12 @@ namespace ctpl {
         template<typename F>
         auto push(F && f) ->std::future<decltype(f(0))> {
             auto pck = std::make_shared<std::packaged_task<decltype(f(0))(int)>>(std::forward<F>(f));
-
             auto _f = new std::function<void(int id)>([pck](int id) {
                 (*pck)(id);
             });
             this->q.push(_f);
-
             std::unique_lock<std::mutex> lock(this->mutex);
             this->cv.notify_one();
-
             return pck->get_future();
         }
 
@@ -192,40 +207,37 @@ namespace ctpl {
         thread_pool & operator=(thread_pool &&);// = delete;
 
         void set_thread(int i) {
-            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]);  // a copy of the shared ptr to the flag
+            std::shared_ptr<std::atomic<bool>> flag(this->flags[i]); // a copy of the shared ptr to the flag
             auto f = [this, i, flag/* a copy of the shared ptr to the flag */]() {
                 std::atomic<bool> & _flag = *flag;
                 std::function<void(int id)> * _f;
                 bool isPop = this->q.pop(_f);
                 while (true) {
                     while (isPop) {  // if there is anything in the queue
-                        std::unique_ptr<std::function<void(int id)>> func(_f);  // at return, delete the function even if an exception occurred
+                        std::unique_ptr<std::function<void(int id)>> func(_f); // at return, delete the function even if an exception occurred
                         (*_f)(i);
-
                         if (_flag)
                             return;  // the thread is wanted to stop, return even if the queue is not empty yet
                         else
                             isPop = this->q.pop(_f);
                     }
-
                     // the queue is empty here, wait for the next command
                     std::unique_lock<std::mutex> lock(this->mutex);
                     ++this->nWaiting;
                     this->cv.wait(lock, [this, &_f, &isPop, &_flag](){ isPop = this->q.pop(_f); return isPop || this->isDone || _flag; });
                     --this->nWaiting;
-
                     if (!isPop)
                         return;  // if the queue is empty and this->isDone == true or *flag then return
                 }
             };
-            this->threads[i].reset(new std::thread(f));  // compiler may not support std::make_unique()
+            this->threads[i].reset(new std::thread(f)); // compiler may not support std::make_unique()
         }
 
         void init() { this->nWaiting = 0; this->isStop = false; this->isDone = false; }
 
         std::vector<std::unique_ptr<std::thread>> threads;
         std::vector<std::shared_ptr<std::atomic<bool>>> flags;
-        mutable boost::lockfree::queue<std::function<void(int id)> *> q;
+        detail::Queue<std::function<void(int id)> *> q;
         std::atomic<bool> isDone;
         std::atomic<bool> isStop;
         std::atomic<int> nWaiting;  // how many threads are waiting
@@ -236,5 +248,4 @@ namespace ctpl {
 
 }
 
-#endif // __ctpl_thread_pool_H__
-
+#endif // __ctpl_stl_thread_pool_H__


### PR DESCRIPTION
Ever since we stopped using Boost.Graph to represent task and command graphs (which was a while ago at this point), Boost has actually caused us more pain than gain. In particular, Boost does not (yet) distinguish between CUDA code being compiled by NVCC and Clang, instead always assuming the former, which causes all kinds of horrible, hard to debug problems.

As it turns out, we already only actually required Boost functionalities in a few select locations, and these uses have all been replaced by (mostly) equivalent vanilla implementations.

This patch includes a breaking change in the (semi-experimental) `host_memory_layout` interface: Instead of returning a `boost::static_vector` of `dimension` objects, the dimensions can now be accessed directly through `host_memory_layout::operator[]`.

Supersedes #15.