### PR TITLE
Remove support for CELERITY_FORCE_WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,6 @@ Celerity's runtime behavior:
   `CELERITY_DEVICES="<platform_id> <first device_id> <second device_id> ... <nth device_id>"`.
   Note that this should normally not be required, as Celerity will attempt to
   automatically assign a unique device to each worker on a host.
-- `CELERITY_FORCE_WG=<work_group_size>` can be used to force a particular work
-  group size for _every kernel_ and _every dimension_. This currently exists
-  as a workaround until Celerity supports ND-range kernels.
 - `CELERITY_PROFILE_OCL` controls whether OpenCL-level profiling information
   should be queried (currently not supported when using hipSYCL).
 

--- a/include/config.h
+++ b/include/config.h
@@ -43,14 +43,12 @@ namespace detail {
 		 */
 		const std::optional<device_config>& get_device_config() const { return device_cfg; };
 		std::optional<bool> get_enable_device_profiling() const { return enable_device_profiling; };
-		std::optional<size_t> get_forced_work_group_size() const { return forced_work_group_size; };
 
 	  private:
 		log_level log_lvl;
 		host_config host_cfg;
 		std::optional<device_config> device_cfg;
 		std::optional<bool> enable_device_profiling;
-		std::optional<size_t> forced_work_group_size;
 	};
 
 } // namespace detail

--- a/include/device_queue.h
+++ b/include/device_queue.h
@@ -32,8 +32,7 @@ namespace detail {
 		 */
 		template <typename Fn>
 		cl::sycl::event submit(Fn&& fn) {
-			// FIXME: Get rid of forced_work_group_size
-			return sycl_queue->submit([fn = std::forward<Fn>(fn), fwgs = forced_work_group_size](cl::sycl::handler& sycl_handler) { fn(sycl_handler, fwgs); });
+			return sycl_queue->submit([fn = std::forward<Fn>(fn)](cl::sycl::handler& sycl_handler) { fn(sycl_handler); });
 		}
 
 		/**
@@ -55,8 +54,6 @@ namespace detail {
 		logger& queue_logger;
 		std::unique_ptr<cl::sycl::queue> sycl_queue;
 		bool device_profiling_enabled = false;
-		// FIXME: Get rid of this
-		size_t forced_work_group_size = 0;
 
 		cl::sycl::device pick_device(const config& cfg, cl::sycl::device* user_device) const;
 		void handle_async_exceptions(cl::sycl::exception_list el) const;

--- a/src/config.cc
+++ b/src/config.cc
@@ -168,10 +168,7 @@ namespace detail {
 
 		{
 			const auto result = get_env("CELERITY_FORCE_WG");
-			if(result.first) {
-				const auto parsed = parse_uint(result.second.c_str());
-				if(parsed.first) { forced_work_group_size = parsed.second; }
-			}
+			if(result.first) { logger.warn("Support for CELERITY_FORCE_WG has been removed with Celerity 0.3.0."); }
 		}
 
 		// -------------------------------- CELERITY_HOST_CPUS --------------------------------

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -9,8 +9,6 @@ namespace detail {
 
 	void device_queue::init(const config& cfg, cl::sycl::device* user_device) {
 		assert(sycl_queue == nullptr);
-		const auto forced_wg_size_cfg = cfg.get_forced_work_group_size();
-		forced_work_group_size = forced_wg_size_cfg != std::nullopt ? *forced_wg_size_cfg : 0;
 		const auto profiling_cfg = cfg.get_enable_device_profiling();
 		device_profiling_enabled = profiling_cfg != std::nullopt && *profiling_cfg;
 		if(device_profiling_enabled) { queue_logger.info("Device profiling enabled."); }


### PR DESCRIPTION
This was a dirty hack from the very beginning, and is no longer needed as SYCL 2020 enables us to support proper nd_range kernels.

If the option is set, print a warning informing the user of its removal.

Resolves #27.