### PR TITLE
Add support for SYCL 2020 accessor constructors along with new enums

### DIFF
--- a/examples/syncing/syncing.cc
+++ b/examples/syncing/syncing.cc
@@ -13,12 +13,12 @@ int main(int argc, char* argv[]) {
 	std::vector<int> host_buff(N);
 
 	q.submit([=](handler& cgh) {
-		auto b = buff.get_access<cl::sycl::access::mode::discard_write>(cgh, access::one_to_one<1>());
+		celerity::accessor b{buff, cgh, access::one_to_one<1>(), cl::sycl::write_only, cl::sycl::no_init};
 		cgh.parallel_for<class mat_mul>(cl::sycl::range<1>(N), [=](cl::sycl::item<1> item) { b[item] = item.get_linear_id(); });
 	});
 
 	q.submit(celerity::allow_by_ref, [=, &host_buff](handler& cgh) {
-		auto b = buff.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, access::fixed<1>({0, N}));
+		celerity::accessor b{buff, cgh, access::fixed<1>({0, N}), cl::sycl::read_only_host_task};
 		cgh.host_task(on_master_node, [=, &host_buff] {
 			std::this_thread::sleep_for(std::chrono::milliseconds(10)); // give the synchronization more time to fail
 			for(int i = 0; i < N; i++) {

--- a/examples/wave_sim/wave_sim.cc
+++ b/examples/wave_sim/wave_sim.cc
@@ -9,7 +9,7 @@
 
 void setup_wave(celerity::distr_queue& queue, celerity::buffer<float, 2> u, cl::sycl::float2 center, float amplitude, cl::sycl::float2 sigma) {
 	queue.submit([=](celerity::handler& cgh) {
-		auto dw_u = u.get_access<cl::sycl::access::mode::discard_write>(cgh, celerity::access::one_to_one<2>());
+		celerity::accessor dw_u{u, cgh, celerity::access::one_to_one<2>(), cl::sycl::write_only, cl::sycl::no_init};
 		cgh.parallel_for<class setup_wave>(u.get_range(), [=, c = center, a = amplitude, s = sigma](cl::sycl::item<2> item) {
 			const float dx = item[1] - c.x();
 			const float dy = item[0] - c.y();
@@ -20,7 +20,7 @@ void setup_wave(celerity::distr_queue& queue, celerity::buffer<float, 2> u, cl::
 
 void zero(celerity::distr_queue& queue, celerity::buffer<float, 2> buf) {
 	queue.submit([=](celerity::handler& cgh) {
-		auto dw_buf = buf.get_access<cl::sycl::access::mode::discard_write>(cgh, celerity::access::one_to_one<2>());
+		celerity::accessor dw_buf{buf, cgh, celerity::access::one_to_one<2>(), cl::sycl::write_only, cl::sycl::no_init};
 		cgh.parallel_for<class zero>(buf.get_range(), [=](cl::sycl::item<2> item) { dw_buf[item] = 0.f; });
 	});
 }
@@ -40,8 +40,8 @@ struct update_config {
 template <typename T, typename Config, typename KernelName>
 void step(celerity::distr_queue& queue, celerity::buffer<T, 2> up, celerity::buffer<T, 2> u, float dt, cl::sycl::float2 delta) {
 	queue.submit([=](celerity::handler& cgh) {
-		auto rw_up = up.template get_access<cl::sycl::access::mode::read_write>(cgh, celerity::access::one_to_one<2>());
-		auto r_u = u.template get_access<cl::sycl::access::mode::read>(cgh, celerity::access::neighborhood<2>(1, 1));
+		celerity::accessor rw_up{up, cgh, celerity::access::one_to_one<2>(), cl::sycl::read_write};
+		celerity::accessor r_u{u, cgh, celerity::access::neighborhood<2>(1, 1), cl::sycl::read_only};
 
 		const auto size = up.get_range();
 		cgh.parallel_for<KernelName>(size, [=](cl::sycl::item<2> item) {
@@ -69,7 +69,7 @@ template <typename T>
 void store(celerity::distr_queue& queue, celerity::buffer<T, 2> up, std::vector<std::vector<float>>& result_frames) {
 	const auto range = up.get_range();
 	queue.submit(celerity::allow_by_ref, [=, &result_frames](celerity::handler& cgh) {
-		auto up_r = up.template get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::fixed<2>{{{}, range}});
+		celerity::accessor up_r{up, cgh, celerity::access::fixed<2>{{{}, range}}, cl::sycl::read_only_host_task};
 		cgh.host_task(celerity::on_master_node, [=, &result_frames] {
 			result_frames.emplace_back();
 			auto& frame = *result_frames.rbegin();

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -5,14 +5,17 @@
 #include <CL/sycl.hpp>
 #include <allscale/utils/functional_utils.h>
 
-#include "accessor.h"
 #include "buffer_manager.h"
-#include "handler.h"
+#include "ccpp_2020_compatibility_layer.h"
 #include "range_mapper.h"
 #include "ranges.h"
 #include "runtime.h"
 
 namespace celerity {
+
+template <typename DataT, int Dims>
+class buffer;
+
 namespace detail {
 
 	struct buffer_lifetime_tracker {
@@ -28,15 +31,20 @@ namespace detail {
 		buffer_id id;
 	};
 
+	template <typename T, int D>
+	buffer_id get_buffer_id(const buffer<T, D>& buff);
+
 } // namespace detail
+
+template <typename DataT, int Dims, cl::sycl::access_mode Mode, cl::sycl::target Target>
+class accessor;
 
 template <typename DataT, int Dims>
 class buffer {
   public:
 	static_assert(Dims > 0, "0-dimensional buffers NYI");
 
-	buffer(const DataT* host_ptr, cl::sycl::range<Dims> range)
-	    : range(range), faux_buf(new cl::sycl::buffer<DataT, Dims>(detail::range_cast<Dims>(cl::sycl::range<3>{1, 1, 1}))) {
+	buffer(const DataT* host_ptr, cl::sycl::range<Dims> range) : range(range) {
 		if(!detail::runtime::is_initialized()) { detail::runtime::init(nullptr, nullptr); }
 
 		lifetime_tracker = std::make_shared<detail::buffer_lifetime_tracker>();
@@ -53,53 +61,24 @@ class buffer {
 
 	~buffer() {}
 
-	template <cl::sycl::access::mode Mode, typename Functor>
-	accessor<DataT, Dims, Mode, cl::sycl::access::target::global_buffer> get_access(handler& cgh, Functor rmfn) const {
-		return get_access<Mode, cl::sycl::access::target::global_buffer>(cgh, rmfn);
+	template <cl::sycl::access_mode Mode, typename Functor>
+	accessor<DataT, Dims, Mode, cl::sycl::target::device> get_access(handler& cgh, Functor rmfn) const {
+		return get_access<Mode, cl::sycl::target::device, Functor>(cgh, rmfn);
 	}
 
-	template <cl::sycl::access::mode Mode, cl::sycl::access::target Target, typename Functor>
+
+	template <cl::sycl::access_mode Mode, cl::sycl::target Target, typename Functor>
 	accessor<DataT, Dims, Mode, Target> get_access(handler& cgh, Functor rmfn) const {
-		static_assert(!std::is_same_v<Functor, cl::sycl::range<Dims>>, "The buffer::get_access overload for master-access tasks (now called 'host tasks') has "
-		                                                               "been removed with Celerity 0.2.0. Please provide a range mapper instead.");
-
-		using rmfn_traits = allscale::utils::lambda_traits<Functor>;
-		static_assert(rmfn_traits::result_type::dims == Dims, "The returned subrange doesn't match buffer dimensions.");
-
-		if(detail::is_prepass_handler(cgh)) {
-			auto& prepass_cgh = dynamic_cast<detail::prepass_handler&>(cgh);
-			prepass_cgh.add_requirement(id, std::make_unique<detail::range_mapper<rmfn_traits::arg1_type::dims, Dims>>(rmfn, Mode, get_range()));
-			if constexpr(Target == cl::sycl::access::target::host_buffer) {
-				return detail::make_host_accessor<DataT, Dims, Mode>();
-			} else {
-				return detail::make_device_accessor<DataT, Dims, Mode>(*faux_buf);
-			}
-		}
-
-		// It's difficult to figure out which stored range mapper corresponds to this get_access call, which is why we just call the raw mapper manually.
-		// This also means that we have to clamp the subrange ourselves here, which is not ideal from an encapsulation standpoint.
-		if constexpr(Target == cl::sycl::access::target::host_buffer) {
-			if(detail::get_handler_execution_target(cgh) != detail::execution_target::HOST) {
-				throw std::runtime_error("Calling buffer::get_access with sycl::access::target::host_buffer is only allowed in host tasks.");
-			}
-			auto& live_cgh = dynamic_cast<detail::live_pass_host_handler&>(cgh);
-			const auto sr = detail::clamp_subrange_to_buffer_size(live_cgh.apply_range_mapper<Dims>(rmfn, get_range()), get_range());
-			auto access_info = detail::runtime::get_instance().get_buffer_manager().get_host_buffer<DataT, Dims>(
-			    id, Mode, detail::range_cast<3>(sr.range), detail::id_cast<3>(sr.offset));
-			return detail::make_host_accessor<DataT, Dims, Mode>(sr, access_info.buffer, access_info.offset, range);
-		} else {
-			if(detail::get_handler_execution_target(cgh) != detail::execution_target::DEVICE) {
-				throw std::runtime_error(
-				    "Calling buffer::get_access on device buffers is only allowed in compute tasks. "
-				    "If you want to access this buffer from within a host task, please specialize the call using sycl::access::target::host_buffer.");
-			}
-			auto& live_cgh = dynamic_cast<detail::live_pass_device_handler&>(cgh);
-			const auto sr = detail::clamp_subrange_to_buffer_size(live_cgh.apply_range_mapper<Dims>(rmfn, get_range()), get_range());
-			auto access_info = detail::runtime::get_instance().get_buffer_manager().get_device_buffer<DataT, Dims>(
-			    id, Mode, detail::range_cast<3>(sr.range), detail::id_cast<3>(sr.offset));
-			return detail::make_device_accessor<DataT, Dims, Mode>(live_cgh.get_eventual_sycl_cgh(), sr, access_info.buffer, access_info.offset);
-		}
+		return accessor<DataT, Dims, Mode, Target>(*this, cgh, rmfn);
 	}
+
+#if WORKAROUND_COMPUTECPP
+	template <cl::sycl::access_mode Mode, cl::sycl::access::target Trgt, typename Functor>
+	auto get_access(handler& cgh, Functor rmfn) const {
+		return accessor<DataT, Dims, Mode, static_cast<cl::sycl::target>(Trgt)>(*this, cgh, rmfn);
+	}
+#endif
+
 
 	cl::sycl::range<Dims> get_range() const { return range; }
 
@@ -108,21 +87,17 @@ class buffer {
 	cl::sycl::range<Dims> range;
 	detail::buffer_id id;
 
-	// Unfortunately, as of SYCL 1.2.1 Rev 6, there is now way of creating a
-	// SYCL accessor without at least a buffer reference (i.e., there is no
-	// default ctor, even for placeholder accessors). During the pre-pass, we
-	// not only don't have access to a SYCL command group handler, but also
-	// don't know the backing buffer yet (it might not even exist at that
-	// point). For calls to get_access() we however still have to construct a
-	// SYCL accessor to return inside the Celerity accessor. For this, we use
-	// this faux buffer. It has size 1 in all dimensions, so the allocation
-	// overhead should be minimal. Hopefully the runtime overhead is also
-	// negligible.
-	//
-	// (The reason why we make this a shared_ptr is so that Celerity buffers
-	// still satisfy StandardLayoutType, which we use as a crude safety check;
-	// see distr_queue::submit).
-	std::shared_ptr<cl::sycl::buffer<DataT, Dims>> faux_buf;
+	template <typename T, int D>
+	friend detail::buffer_id detail::get_buffer_id(const buffer<T, D>& buff);
 };
+
+namespace detail {
+
+	template <typename T, int D>
+	buffer_id get_buffer_id(const buffer<T, D>& buff) {
+		return buff.id;
+	}
+
+} // namespace detail
 
 } // namespace celerity

--- a/include/ccpp_2020_compatibility_layer.h
+++ b/include/ccpp_2020_compatibility_layer.h
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * This whole file is just a 'compatibility' layer for ComputeCPP 2.5.0 until they provide support for the SYCL 2020 features specified below.
+ */
+#pragma once
+
+#include "workaround.h"
+
+#if WORKAROUND_COMPUTECPP
+
+#include <CL/sycl.hpp>
+
+
+namespace cl::sycl {
+using access_mode = cl::sycl::access::mode;
+enum class target {
+	device = static_cast<std::underlying_type_t<cl::sycl::access::target>>(cl::sycl::access::target::global_buffer),
+	host_task = static_cast<std::underlying_type_t<cl::sycl::access::target>>(cl::sycl::access::target::host_buffer),
+	global_buffer = device,
+	constant_buffer = static_cast<std::underlying_type_t<cl::sycl::access::target>>(cl::sycl::access::target::constant_buffer),
+	local = static_cast<std::underlying_type_t<cl::sycl::access::target>>(cl::sycl::access::target::local),
+	host_buffer = static_cast<std::underlying_type_t<cl::sycl::access::target>>(cl::sycl::access::target::host_buffer)
+};
+
+namespace detail {
+
+	template <cl::sycl::target Target>
+	constexpr cl::sycl::access::target ccpp_target_2_acc() {
+		return static_cast<cl::sycl::access::target>(Target);
+	}
+
+
+	template <cl::sycl::access::target Target>
+	constexpr cl::sycl::target ccpp_acc_2_target() {
+		return static_cast<cl::sycl::target>(Target);
+	}
+
+	struct read_only_tag_t {};
+	struct read_write_tag_t {};
+	struct write_only_tag_t {};
+	struct read_only_host_task_tag_t {};
+	struct read_write_host_task_tag_t {};
+	struct write_only_host_task_tag_t {};
+
+} // namespace detail
+
+inline constexpr detail::read_only_tag_t read_only;
+inline constexpr detail::read_write_tag_t read_write;
+inline constexpr detail::write_only_tag_t write_only;
+inline constexpr detail::read_only_host_task_tag_t read_only_host_task;
+inline constexpr detail::read_write_host_task_tag_t read_write_host_task;
+inline constexpr detail::write_only_host_task_tag_t write_only_host_task;
+
+namespace property {
+	struct no_init : detail::property_base {
+		no_init() : detail::property_base(static_cast<detail::property_enum>(0)) {}
+	};
+} // namespace property
+inline property::no_init no_init;
+
+}; // namespace cl::sycl
+
+#endif

--- a/include/celerity.h
+++ b/include/celerity.h
@@ -3,6 +3,7 @@
 
 #include "runtime.h"
 
+#include "accessor.h"
 #include "buffer.h"
 #include "distr_queue.h"
 #include "user_bench.h"


### PR DESCRIPTION
Since Celerity supports many implementations of SYCL and they each have a different degree of support for the SYCL 2020 functionalities, in this first approach I intend to introduce to our users a new option for instantiating accessors, using the new Tags to specify Mode and Target.

A compatibility layer had to be implemented for ComputeCpp since they have not yet implemented some enums and types needed to provide this new functionalities to our users. 