### PR TITLE
Improve range mapper ergonomics, check for dimensionality mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ celerity::buffer<float, 1> buf(sycl::range<1>(1024));
 queue.submit([=](celerity::handler& cgh) {
   auto acc = buf.get_access<sycl::access::mode::discard_write>(
     cgh,
-    celerity::access::one_to_one<1>()           // 1
+    celerity::access::one_to_one()              // 1
   );
   cgh.parallel_for<class MyKernel>(
     sycl::range<1>(1024),                       // 2

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -170,8 +170,8 @@ aforementioned buffer accessors. Let's create these now - replace the TODO
 before the kernel function with the following:
 
 ```cpp
-auto r_input = input_buf.get_access<cl::sycl::access::mode::read>(cgh, celerity::access::neighborhood<2>(1, 1));
-auto dw_edge = edge_buf.get_access<cl::sycl::access::mode::discard_write>(cgh, celerity::access::one_to_one<2>());
+auto r_input = input_buf.get_access<cl::sycl::access::mode::read>(cgh, celerity::access::neighborhood(1, 1));
+auto dw_edge = edge_buf.get_access<cl::sycl::access::mode::discard_write>(cgh, celerity::access::one_to_one());
 ```
 
 If you have worked with SYCL before, these buffer accessors will look
@@ -201,8 +201,8 @@ for each invocation of the kernel -- i.e., for each work item, we only ever
 access the output buffer once: at exactly the current location represented by
 the `item`. This means there exists a one-to-one mapping of the kernel index
 and the accessed buffer index. For this reason we pass a
-`celerity::access::one_to_one<2>` range mapper (where the `2` simply means
-that we are operating on two-dimensional kernels and buffers).
+`celerity::access::one_to_one` range mapper (which means that kernel and
+buffer need to have the same dimensionality and size).
 
 The range mapper for our `input_buf` is a bit more complicated, but not by
 much: Remember that for computing the Laplace filter, we are summing up the

--- a/examples/convolution/convolution.cc
+++ b/examples/convolution/convolution.cc
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
 
 	queue.submit([=](celerity::handler& cgh) {
 		auto out = image_output_buf.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(
-		    cgh, celerity::access::fixed<2>{{{}, cl::sycl::range<2>(image_height, image_width)}});
+		    cgh, celerity::access::all<1, 2>{}); // we need to access all of the 2D buffer, but the master-node task produces a one-dimensional chunk
 
 		cgh.host_task(celerity::on_master_node, [=] {
 			std::vector<uint8_t> image_output(image_width * image_height * 3);

--- a/examples/distr_io/distr_io.cc
+++ b/examples/distr_io/distr_io.cc
@@ -121,7 +121,7 @@ int main(int argc, char* argv[]) {
 		read_hdf5_file(q, in, argv[2]);
 
 		q.submit([=](celerity::handler& cgh) {
-			auto a = in.get_access<cl::sycl::access::mode::read>(cgh, celerity::access::one_to_one<2>());
+			auto a = in.get_access<cl::sycl::access::mode::read>(cgh, celerity::access::one_to_one{});
 			auto b = out.get_access<cl::sycl::access::mode::discard_write>(cgh, transposed);
 			cgh.parallel_for<class transpose>(cl::sycl::range<2>{N, N}, [=](cl::sycl::item<2> item) {
 				auto id = item.get_id();
@@ -142,9 +142,8 @@ int main(int argc, char* argv[]) {
 			read_hdf5_file(q, right, argv[3]);
 
 			q.submit(celerity::allow_by_ref, [=, &equal](celerity::handler& cgh) {
-				// We need to access all of the 2D buffers, but the master-node task produces a one-dimensional chunk
-				auto a = left.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::all<1, 2>());
-				auto b = right.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::all<1, 2>());
+				auto a = left.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::all{});
+				auto b = right.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::all{});
 				cgh.host_task(celerity::on_master_node, [=, &equal] {
 					for(size_t i = 0; i < N; ++i) {
 						for(size_t j = 0; j < N; ++j) {

--- a/examples/distr_io/distr_io.cc
+++ b/examples/distr_io/distr_io.cc
@@ -142,8 +142,9 @@ int main(int argc, char* argv[]) {
 			read_hdf5_file(q, right, argv[3]);
 
 			q.submit(celerity::allow_by_ref, [=, &equal](celerity::handler& cgh) {
-				auto a = left.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::all<2>());
-				auto b = right.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::all<2>());
+				// We need to access all of the 2D buffers, but the master-node task produces a one-dimensional chunk
+				auto a = left.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::all<1, 2>());
+				auto b = right.get_access<cl::sycl::access::mode::read, cl::sycl::access::target::host_buffer>(cgh, celerity::access::all<1, 2>());
 				cgh.host_task(celerity::on_master_node, [=, &equal] {
 					for(size_t i = 0; i < N; ++i) {
 						for(size_t j = 0; j < N; ++j) {

--- a/examples/matmul/matmul.cc
+++ b/examples/matmul/matmul.cc
@@ -7,7 +7,7 @@ constexpr size_t MAT_SIZE = 1024;
 template <typename T>
 void set_identity(celerity::distr_queue queue, celerity::buffer<T, 2> mat) {
 	queue.submit([=](celerity::handler& cgh) {
-		celerity::accessor dw{mat, cgh, celerity::access::one_to_one<2>(), cl::sycl::write_only, cl::sycl::no_init};
+		celerity::accessor dw{mat, cgh, celerity::access::one_to_one{}, cl::sycl::write_only, cl::sycl::no_init};
 		cgh.parallel_for<class set_identity_kernel>(mat.get_range(), [=](cl::sycl::item<2> item) { dw[item] = item[0] == item[1]; });
 	});
 }
@@ -17,7 +17,7 @@ void multiply(celerity::distr_queue queue, celerity::buffer<T, 2> mat_a, celerit
 	queue.submit([=](celerity::handler& cgh) {
 		celerity::accessor a{mat_a, cgh, celerity::access::slice<2>(1), cl::sycl::read_only};
 		celerity::accessor b{mat_b, cgh, celerity::access::slice<2>(0), cl::sycl::read_only};
-		celerity::accessor c{mat_c, cgh, celerity::access::one_to_one<2>(), cl::sycl::write_only, cl::sycl::no_init};
+		celerity::accessor c{mat_c, cgh, celerity::access::one_to_one{}, cl::sycl::write_only, cl::sycl::no_init};
 
 		cgh.parallel_for<class mat_mul>(cl::sycl::range<2>(MAT_SIZE, MAT_SIZE), [=](cl::sycl::item<2> item) {
 			auto sum = 0.f;
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
 		multiply(queue, mat_b_buf, mat_c_buf, mat_a_buf);
 
 		queue.submit(celerity::allow_by_ref, [&](celerity::handler& cgh) {
-			celerity::accessor result{mat_a_buf, cgh, celerity::access::one_to_one<2>(), cl::sycl::read_only_host_task};
+			celerity::accessor result{mat_a_buf, cgh, celerity::access::one_to_one{}, cl::sycl::read_only_host_task};
 
 			cgh.host_task(range, [=, &verification_passed](celerity::partition<2> part) {
 				celerity::experimental::bench::end("main program");

--- a/examples/syncing/syncing.cc
+++ b/examples/syncing/syncing.cc
@@ -13,12 +13,12 @@ int main(int argc, char* argv[]) {
 	std::vector<int> host_buff(N);
 
 	q.submit([=](handler& cgh) {
-		celerity::accessor b{buff, cgh, access::one_to_one<1>(), cl::sycl::write_only, cl::sycl::no_init};
+		celerity::accessor b{buff, cgh, access::one_to_one{}, cl::sycl::write_only, cl::sycl::no_init};
 		cgh.parallel_for<class mat_mul>(cl::sycl::range<1>(N), [=](cl::sycl::item<1> item) { b[item] = item.get_linear_id(); });
 	});
 
 	q.submit(celerity::allow_by_ref, [=, &host_buff](handler& cgh) {
-		celerity::accessor b{buff, cgh, access::all<1>{}, cl::sycl::read_only_host_task};
+		celerity::accessor b{buff, cgh, access::all{}, cl::sycl::read_only_host_task};
 		cgh.host_task(on_master_node, [=, &host_buff] {
 			std::this_thread::sleep_for(std::chrono::milliseconds(10)); // give the synchronization more time to fail
 			for(int i = 0; i < N; i++) {

--- a/examples/syncing/syncing.cc
+++ b/examples/syncing/syncing.cc
@@ -18,7 +18,7 @@ int main(int argc, char* argv[]) {
 	});
 
 	q.submit(celerity::allow_by_ref, [=, &host_buff](handler& cgh) {
-		celerity::accessor b{buff, cgh, access::fixed<1>({0, N}), cl::sycl::read_only_host_task};
+		celerity::accessor b{buff, cgh, access::all<1>{}, cl::sycl::read_only_host_task};
 		cgh.host_task(on_master_node, [=, &host_buff] {
 			std::this_thread::sleep_for(std::chrono::milliseconds(10)); // give the synchronization more time to fail
 			for(int i = 0; i < N; i++) {

--- a/examples/wave_sim/wave_sim.cc
+++ b/examples/wave_sim/wave_sim.cc
@@ -9,7 +9,7 @@
 
 void setup_wave(celerity::distr_queue& queue, celerity::buffer<float, 2> u, cl::sycl::float2 center, float amplitude, cl::sycl::float2 sigma) {
 	queue.submit([=](celerity::handler& cgh) {
-		celerity::accessor dw_u{u, cgh, celerity::access::one_to_one<2>(), cl::sycl::write_only, cl::sycl::no_init};
+		celerity::accessor dw_u{u, cgh, celerity::access::one_to_one{}, cl::sycl::write_only, cl::sycl::no_init};
 		cgh.parallel_for<class setup_wave>(u.get_range(), [=, c = center, a = amplitude, s = sigma](cl::sycl::item<2> item) {
 			const float dx = item[1] - c.x();
 			const float dy = item[0] - c.y();
@@ -20,7 +20,7 @@ void setup_wave(celerity::distr_queue& queue, celerity::buffer<float, 2> u, cl::
 
 void zero(celerity::distr_queue& queue, celerity::buffer<float, 2> buf) {
 	queue.submit([=](celerity::handler& cgh) {
-		celerity::accessor dw_buf{buf, cgh, celerity::access::one_to_one<2>(), cl::sycl::write_only, cl::sycl::no_init};
+		celerity::accessor dw_buf{buf, cgh, celerity::access::one_to_one{}, cl::sycl::write_only, cl::sycl::no_init};
 		cgh.parallel_for<class zero>(buf.get_range(), [=](cl::sycl::item<2> item) { dw_buf[item] = 0.f; });
 	});
 }
@@ -40,8 +40,8 @@ struct update_config {
 template <typename T, typename Config, typename KernelName>
 void step(celerity::distr_queue& queue, celerity::buffer<T, 2> up, celerity::buffer<T, 2> u, float dt, cl::sycl::float2 delta) {
 	queue.submit([=](celerity::handler& cgh) {
-		celerity::accessor rw_up{up, cgh, celerity::access::one_to_one<2>(), cl::sycl::read_write};
-		celerity::accessor r_u{u, cgh, celerity::access::neighborhood<2>(1, 1), cl::sycl::read_only};
+		celerity::accessor rw_up{up, cgh, celerity::access::one_to_one{}, cl::sycl::read_write};
+		celerity::accessor r_u{u, cgh, celerity::access::neighborhood{1, 1}, cl::sycl::read_only};
 
 		const auto size = up.get_range();
 		cgh.parallel_for<KernelName>(size, [=](cl::sycl::item<2> item) {
@@ -69,8 +69,7 @@ template <typename T>
 void store(celerity::distr_queue& queue, celerity::buffer<T, 2> up, std::vector<std::vector<float>>& result_frames) {
 	const auto range = up.get_range();
 	queue.submit(celerity::allow_by_ref, [=, &result_frames](celerity::handler& cgh) {
-		// We need to access all of the 2D buffer, but the master-node task produces a one-dimensional chunk
-		celerity::accessor up_r{up, cgh, celerity::access::all<1, 2>{}, cl::sycl::read_only_host_task};
+		celerity::accessor up_r{up, cgh, celerity::access::all{}, cl::sycl::read_only_host_task};
 		cgh.host_task(celerity::on_master_node, [=, &result_frames] {
 			result_frames.emplace_back();
 			auto& frame = *result_frames.rbegin();

--- a/examples/wave_sim/wave_sim.cc
+++ b/examples/wave_sim/wave_sim.cc
@@ -69,7 +69,8 @@ template <typename T>
 void store(celerity::distr_queue& queue, celerity::buffer<T, 2> up, std::vector<std::vector<float>>& result_frames) {
 	const auto range = up.get_range();
 	queue.submit(celerity::allow_by_ref, [=, &result_frames](celerity::handler& cgh) {
-		celerity::accessor up_r{up, cgh, celerity::access::fixed<2>{{{}, range}}, cl::sycl::read_only_host_task};
+		// We need to access all of the 2D buffer, but the master-node task produces a one-dimensional chunk
+		celerity::accessor up_r{up, cgh, celerity::access::all<1, 2>{}, cl::sycl::read_only_host_task};
 		cgh.host_task(celerity::on_master_node, [=, &result_frames] {
 			result_frames.emplace_back();
 			auto& frame = *result_frames.rbegin();

--- a/include/print_utils.h
+++ b/include/print_utils.h
@@ -11,12 +11,12 @@ namespace detail {
 
 template <int Dims>
 std::ostream& operator<<(std::ostream& os, chunk<Dims> chnk) {
-	return detail::print_chunk3(os, chnk);
+	return detail::print_chunk3(os, detail::chunk_cast<3>(chnk));
 }
 
 template <int Dims>
 std::ostream& operator<<(std::ostream& os, subrange<Dims> subr) {
-	return detail::print_subrange3(os, subr);
+	return detail::print_subrange3(os, detail::subrange_cast<3>(subr));
 }
 
 } // namespace celerity

--- a/include/range_mapper.h
+++ b/include/range_mapper.h
@@ -12,88 +12,45 @@ namespace celerity {
 
 namespace detail {
 
-
-	template <int KernelDims, int BufferDims>
-	using range_mapper_fn = std::function<subrange<BufferDims>(chunk<KernelDims> chnk, cl::sycl::range<BufferDims> buffer_size)>;
+	template <typename Functor, int BufferDims, int KernelDims>
+	constexpr bool is_range_mapper_invocable_for_chunk_only = std::is_invocable_r_v<subrange<BufferDims>, const Functor&, const celerity::chunk<KernelDims>&>;
 
 	template <typename Functor, int BufferDims, int KernelDims>
-	constexpr bool is_range_mapper_invocable_for_kernel =
-	    std::is_invocable_v<Functor&&, const celerity::chunk<KernelDims>&,
-	        const cl::sycl::range<BufferDims>&> || std::is_invocable_v<Functor&&, const celerity::chunk<KernelDims>&>;
+	constexpr bool is_range_mapper_invocable_for_chunk_and_global_size =
+	    std::is_invocable_r_v<subrange<BufferDims>, const Functor&, const celerity::chunk<KernelDims>&, const cl::sycl::range<BufferDims>&>;
+
+	template <typename Functor, int BufferDims, int KernelDims>
+	constexpr bool is_range_mapper_invocable_for_kernel = is_range_mapper_invocable_for_chunk_only<Functor, BufferDims, KernelDims> //
+	                                                      || is_range_mapper_invocable_for_chunk_and_global_size<Functor, BufferDims, KernelDims>;
 
 	template <typename Functor, int BufferDims>
-	constexpr bool is_range_mapper_invocable =
-	    is_range_mapper_invocable_for_kernel<Functor, BufferDims,
-	        1> || is_range_mapper_invocable_for_kernel<Functor, BufferDims, 2> || is_range_mapper_invocable_for_kernel<Functor, BufferDims, 3>;
+	constexpr bool is_range_mapper_invocable = is_range_mapper_invocable_for_kernel<Functor, BufferDims, 1>    //
+	                                           || is_range_mapper_invocable_for_kernel<Functor, BufferDims, 2> //
+	                                           || is_range_mapper_invocable_for_kernel<Functor, BufferDims, 3>;
+
+	[[noreturn]] inline void throw_invalid_range_mapper_args(int expect_kernel_dims, int expect_buffer_dims) {
+		throw std::runtime_error(fmt::format("Invalid range mapper dimensionality: {0}-dimensional kernel submitted with a requirement whose range mapper "
+		                                     "is neither invocable for chunk<{0}> nor (chunk<{0}>, range<{1}>) to produce subrange<{1}>",
+		    expect_kernel_dims, expect_buffer_dims));
+	}
+
+	[[noreturn]] inline void throw_invalid_range_mapper_result(int expect_sr_dims, int actual_sr_dims, int kernel_dims) {
+		throw std::runtime_error(fmt::format("Range mapper produces subrange of wrong dimensionality: Expecting subrange<{}>, got subrange<{}> for chunk<{}>",
+		    expect_sr_dims, actual_sr_dims, kernel_dims));
+	}
 
 	template <int KernelDims, int BufferDims, typename Functor>
-	subrange<BufferDims> invoke_range_mapper_for_kernel_dims(
+	subrange<BufferDims> invoke_range_mapper_for_kernel(
 	    Functor&& fn, const celerity::chunk<KernelDims>& chunk, const cl::sycl::range<BufferDims>& buffer_size) {
 		static_assert(KernelDims >= 1 && KernelDims <= 3 && BufferDims >= 1 && BufferDims <= 3);
-		if constexpr(std::is_invocable_v<Functor&&, const celerity::chunk<KernelDims>&, const cl::sycl::range<BufferDims>&>) {
+		if constexpr(is_range_mapper_invocable_for_chunk_and_global_size<Functor, BufferDims, KernelDims>) {
 			return std::forward<Functor>(fn)(chunk, buffer_size);
-		} else if constexpr(std::is_invocable_v<Functor&&, const celerity::chunk<KernelDims>&>) {
+		} else if constexpr(is_range_mapper_invocable_for_chunk_only<Functor, BufferDims, KernelDims>) {
 			return std::forward<Functor>(fn)(chunk);
 		} else {
-			throw std::runtime_error(fmt::format("Invalid range mapper dimensionality: {0}-dimensional kernel submitted with a requirement whose range mapper "
-			                                     "is neither invocable for chunk<{0}> nor (chunk<{0}>, range<{1}>)",
-			    KernelDims, BufferDims));
+			throw_invalid_range_mapper_args(KernelDims, BufferDims);
 		}
 	}
-
-	template <int BufferDims, typename Functor>
-	subrange<BufferDims> invoke_range_mapper(int kernel_dims, Functor&& fn, const celerity::chunk<3>& chunk, const cl::sycl::range<BufferDims>& buffer_size) {
-		static_assert(is_range_mapper_invocable<Functor, BufferDims>);
-		switch(kernel_dims) {
-		case 0:
-			[[fallthrough]]; // cl::sycl::range is not defined for the 0d case, but since only constant range mappers are useful in the 0d-kernel case
-			                 // anyway, we require range mappers to take at least 1d subranges
-		case 1: return invoke_range_mapper_for_kernel_dims<1>(std::forward<Functor>(fn), chunk_cast<1>(chunk), buffer_size);
-		case 2: return invoke_range_mapper_for_kernel_dims<2>(std::forward<Functor>(fn), chunk_cast<2>(chunk), buffer_size);
-		case 3: return invoke_range_mapper_for_kernel_dims<3>(std::forward<Functor>(fn), chunk_cast<3>(chunk), buffer_size);
-		default: assert(!"Unreachable"); return {};
-		}
-	}
-
-	template <int KernelDims, int BufferDims, typename Functor>
-	auto bind_range_mapper(Functor fn) {
-		return [fn](const chunk<KernelDims>& chunk, const cl::sycl::range<BufferDims>& buffer_size) {
-			return invoke_range_mapper_for_kernel_dims<KernelDims>(fn, chunk, buffer_size);
-		};
-	}
-
-	class range_mapper_base {
-	  public:
-		range_mapper_base(cl::sycl::access::mode am) : access_mode(am) {}
-		range_mapper_base(const range_mapper_base& other) = delete;
-		range_mapper_base(range_mapper_base&& other) = delete;
-
-		cl::sycl::access::mode get_access_mode() const { return access_mode; }
-
-		virtual int get_kernel_dimensions() const = 0;
-		virtual int get_buffer_dimensions() const = 0;
-
-		virtual subrange<1> map_1(chunk<1> chnk) const { throw create_dimension_mismatch_error(1, 1); }
-		virtual subrange<1> map_1(chunk<2> chnk) const { throw create_dimension_mismatch_error(2, 1); }
-		virtual subrange<1> map_1(chunk<3> chnk) const { throw create_dimension_mismatch_error(3, 1); }
-		virtual subrange<2> map_2(chunk<1> chnk) const { throw create_dimension_mismatch_error(1, 2); }
-		virtual subrange<2> map_2(chunk<2> chnk) const { throw create_dimension_mismatch_error(2, 2); }
-		virtual subrange<2> map_2(chunk<3> chnk) const { throw create_dimension_mismatch_error(3, 2); }
-		virtual subrange<3> map_3(chunk<1> chnk) const { throw create_dimension_mismatch_error(1, 3); }
-		virtual subrange<3> map_3(chunk<2> chnk) const { throw create_dimension_mismatch_error(2, 3); }
-		virtual subrange<3> map_3(chunk<3> chnk) const { throw create_dimension_mismatch_error(3, 3); }
-
-		virtual ~range_mapper_base() = default;
-
-	  private:
-		cl::sycl::access::mode access_mode;
-
-		std::runtime_error create_dimension_mismatch_error(int wrong_kernel_dims, int buffer_dims) const {
-			const int kernel_dims = get_kernel_dimensions();
-			return std::runtime_error(fmt::format("Range mapper maps chunk<{}> -> subrange<{}>, but should map chunk<{}> -> subrange<{}>.", wrong_kernel_dims,
-			    buffer_dims, kernel_dims, buffer_dims));
-		}
-	};
 
 	template <int BufferDims>
 	subrange<BufferDims> clamp_subrange_to_buffer_size(subrange<BufferDims> sr, cl::sycl::range<BufferDims> buffer_size) {
@@ -104,52 +61,78 @@ namespace detail {
 		return sr;
 	}
 
-	template <int KernelDims, int BufferDims>
-	class range_mapper : public range_mapper_base {
+	template <int BufferDims, typename Functor>
+	subrange<BufferDims> invoke_range_mapper(int kernel_dims, Functor fn, const celerity::chunk<3>& chunk, const cl::sycl::range<BufferDims>& buffer_size) {
+		static_assert(is_range_mapper_invocable<Functor, BufferDims>);
+		subrange<BufferDims> sr;
+		switch(kernel_dims) {
+		case 0:
+			[[fallthrough]]; // cl::sycl::range is not defined for the 0d case, but since only constant range mappers are useful in the 0d-kernel case
+			                 // anyway, we require range mappers to take at least 1d subranges
+		case 1: sr = invoke_range_mapper_for_kernel(fn, chunk_cast<1>(chunk), buffer_size); break;
+		case 2: sr = invoke_range_mapper_for_kernel(fn, chunk_cast<2>(chunk), buffer_size); break;
+		case 3: sr = invoke_range_mapper_for_kernel(fn, chunk_cast<3>(chunk), buffer_size); break;
+		default: assert(!"Unreachable"); return {};
+		}
+		return clamp_subrange_to_buffer_size(sr, buffer_size);
+	}
+
+	class range_mapper_base {
 	  public:
-		template <typename RangeMapperFn>
-		range_mapper(RangeMapperFn fn, cl::sycl::access::mode am, cl::sycl::range<BufferDims> buffer_size)
-		    : range_mapper_base(am), rmfn(bind_range_mapper<KernelDims, BufferDims>(fn)), buffer_size(buffer_size) {}
+		explicit range_mapper_base(cl::sycl::access::mode am) : access_mode(am) {}
+		range_mapper_base(const range_mapper_base& other) = delete;
+		range_mapper_base(range_mapper_base&& other) = delete;
 
-		int get_kernel_dimensions() const override { return KernelDims; }
-		int get_buffer_dimensions() const override { return BufferDims; }
+		cl::sycl::access::mode get_access_mode() const { return access_mode; }
 
-		subrange<1> map_1(chunk<KernelDims> chnk) const override { return map_1_impl(chnk); }
-		subrange<2> map_2(chunk<KernelDims> chnk) const override { return map_2_impl(chnk); }
-		subrange<3> map_3(chunk<KernelDims> chnk) const override { return map_3_impl(chnk); }
+		virtual int get_buffer_dimensions() const = 0;
+
+		virtual subrange<1> map_1(chunk<1> chnk) const = 0;
+		virtual subrange<1> map_1(chunk<2> chnk) const = 0;
+		virtual subrange<1> map_1(chunk<3> chnk) const = 0;
+		virtual subrange<2> map_2(chunk<1> chnk) const = 0;
+		virtual subrange<2> map_2(chunk<2> chnk) const = 0;
+		virtual subrange<2> map_2(chunk<3> chnk) const = 0;
+		virtual subrange<3> map_3(chunk<1> chnk) const = 0;
+		virtual subrange<3> map_3(chunk<2> chnk) const = 0;
+		virtual subrange<3> map_3(chunk<3> chnk) const = 0;
+
+		virtual ~range_mapper_base() = default;
 
 	  private:
-		range_mapper_fn<KernelDims, BufferDims> rmfn;
+		cl::sycl::access::mode access_mode;
+	};
+
+	template <int BufferDims, typename Functor>
+	class range_mapper : public range_mapper_base {
+	  public:
+		range_mapper(Functor rmfn, cl::sycl::access::mode am, cl::sycl::range<BufferDims> buffer_size)
+		    : range_mapper_base(am), rmfn(rmfn), buffer_size(buffer_size) {}
+
+		int get_buffer_dimensions() const override { return BufferDims; }
+
+		subrange<1> map_1(chunk<1> chnk) const override { return map<1>(chnk); }
+		subrange<1> map_1(chunk<2> chnk) const override { return map<1>(chnk); }
+		subrange<1> map_1(chunk<3> chnk) const override { return map<1>(chnk); }
+		subrange<2> map_2(chunk<1> chnk) const override { return map<2>(chnk); }
+		subrange<2> map_2(chunk<2> chnk) const override { return map<2>(chnk); }
+		subrange<2> map_2(chunk<3> chnk) const override { return map<2>(chnk); }
+		subrange<3> map_3(chunk<1> chnk) const override { return map<3>(chnk); }
+		subrange<3> map_3(chunk<2> chnk) const override { return map<3>(chnk); }
+		subrange<3> map_3(chunk<3> chnk) const override { return map<3>(chnk); }
+
+	  private:
+		Functor rmfn;
 		cl::sycl::range<BufferDims> buffer_size;
 
-		template <int D = BufferDims>
-		typename std::enable_if<D == 1, subrange<1>>::type map_1_impl(chunk<KernelDims> chnk) const {
-			return clamp_subrange_to_buffer_size(rmfn(chnk, buffer_size), buffer_size);
-		}
-
-		template <int D = BufferDims>
-		typename std::enable_if<D != 1, subrange<1>>::type map_1_impl(chunk<KernelDims> chnk) const {
-			return range_mapper_base::map_1(chnk);
-		}
-
-		template <int D = BufferDims>
-		typename std::enable_if<D == 2, subrange<2>>::type map_2_impl(chunk<KernelDims> chnk) const {
-			return clamp_subrange_to_buffer_size(rmfn(chnk, buffer_size), buffer_size);
-		}
-
-		template <int D = BufferDims>
-		typename std::enable_if<D != 2, subrange<2>>::type map_2_impl(chunk<KernelDims> chnk) const {
-			return range_mapper_base::map_2(chnk);
-		}
-
-		template <int D = BufferDims>
-		typename std::enable_if<D == 3, subrange<3>>::type map_3_impl(chunk<KernelDims> chnk) const {
-			return clamp_subrange_to_buffer_size(rmfn(chnk, buffer_size), buffer_size);
-		}
-
-		template <int D = BufferDims>
-		typename std::enable_if<D != 3, subrange<3>>::type map_3_impl(chunk<KernelDims> chnk) const {
-			return range_mapper_base::map_3(chnk);
+		template <int OtherBufferDims, int KernelDims>
+		subrange<OtherBufferDims> map(chunk<KernelDims> chnk) const {
+			if constexpr(OtherBufferDims == BufferDims) {
+				auto sr = invoke_range_mapper_for_kernel(rmfn, chnk, buffer_size);
+				return clamp_subrange_to_buffer_size(sr, buffer_size);
+			} else {
+				throw_invalid_range_mapper_result(OtherBufferDims, BufferDims, KernelDims);
+			}
 		}
 	};
 
@@ -160,20 +143,48 @@ namespace detail {
 
 namespace access {
 
-	template <int Dims>
-	struct one_to_one {
-		subrange<Dims> operator()(chunk<Dims> chnk) const { return chnk; }
+	template <int Dims = 0>
+	struct one_to_one;
+
+	template <>
+	struct one_to_one<0> {
+		template <int Dims>
+		subrange<Dims> operator()(chunk<Dims> chnk) const {
+			return chnk;
+		}
 	};
 
+	template <int Dims>
+	struct [[deprecated("Explicitly-dimensioned range mappers are deprecated, remove template arguments from celerity::one_to_one")]] one_to_one
+	    : one_to_one<0>{};
+
+	one_to_one() -> one_to_one<>;
+
 	template <int KernelDims, int BufferDims = KernelDims>
-	struct fixed {
+	struct fixed;
+
+	template <int BufferDims>
+	struct fixed<BufferDims, BufferDims> {
 		fixed(subrange<BufferDims> sr) : sr(sr) {}
 
-		subrange<BufferDims> operator()(chunk<KernelDims>) const { return sr; }
+		template <int KernelDims>
+		subrange<BufferDims> operator()(chunk<KernelDims>) const {
+			return sr;
+		}
 
 	  private:
 		subrange<BufferDims> sr;
 	};
+
+	template <int KernelDims, int BufferDims>
+	struct fixed : fixed<BufferDims, BufferDims> {
+		[[deprecated("Explicitly-dimensioned range mappers are deprecated, remove first template argument from celerity::fixed")]] //
+		fixed(subrange<BufferDims> sr)
+		    : fixed<BufferDims, BufferDims>(sr) {}
+	};
+
+	template <int BufferDims>
+	fixed(subrange<BufferDims>) -> fixed<BufferDims>;
 
 	template <int Dims>
 	struct slice {
@@ -191,10 +202,21 @@ namespace access {
 		size_t dim_idx;
 	};
 
-	template <int KernelDims, int BufferDims = KernelDims>
-	struct all {
-		subrange<BufferDims> operator()(chunk<KernelDims>, cl::sycl::range<BufferDims> buffer_size) const { return {{}, buffer_size}; }
+	template <int KernelDims = 0, int BufferDims = KernelDims>
+	struct all;
+
+	template <>
+	struct all<0, 0> {
+		template <int KernelDims, int BufferDims>
+		subrange<BufferDims> operator()(chunk<KernelDims>, cl::sycl::range<BufferDims> buffer_size) const {
+			return {{}, buffer_size};
+		}
 	};
+
+	template <int KernelDims, int BufferDims>
+	struct [[deprecated("Explicitly-dimensioned range mappers are deprecated, remove template arguments from celerity::all")]] all : all<0, 0>{};
+
+	all() -> all<>;
 
 	template <int Dims>
 	struct neighborhood {
@@ -218,6 +240,10 @@ namespace access {
 	  private:
 		size_t dim0, dim1, dim2;
 	};
+
+	neighborhood(size_t) -> neighborhood<1>;
+	neighborhood(size_t, size_t) -> neighborhood<2>;
+	neighborhood(size_t, size_t, size_t) -> neighborhood<3>;
 
 } // namespace access
 

--- a/include/range_mapper.h
+++ b/include/range_mapper.h
@@ -158,7 +158,7 @@ namespace access {
 	struct [[deprecated("Explicitly-dimensioned range mappers are deprecated, remove template arguments from celerity::one_to_one")]] one_to_one
 	    : one_to_one<0>{};
 
-	one_to_one() -> one_to_one<>;
+	one_to_one()->one_to_one<>;
 
 	template <int KernelDims, int BufferDims = KernelDims>
 	struct fixed;
@@ -216,7 +216,7 @@ namespace access {
 	template <int KernelDims, int BufferDims>
 	struct [[deprecated("Explicitly-dimensioned range mappers are deprecated, remove template arguments from celerity::all")]] all : all<0, 0>{};
 
-	all() -> all<>;
+	all()->all<>;
 
 	template <int Dims>
 	struct neighborhood {
@@ -241,9 +241,9 @@ namespace access {
 		size_t dim0, dim1, dim2;
 	};
 
-	neighborhood(size_t) -> neighborhood<1>;
-	neighborhood(size_t, size_t) -> neighborhood<2>;
-	neighborhood(size_t, size_t, size_t) -> neighborhood<3>;
+	neighborhood(size_t)->neighborhood<1>;
+	neighborhood(size_t, size_t)->neighborhood<2>;
+	neighborhood(size_t, size_t, size_t)->neighborhood<3>;
 
 } // namespace access
 

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -60,10 +60,6 @@ struct chunk {
 	chunk() = default;
 
 	chunk(cl::sycl::id<Dims> offset, cl::sycl::range<Dims> range, cl::sycl::range<Dims> global_size) : offset(offset), range(range), global_size(global_size) {}
-
-	template <int OtherDims>
-	chunk(chunk<OtherDims> other)
-	    : offset(detail::id_cast<Dims>(other.offset)), range(detail::range_cast<Dims>(other.range)), global_size(detail::range_cast<Dims>(other.global_size)) {}
 };
 
 template <int Dims>
@@ -79,12 +75,23 @@ struct subrange {
 
 	subrange(cl::sycl::id<Dims> offset, cl::sycl::range<Dims> range) : offset(offset), range(range) {}
 
-	template <int OtherDims>
-	subrange(subrange<OtherDims> other) : offset(detail::id_cast<Dims>(other.offset)), range(detail::range_cast<Dims>(other.range)) {}
-
 	subrange(chunk<Dims> other) : offset(other.offset), range(other.range) {}
 
 	bool operator==(const subrange& rhs) { return offset == rhs.offset && range == rhs.range; }
 };
+
+namespace detail {
+
+	template <int Dims, int OtherDims>
+	chunk<Dims> chunk_cast(chunk<OtherDims> other) {
+		return chunk{detail::id_cast<Dims>(other.offset), detail::range_cast<Dims>(other.range), detail::range_cast<Dims>(other.global_size)};
+	}
+
+	template <int Dims, int OtherDims>
+	subrange<Dims> subrange_cast(subrange<OtherDims> other) {
+		return subrange{detail::id_cast<Dims>(other.offset), detail::range_cast<Dims>(other.range)};
+	}
+
+} // namespace detail
 
 } // namespace celerity

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -89,12 +89,12 @@ struct subrange {
 namespace detail {
 
 	template <int Dims, int OtherDims>
-	chunk<Dims> chunk_cast(chunk<OtherDims> other) {
+	chunk<Dims> chunk_cast(const chunk<OtherDims>& other) {
 		return chunk{detail::id_cast<Dims>(other.offset), detail::range_cast<Dims>(other.range), detail::range_cast<Dims>(other.global_size)};
 	}
 
 	template <int Dims, int OtherDims>
-	subrange<Dims> subrange_cast(subrange<OtherDims> other) {
+	subrange<Dims> subrange_cast(const subrange<OtherDims>& other) {
 		return subrange{detail::id_cast<Dims>(other.offset), detail::range_cast<Dims>(other.range)};
 	}
 

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -60,6 +60,11 @@ struct chunk {
 	chunk() = default;
 
 	chunk(cl::sycl::id<Dims> offset, cl::sycl::range<Dims> range, cl::sycl::range<Dims> global_size) : offset(offset), range(range), global_size(global_size) {}
+
+	friend bool operator==(const chunk& lhs, const chunk& rhs) {
+		return lhs.offset == rhs.offset && lhs.range == rhs.range && lhs.global_size == rhs.global_size;
+	}
+	friend bool operator!=(const chunk& lhs, const chunk& rhs) { return !operator==(lhs, rhs); }
 };
 
 template <int Dims>
@@ -77,7 +82,8 @@ struct subrange {
 
 	subrange(chunk<Dims> other) : offset(other.offset), range(other.range) {}
 
-	bool operator==(const subrange& rhs) { return offset == rhs.offset && range == rhs.range; }
+	friend bool operator==(const subrange& lhs, const subrange& rhs) { return lhs.offset == rhs.offset && lhs.range == rhs.range; }
+	friend bool operator!=(const subrange& lhs, const subrange& rhs) { return !operator==(lhs, rhs); }
 };
 
 namespace detail {

--- a/include/task.h
+++ b/include/task.h
@@ -61,7 +61,7 @@ namespace detail {
 		 * @returns The region obtained by merging the results of all range-mappers for this buffer and mode
 		 */
 		GridRegion<3> get_requirements_for_access(
-		    buffer_id bid, cl::sycl::access::mode mode, const subrange<3>& sr, const cl::sycl::range<3>& global_size) const;
+		    buffer_id bid, cl::sycl::access::mode mode, int kernel_dims, const subrange<3>& sr, const cl::sycl::range<3>& global_size) const;
 
 	  private:
 		std::unordered_multimap<buffer_id, std::unique_ptr<range_mapper_base>> map;

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -81,7 +81,7 @@ namespace detail {
 		for(const buffer_id bid : buffers) {
 			const auto modes = access_map.get_access_modes(bid);
 			for(auto m : modes) {
-				result[bid][m] = access_map.get_requirements_for_access(bid, m, sr, global_size);
+				result[bid][m] = access_map.get_requirements_for_access(bid, m, tsk->get_dimensions(), sr, global_size);
 			}
 		}
 		return result;

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -44,7 +44,7 @@ namespace detail {
 			for(size_t nid = 0; nid < num_nodes; ++nid) {
 				auto offset = cl::sycl::id<1>{nid};
 				auto range = cl::sycl::range<1>{1};
-				const auto sr = subrange<1>{offset, range};
+				const auto sr = subrange_cast<3>(subrange<1>{offset, range});
 				auto* cmd = cdag.create<task_command>(nid, tid, sr);
 
 				// Collective host tasks have an implicit dependency on the previous task in the same collective group, which is required in order to guarantee

--- a/src/task.cc
+++ b/src/task.cc
@@ -22,7 +22,7 @@ namespace detail {
 	}
 
 	template <int KernelDims>
-	subrange<3> apply_range_mapper(range_mapper_base const* rm, chunk<KernelDims> chnk) {
+	subrange<3> apply_range_mapper(range_mapper_base const* rm, const chunk<KernelDims>& chnk) {
 		switch(rm->get_buffer_dimensions()) {
 		case 1: return subrange_cast<3>(rm->map_1(chnk));
 		case 2: return subrange_cast<3>(rm->map_2(chnk));

--- a/src/task.cc
+++ b/src/task.cc
@@ -24,8 +24,8 @@ namespace detail {
 	template <int KernelDims>
 	subrange<3> apply_range_mapper(range_mapper_base const* rm, chunk<KernelDims> chnk) {
 		switch(rm->get_buffer_dimensions()) {
-		case 1: return rm->map_1(chnk);
-		case 2: return rm->map_2(chnk);
+		case 1: return subrange_cast<3>(rm->map_1(chnk));
+		case 2: return subrange_cast<3>(rm->map_2(chnk));
 		case 3: return rm->map_3(chnk);
 		default: assert(false);
 		}

--- a/src/task.cc
+++ b/src/task.cc
@@ -39,8 +39,8 @@ namespace detail {
 
 		GridRegion<3> result;
 		for(auto iter = first; iter != last; ++iter) {
-			auto range = iter->second.get();
-			if(range->get_access_mode() != mode) continue;
+			auto rm = iter->second.get();
+			if(rm->get_access_mode() != mode) continue;
 
 			chunk<3> chnk{sr.offset, sr.range, global_size};
 			subrange<3> req;
@@ -48,9 +48,9 @@ namespace detail {
 			case 0:
 				[[fallthrough]]; // cl::sycl::range is not defined for the 0d case, but since only constant range mappers are useful in the 0d-kernel case
 				                 // anyway, we require range mappers to take at least 1d subranges
-			case 1: req = apply_range_mapper<1>(range, chunk_cast<1>(chnk)); break;
-			case 2: req = apply_range_mapper<2>(range, chunk_cast<2>(chnk)); break;
-			case 3: req = apply_range_mapper<3>(range, chunk_cast<3>(chnk)); break;
+			case 1: req = apply_range_mapper<1>(rm, chunk_cast<1>(chnk)); break;
+			case 2: req = apply_range_mapper<2>(rm, chunk_cast<2>(chnk)); break;
+			case 3: req = apply_range_mapper<3>(rm, chunk_cast<3>(chnk)); break;
 			default: assert(!"Unreachable");
 			}
 			result = GridRegion<3>::merge(result, subrange_to_grid_box(req));

--- a/src/transformers/naive_split.cc
+++ b/src/transformers/naive_split.cc
@@ -19,7 +19,7 @@ namespace detail {
 
 		std::vector<chunk<3>> result;
 		for(auto i = 0u; i < num_chunks; ++i) {
-			result.push_back(chnk);
+			result.push_back(chunk_cast<3>(chnk));
 			chnk.offset = chnk.offset + chnk.range;
 			if(i == num_chunks - 1) { result[i].range[0] += full_chunk.range.size() % num_chunks; }
 		}
@@ -34,8 +34,8 @@ namespace detail {
 		        num_chunks);
 		std::vector<chunk<3>> result;
 		for(auto& row : rows) {
-			result.push_back(
-			    chunk<2>{cl::sycl::id<2>(row.offset[0], full_chunk.offset[1]), cl::sycl::range<2>(row.range[0], full_chunk.range[1]), full_chunk.global_size});
+			result.push_back(chunk_cast<3>(
+			    chunk<2>{cl::sycl::id<2>(row.offset[0], full_chunk.offset[1]), cl::sycl::range<2>(row.range[0], full_chunk.range[1]), full_chunk.global_size}));
 		}
 		return result;
 	}
@@ -91,19 +91,19 @@ namespace detail {
 		std::vector<chunk<3>> chunks;
 		switch(tsk->get_dimensions()) {
 		case 1: {
-			chunks = split_equal(chunk<1>(full_chunk), num_chunks);
+			chunks = split_equal(chunk_cast<1>(full_chunk), num_chunks);
 		} break;
 		case 2: {
-			chunks = split_equal(chunk<2>(full_chunk), num_chunks);
+			chunks = split_equal(chunk_cast<2>(full_chunk), num_chunks);
 		} break;
 		case 3: {
-			chunks = split_equal(chunk<3>(full_chunk), num_chunks);
+			chunks = split_equal(full_chunk, num_chunks);
 		} break;
 		default: assert(false);
 		}
 
 		for(size_t i = 0; i < chunks.size(); ++i) {
-			cdag.create<task_command>(nodes[i], tsk->get_id(), chunks[i]);
+			cdag.create<task_command>(nodes[i], tsk->get_id(), subrange{chunks[i]});
 		}
 
 		// Remove original

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -160,15 +160,15 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(init_a_b)>(
 		        ctx.get_task_manager(),
 		        [&](handler& cgh) {
-			        buf_a.get_access<mode::discard_write>(cgh, one_to_one<1>());
-			        buf_b.get_access<mode::discard_write>(cgh, one_to_one<1>());
+			        buf_a.get_access<mode::discard_write>(cgh, one_to_one{});
+			        buf_b.get_access<mode::discard_write>(cgh, one_to_one{});
 		        },
 		        full_range));
 
 		// then read from buf_b to later induce anti-dependence
 		test_utils::build_and_flush(ctx, NUM_NODES,
 		    test_utils::add_compute_task<class UKN(read_b_before_first_horizon)>(
-		        ctx.get_task_manager(), [&](handler& cgh) { buf_b.get_access<mode::read>(cgh, one_to_one<1>()); }, full_range));
+		        ctx.get_task_manager(), [&](handler& cgh) { buf_b.get_access<mode::read>(cgh, one_to_one{}); }, full_range));
 
 		// here, the first horizon should have been generated
 
@@ -176,14 +176,14 @@ namespace detail {
 		for(int i = 0; i < 1; ++i) {
 			test_utils::build_and_flush(ctx, NUM_NODES,
 			    test_utils::add_compute_task<class UKN(buf_a_rw)>(
-			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read_write>(cgh, one_to_one<1>()); }, full_range));
+			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read_write>(cgh, one_to_one{}); }, full_range));
 		}
 
 		// now, do a write on buf_b which should generate an anti-dependency on the first horizon
 
 		auto write_b_after_first_horizon = test_utils::build_and_flush(ctx, NUM_NODES,
 		    test_utils::add_compute_task<class UKN(write_b_after_first_horizon)>(
-		        ctx.get_task_manager(), [&](handler& cgh) { buf_b.get_access<mode::discard_write>(cgh, one_to_one<1>()); }, full_range));
+		        ctx.get_task_manager(), [&](handler& cgh) { buf_b.get_access<mode::discard_write>(cgh, one_to_one{}); }, full_range));
 
 		// Now we need to check various graph properties
 
@@ -225,22 +225,22 @@ namespace detail {
 		// write to buf_a on all nodes
 		test_utils::build_and_flush(ctx, NUM_NODES,
 		    test_utils::add_compute_task<class UKN(init_a)>(
-		        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::discard_write>(cgh, one_to_one<1>()); }, full_range));
+		        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::discard_write>(cgh, one_to_one{}); }, full_range));
 
 		// perform another read-write step to ensure that horizons are generated as expected
 		test_utils::build_and_flush(ctx, NUM_NODES,
 		    test_utils::add_compute_task<class UKN(rw_a)>(
-		        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read_write>(cgh, one_to_one<1>()); }, full_range));
+		        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read_write>(cgh, one_to_one{}); }, full_range));
 
 		// now for the actual test, read only on node 0
-		test_utils::build_and_flush(ctx, NUM_NODES,
-		    test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) { buf_a.get_access<mode::read>(cgh, all<1>{}); }));
+		test_utils::build_and_flush(
+		    ctx, NUM_NODES, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) { buf_a.get_access<mode::read>(cgh, all{}); }));
 
 		// build some additional read/write steps so that we reach deletion
 		for(int i = 0; i < 2; ++i) {
 			test_utils::build_and_flush(ctx, NUM_NODES,
 			    test_utils::add_compute_task<class UKN(rw_a)>(
-			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read_write>(cgh, one_to_one<1>()); }, full_range));
+			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read_write>(cgh, one_to_one{}); }, full_range));
 		}
 
 		// check that all horizons were flushed

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -19,6 +19,15 @@
 #define _UKN_CONCAT(x, y) _UKN_CONCAT2(x, y)
 #define UKN(name) _UKN_CONCAT(name, __COUNTER__)
 
+#define CHECK_THROWS_IN_LIVE_PASS(cgh, ...)                                                                                                                    \
+	do {                                                                                                                                                       \
+		if(::celerity::detail::is_prepass_handler(cgh)) {                                                                                                      \
+			(void)(__VA_ARGS__);                                                                                                                               \
+		} else {                                                                                                                                               \
+			CHECK_THROWS(__VA_ARGS__);                                                                                                                         \
+		}                                                                                                                                                      \
+	} while(false)
+
 namespace celerity {
 namespace test_utils {
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -19,15 +19,6 @@
 #define _UKN_CONCAT(x, y) _UKN_CONCAT2(x, y)
 #define UKN(name) _UKN_CONCAT(name, __COUNTER__)
 
-#define CHECK_THROWS_IN_LIVE_PASS(cgh, ...)                                                                                                                    \
-	do {                                                                                                                                                       \
-		if(::celerity::detail::is_prepass_handler(cgh)) {                                                                                                      \
-			(void)(__VA_ARGS__);                                                                                                                               \
-		} else {                                                                                                                                               \
-			CHECK_THROWS(__VA_ARGS__);                                                                                                                         \
-		}                                                                                                                                                      \
-	} while(false)
-
 namespace celerity {
 namespace test_utils {
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -38,11 +38,9 @@ namespace test_utils {
 	  public:
 		template <cl::sycl::access::mode Mode, typename Functor>
 		void get_access(handler& cgh, Functor rmfn) {
-			using rmfn_traits = allscale::utils::lambda_traits<Functor>;
-			static_assert(rmfn_traits::result_type::dims == Dims, "The returned subrange doesn't match buffer dimensions.");
 			if(detail::is_prepass_handler(cgh)) {
 				auto& prepass_cgh = dynamic_cast<detail::prepass_handler&>(cgh);
-				prepass_cgh.add_requirement(id, std::make_unique<detail::range_mapper<rmfn_traits::arg1_type::dims, Dims>>(rmfn, Mode, size));
+				prepass_cgh.add_requirement(id, std::make_unique<detail::range_mapper<Dims, Functor>>(rmfn, Mode, size));
 			}
 		}
 


### PR DESCRIPTION
Previously, `subrange` and `chunk` were implicitly convertible between dimensions.
This allowed mismatches between kernel dimensionality and the chunk dimensionality accepted by range mappers to go unnoticed.
Casts are now explicit via `detail::subrange_cast` and `detail::chunk_cast`.
We attempt to report range mapper signature mismatches aside from dimensionality at compile time, and fail on dimensionality mismatch at runtime.