### PR TITLE
Remove some obsolete workarounds

### DIFF
--- a/include/buffer_storage.h
+++ b/include/buffer_storage.h
@@ -184,9 +184,7 @@ namespace detail {
 			auto result = raw_buffer_data{sizeof(DataT), range};
 			auto buf = get_device_buffer();
 
-			// ComputeCpp (as of version 2.1.0) expects the target pointer of an explicit copy operation to have the same size as the buffer,
-			// even though the SYCL 1.2.1 Rev 7 spec states that "dest must have at least as many bytes as the range accessed by src", which
-			// in my (psalz) opinion indicates that this is supposed to result in a contiguous copy of potentially strided source data.
+			// ComputeCpp (as of version 2.5.0) expects the target pointer of an explicit copy operation to have the same size as the buffer.
 			// As a workaround, we copy the data manually using a kernel.
 #if WORKAROUND_COMPUTECPP
 			cl::sycl::buffer<DataT, Dims> tmp_dst_buf(reinterpret_cast<DataT*>(result.get_pointer()), range_cast<Dims>(range));

--- a/include/worker_job.h
+++ b/include/worker_job.h
@@ -136,8 +136,6 @@ namespace detail {
 		cl::sycl::event event;
 		bool submitted = false;
 
-		std::future<void> computecpp_workaround_future;
-
 		bool execute(const command_pkg& pkg, std::shared_ptr<logger> logger) override;
 		std::pair<command_type, std::string> get_description(const command_pkg& pkg) override;
 	};

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -74,14 +74,7 @@ namespace detail {
 
 		const auto platform_name = device.get_platform().get_info<cl::sycl::info::platform::name>();
 		const auto device_name = device.get_info<cl::sycl::info::device::name>();
-#if WORKAROUND(COMPUTECPP, 1, 1, 2)
-		// The names returned by ComputeCpp seem to contain an additional null byte,
-		// which causes problems (log files get interpreted as binary data etc), so we chop it off.
-		queue_logger.info("Using platform '{}', device '{}' ({})", platform_name.substr(0, platform_name.size() - 1),
-		    device_name.substr(0, device_name.size() - 1), how_selected);
-#else
 		queue_logger.info("Using platform '{}', device '{}' ({})", platform_name, device_name, how_selected);
-#endif
 
 		return device;
 	}


### PR DESCRIPTION
Remove some workarounds for ComputeCpp that either have been obsolete for a while, or are now as we no longer support the PTX backend (which was always plagued by issues, in particular regarding kernel offsets).

Additionally, update the signature of `parallel_for` to more closely match SYCL 2020, in that it now receives the kernel functor as a const reference instead of a copy. This requires some care, as we need to ensure that kernel functors are copied at least once during the call to `live_pass_device_handler::submit_to_sycl` (so we can hydrate SYCL placeholder accessors within Celerity accessor's copy constructors). To make this explicit, a new `copy_kernel` function is added.