### PR TITLE
Revise accessor host_memory API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ if(CELERITY_BUILD_EXAMPLES)
 
   find_package(PkgConfig)
   if (PkgConfig_FOUND)
-	pkg_check_modules(HDF5 IMPORTED_TARGET hdf5-1.12.0)
+	pkg_search_module(HDF5 IMPORTED_TARGET hdf5-openmpi hdf5-1.12.0 hdf5)
 	if(HDF5_FOUND)
       add_subdirectory(examples/distr_io)
       set_property(TARGET distr_io PROPERTY FOLDER "examples")

--- a/docs/host-tasks.md
+++ b/docs/host-tasks.md
@@ -140,9 +140,9 @@ Collective host tasks are special in that they receive an implicit one-dimension
 the participating nodes. To access buffers in a meaningful way, these node indices must be translated to buffer regions.
 In the typical Celerity fashion, this is handled via range mappers.
 
-The `celerity::experimental::even_split` range mapper maps a one-dimensional range onto arbitrary-dimensional buffers
-by splitting them along the first (slowest) dimension into contiguous memory portions.
-`celerity::accessor::get_host_memory` can then be used to retrieve the host-local chunk of the buffer:
+The `celerity::experimental::even_split` range mapper maps a one-dimensional range onto arbitrary-dimensional buffers by
+splitting them along the first (slowest) dimension into contiguous memory portions.
+`celerity::accessor::get_allocation_window` can then be used to retrieve the host-local chunk of the buffer:
 
 ```cpp
 celerity::distr_queue q;
@@ -153,7 +153,7 @@ q.submit([=](celerity::handler& cgh) {
             celerity::experimental::access::even_split<2>());
     cgh.host_task(celerity::experimental::collective,
             [=](celerity::experimental::collective_partition part) {
-        auto [data, layout] = acc.get_host_memory(part);
+        auto aw = acc.get_allocation_window(part);
         // ...
     });
 });

--- a/include/handler.h
+++ b/include/handler.h
@@ -169,7 +169,7 @@ class handler {
 	 *
 	 * The kernel is executed in a background thread pool with multiple host tasks being run concurrently if they are independent in the task graph,
 	 * so proper synchronization must be ensured. The partition passed into the kernel describes the split each host receives. It may be used with accessors
-	 * to obtain the per-node portion of a buffer en-bloc, see `celerity::accessor::get_host_memory` for details.
+	 * to obtain the per-node portion of a buffer en-bloc, see `celerity::accessor::get_allocation_window` for details.
 	 *
 	 * There are no guarantees with respect to the split size and the order in which host tasks are re-orered between nodes other than
 	 * the restrictions imposed by dependencies in the task graph. Also, the kernel may be invoked multiple times on one node and not be scheduled on

--- a/include/range_mapper.h
+++ b/include/range_mapper.h
@@ -254,7 +254,7 @@ namespace experimental::access {
 	 *
 	 * This range mapper is unique in the sense that the chunk parameter (i.e. the iteration space) is unrelated to the buffer indices it maps to.
 	 * It is designed to distribute a buffer in contiguous portions between nodes for collective host tasks, allowing each node to output its portion in
-	 * I/O operations. See `accessor::get_host_memory` on how to access the resulting host memory.
+	 * I/O operations. See `accessor::get_allocation_window` on how to access the resulting host memory.
 	 */
 	template <int BufferDims>
 	class even_split {

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -1872,7 +1872,7 @@ namespace detail {
 		buffer<char, 1> buf1d(memory1d.data(), cl::sycl::range<1>(10));
 
 		q.submit([=](handler& cgh) {
-			auto b = buf1d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, all{});
+			accessor b{buf1d, cgh, all{}, cl::sycl::write_only_host_task, cl::sycl::no_init};
 			cgh.host_task(on_master_node, [=](partition<0> part) {
 				auto aw = b.get_allocation_window(part);
 				CHECK(aw.get_window_offset_in_buffer()[0] == 0);
@@ -1884,7 +1884,7 @@ namespace detail {
 		});
 
 		q.submit([=](handler& cgh) {
-			auto b = buf1d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one{});
+			accessor b{buf1d, cgh, one_to_one{}, cl::sycl::write_only_host_task, cl::sycl::no_init};
 			cgh.host_task(cl::sycl::range<1>(6), cl::sycl::id<1>(2), [=](partition<1> part) {
 				auto aw = b.get_allocation_window(part);
 				CHECK(aw.get_window_offset_in_buffer()[0] == 2);
@@ -1900,7 +1900,7 @@ namespace detail {
 		buffer<char, 2> buf2d(memory2d.data(), cl::sycl::range<2>(10, 10));
 
 		q.submit([=](handler& cgh) {
-			auto b = buf2d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one{});
+			accessor b{buf2d, cgh, one_to_one{}, cl::sycl::write_only_host_task, cl::sycl::no_init};
 			cgh.host_task(cl::sycl::range<2>(5, 6), cl::sycl::id<2>(1, 2), [=](partition<2> part) {
 				auto aw = b.get_allocation_window(part);
 				CHECK(aw.get_window_offset_in_buffer()[0] == 1);
@@ -1919,7 +1919,7 @@ namespace detail {
 		buffer<char, 3> buf3d(memory3d.data(), cl::sycl::range<3>(10, 10, 10));
 
 		q.submit([=](handler& cgh) {
-			auto b = buf3d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one{});
+			accessor b{buf3d, cgh, one_to_one{}, cl::sycl::write_only_host_task, cl::sycl::no_init};
 			cgh.host_task(cl::sycl::range<3>(5, 6, 7), cl::sycl::id<3>(1, 2, 3), [=](partition<3> part) {
 				auto aw = b.get_allocation_window(part);
 				CHECK(aw.get_window_offset_in_buffer()[0] == 1);

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -1872,7 +1872,7 @@ namespace detail {
 		buffer<char, 1> buf1d(memory1d.data(), cl::sycl::range<1>(10));
 
 		q.submit([=](handler& cgh) {
-			auto b = buf1d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, all<1>());
+			auto b = buf1d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, all{});
 			cgh.host_task(on_master_node, [=](partition<0> part) {
 				auto aw = b.get_allocation_window(part);
 				CHECK(aw.get_window_offset_in_buffer()[0] == 0);
@@ -1884,7 +1884,7 @@ namespace detail {
 		});
 
 		q.submit([=](handler& cgh) {
-			auto b = buf1d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one<1>());
+			auto b = buf1d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one{});
 			cgh.host_task(cl::sycl::range<1>(6), cl::sycl::id<1>(2), [=](partition<1> part) {
 				auto aw = b.get_allocation_window(part);
 				CHECK(aw.get_window_offset_in_buffer()[0] == 2);
@@ -1900,7 +1900,7 @@ namespace detail {
 		buffer<char, 2> buf2d(memory2d.data(), cl::sycl::range<2>(10, 10));
 
 		q.submit([=](handler& cgh) {
-			auto b = buf2d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one<2>());
+			auto b = buf2d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one{});
 			cgh.host_task(cl::sycl::range<2>(5, 6), cl::sycl::id<2>(1, 2), [=](partition<2> part) {
 				auto aw = b.get_allocation_window(part);
 				CHECK(aw.get_window_offset_in_buffer()[0] == 1);
@@ -1919,7 +1919,7 @@ namespace detail {
 		buffer<char, 3> buf3d(memory3d.data(), cl::sycl::range<3>(10, 10, 10));
 
 		q.submit([=](handler& cgh) {
-			auto b = buf3d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one<3>());
+			auto b = buf3d.get_access<cl::sycl::access::mode::discard_write, cl::sycl::access::target::host_buffer>(cgh, one_to_one{});
 			cgh.host_task(cl::sycl::range<3>(5, 6, 7), cl::sycl::id<3>(1, 2, 3), [=](partition<3> part) {
 				auto aw = b.get_allocation_window(part);
 				CHECK(aw.get_window_offset_in_buffer()[0] == 1);


### PR DESCRIPTION
The host-accessor API `get_host_memory` was designed to collapse adjacent dimensions where possible in order to allow efficient non-strided operations from the user side whenever the allocation happens to match the range accessed by the kernel in one or more dimensions. However, this collapsing was never implemented, and it is also not particularly useful in conjunction with APIs like HDF5 that allow expressing multidimensional subranges natively. Until now, the `distr_io` abused this knowledge about the implementation to set up its HDF5 hyperslabs.

This patch deprecates `host_memory_layout` and `accessor::get_host_memory` in favor of the new `buffer_allocation_window` and `accessor::get_allocation_window`. This new API delivers an explicitly-dimensioned description of allocation vs. kernel subranges while excluding any collapsing semantics. These should be added in a later PR once an actual use case arises.

**TODO**: Bikeshed names `buffer_allocation_window` and `accessor::get_allocation_window`.