### PR TITLE
Add Intel CI platform support, run CCPP on Intel

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -21,29 +21,25 @@ on:
       - '**:**'
 
 jobs:
-  checkout:
-    runs-on: [self-hosted]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # We clean up artifacts ourselves.
-          # Cleaning here can cause problems with concurrent workflow runs,
-          # where build folders are being removed mid-run.
-          clean: false
-          submodules: true
-
-  build:
-    needs: [checkout]
-    runs-on: [self-hosted]
+  build-and-test:
+    runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
+        platform: ["intel", "nvidia"]
         SYCL-impl: ["hipSYCL", "ComputeCpp"]
         build-type: ["Debug", "Release"]
+        exclude:
+          - platform: "intel"
+            SYCL-impl: "hipSYCL"
+          - platform: "nvidia"
+            SYCL-impl: "ComputeCpp"
     env:
-      # FIXME: Can we keep this DRY?
-      build-name: build-${{ matrix.SYCL-impl }}-${{ matrix.build-type }}-${{ github.run_id }}-${{ github.run_number }}
+      build-name: ${{ matrix.platform }}-${{ matrix.SYCL-impl }}-${{ matrix.build-type }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Run build script
         run: |
           mkdir ${{ env.build-name }}
@@ -53,22 +49,8 @@ jobs:
       - name: Upload build log
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ env.build-name }}-log
+          name: ${{ env.build-name }}
           path: ${{ env.build-name }}/${{ env.build-name }}.log
-
-  test:
-    needs: [build]
-    runs-on: [self-hosted]
-    # FIXME: Can we keep this DRY?
-    strategy:
-      fail-fast: false
-      matrix:
-        SYCL-impl: ["hipSYCL", "ComputeCpp"]
-        build-type: ["Debug", "Release"]
-    env:
-      # FIXME: Can we keep this DRY?
-      build-name: build-${{ matrix.SYCL-impl }}-${{ matrix.build-type }}-${{ github.run_id }}-${{ github.run_number }}
-    steps:
       - name: Run unit tests
         working-directory: ${{ env.build-name }}
         # Running "make test" is slow (why?), so we just call all test executables manually
@@ -78,8 +60,8 @@ jobs:
         run: ${{ github.workspace }}/ci/run-integration-tests.sh /data/Lenna.png 1 2 4
 
   report:
-    needs: [test]
-    runs-on: [self-hosted]
+    needs: [build-and-test]
+    runs-on: self-hosted
     steps:
       - name: Check code formatting
         id: formatting
@@ -87,31 +69,8 @@ jobs:
           unformatted=$("./ci/find-unformatted-files.sh")
           unformatted=${unformatted//$'\n'/'%0A'}
           echo "::set-output name=unformatted-files::$unformatted"
-      - uses: "celerity/ci-report-action@v3"
+      - uses: "celerity/ci-report-action@v4"
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           unformatted-files: ${{ steps.formatting.outputs.unformatted-files }}
-          # FIXME: Can we somehow keep this DRY with the matrix config above?
-          builds: "hipSYCL-Debug, hipSYCL-Release, ComputeCpp-Debug, ComputeCpp-Release"
 
-  cleanup:
-    needs: [report]
-    if: always() # Execute even if our dependencies fail
-    runs-on: [self-hosted]
-    # FIXME: Can we keep this DRY?
-    strategy:
-      fail-fast: false
-      matrix:
-        SYCL-impl: ["hipSYCL", "ComputeCpp"]
-        build-type: ["Debug", "Release"]
-    env:
-      # FIXME: Can we keep this DRY?
-      build-name: build-${{ matrix.SYCL-impl }}-${{ matrix.build-type }}-${{ github.run_id }}-${{ github.run_number }}
-    steps:
-      - name: Remove build directory
-        run: rm -rf ${{ env.build-name }}
-      # The report step downloads build logs for analysis
-      # FIXME: Either read build logs directly from within build folder (don't download them again),
-      #        or at least clean up directly within report action script.
-      - name: Remove build log
-        run: rm -f ${{ env.build-name }}.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,8 @@ Unfortunately Clang Format frequently has breaking changes with major
 releases (which are tied to the Clang release cycle), which means we have to
 settle on a specific version.
 
-We currently use `clang-format-8`. Please make sure to use the correct
+We currently use `clang-format-10`. Please make sure to use the correct
 version to avoid cluttering your diffs with unrelated format changes.
-[Prebuilt binaries can be found on llvm.org](http://releases.llvm.org/8.0.0/).
 
 You can automatically determine whether you've correctly formatted all of
 your files using our [find-unformatted-files](ci/find-unformatted-files.sh)
@@ -46,7 +45,8 @@ Always use [`git rebase`](https://git-scm.com/docs/git-rebase) instead of
 creating merge commits when incorporating upstream changes into your local
 branches. This is to reduce noise in our git history.
 
-Please use imperative form for your commit messages, i.e., prefer `"Add feature X"` over `"Added feature X"`, or just `"feature X"`. Furthermore, try
+Please use imperative form for your commit messages, i.e., prefer `"Add feature
+X"` over `"Added feature X"`, or just `"feature X"`. Furthermore, try
 to come up with meaningful commit messages that succinctly describe your
 change. If your commit introduces a large change, consider providing a more
 detailed description in the commit message body.

--- a/ci/find-unformatted-files.sh
+++ b/ci/find-unformatted-files.sh
@@ -9,7 +9,7 @@ SOURCES=$(find examples include src test \( -name "*.h" -o -name "*.cc" \) ! -na
 for s in $SOURCES; do
     # Since clang-format does not provide an option to check whether formatting is required,
     # we use the XML replacements output together with grep as a workaround.
-    NUM_REPLACEMENTS=$(clang-format-8 -output-replacements-xml "$s" | grep -v -c -E "<(/?replacements|\?xml)")
+    NUM_REPLACEMENTS=$(clang-format -output-replacements-xml "$s" | grep -v -c -E "<(/?replacements|\?xml)")
     if [[ $NUM_REPLACEMENTS -ne 0 ]]; then
         echo $s
     fi


### PR DESCRIPTION
Summary:

- Add support for second self-hosted actions runner on Intel hardware
- Run ComputeCpp only on Intel going forward
- Run hipSYCL only on NVIDIA (for now)
- Upgrade clang-format version used in CI to 10

Context:

This reworks the CI setup once again, this time DRYing up the matrix build mechanism considerably. We now support two types of self-hosted runners, which are labelled as either "intel" or "nvidia".

As it turns out, different jobs from the same workflow run can be executed on different runners. This has never occurred so far as we only had a single runner. Therefore it is also not safe to assume that side-effects from predecessor ("needs") jobs still exist or ever existed on the current runner -- which includes things like build directories.

The canonical way of sharing artifacts between jobs is to upload them in one job and then download them again in the next. As this is rather inefficient and wasteful for large artifacts such as entire builds, we instead opt to combine building and testing into a single job. While this change somewhat decreases the granularity of reporting, it makes the workflow definition a lot cleaner and should fix any remaining inter-job race conditions encountered in the past (such as addressed in #29).

As part of upgrading the CI infrastructure, we now use clang-format-10, which does not produce any formatting changes for the codebase.