### PR TITLE
Don't read uninitialized memory in buffer_manager tests

### DIFF
--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -224,7 +224,6 @@ namespace detail {
 
 			audit_buffer_access(bid, new_buffer.is_allocated(), mode);
 
-#ifdef CELERITY_TEST
 			if(test_mode && new_buffer.is_allocated()) {
 				auto device_buf = static_cast<device_buffer_storage<DataT, Dims>*>(new_buffer.storage.get())->get_device_buffer();
 
@@ -250,7 +249,6 @@ namespace detail {
 				    })
 				    .wait();
 			}
-#endif
 
 			backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
 			const backing_buffer empty{};
@@ -286,12 +284,10 @@ namespace detail {
 
 			audit_buffer_access(bid, new_buffer.is_allocated(), mode);
 
-#ifdef CELERITY_TEST
 			if(test_mode && new_buffer.is_allocated()) {
 				auto& host_buf = static_cast<host_buffer_storage<DataT, Dims>*>(new_buffer.storage.get())->get_host_buffer();
 				std::memset(host_buf.get_pointer(), test_mode_pattern, host_buf.get_range().size() * sizeof(DataT));
 			}
-#endif
 
 			backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
 			const backing_buffer empty{};
@@ -454,19 +450,17 @@ namespace detail {
 		 */
 		void audit_buffer_access(buffer_id bid, bool requires_allocation, cl::sycl::access::mode mode);
 
-#ifdef CELERITY_TEST
 	  public:
+		static constexpr unsigned char test_mode_pattern = 0b10101010;
+
 		/**
 		 * @brief Enables test mode, ensuring that newly allocated buffers are always initialized to
 		 *        a known bit pattern, see buffer_manager::test_mode_pattern.
 		 */
-		static void enable_test_mode() { test_mode = true; }
+		void enable_test_mode() { test_mode = true; }
 
-		static constexpr unsigned char test_mode_pattern = 0b10101010;
-
-#endif
 	  private:
-		inline static bool test_mode = false;
+		bool test_mode = false;
 	};
 
 } // namespace detail

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -123,7 +123,6 @@ namespace detail {
 
 		void flush_command(node_id target, const command_pkg& pkg, const std::vector<command_id>& dependencies);
 
-#ifdef CELERITY_TEST
 		// ------------------------------------------ TESTING UTILS ------------------------------------------
 		// We have to jump through some hoops to be able to re-initialize the runtime for unit testing.
 		// MPI does not like being initialized more than once per process, so we have to skip that part for
@@ -146,9 +145,9 @@ namespace detail {
 			assert(test_mode);
 			instance.reset();
 		}
-#endif
+
 	  private:
-		static bool test_mode;
+		inline static bool test_mode = false;
 	};
 
 } // namespace detail

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -29,7 +29,6 @@ namespace celerity {
 namespace detail {
 
 	std::unique_ptr<runtime> runtime::instance = nullptr;
-	bool runtime::test_mode = false;
 
 	void runtime::init(int* argc, char** argv[], cl::sycl::device* user_device) {
 		if(test_mode) {

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -6,7 +6,6 @@
 
 #include <catch2/catch.hpp>
 
-#define CELERITY_TEST
 #include <celerity.h>
 
 #include "access_modes.h"

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -6,7 +6,6 @@
 
 #include <catch2/catch.hpp>
 
-#define CELERITY_TEST
 #include <celerity.h>
 
 #include "access_modes.h"

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -6,7 +6,6 @@
 
 #include <catch2/catch.hpp>
 
-#define CELERITY_TEST
 #include <celerity.h>
 
 #include "ranges.h"

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -2,7 +2,6 @@
 
 #include <catch2/catch.hpp>
 
-#define CELERITY_TEST
 #include <celerity.h>
 
 #include "command.h"


### PR DESCRIPTION
Some of the tests for the `buffer_manager` try to determine whether certain superfluous coherence transfers have NOT been performed. To do so, these tests used to read uninitialized memory, checking that the superflouous data was not there.

While this was never a great idea, the thinking was that it would be highly unlikely to encounter the expected values in uninitialized memory. While this has worked so far for dedicated GPUs, as it turns out, this is not as unlikely for integrated GPUs that share RAM with the CPU.

This change introduces a special test mode for the `buffer_manager` that, when enabled, initializes all newly allocated buffers with a known bit pattern. We can then check for this bit pattern to establish that no coherence transfers have taken place.