### PR TITLE
Make run-integration-tests.sh more robust and readable

### DIFF
--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+set -o errexit -o pipefail -o nounset
+
 if [[ ! -d examples || ! -d CMakeFiles ]]; then
     echo "Warning: This script should be run from within a build directory" 1>&2
 fi
 
 if [[ $# -le 1 ]]; then
-    echo "Usage: $0 <convolution image file> <num nodes> [<num nodes>...]"
+    echo "Usage: $0 <convolution image file> <num nodes> [<num nodes>...]" 1>&2
     exit 1
 fi
 
@@ -20,7 +22,7 @@ EXAMPLES=(
 )
 PARAMS=(
     ""
-    $CONV_IMG
+    "$CONV_IMG"
     "-T 15 --dt 0.5 --sample-rate 2"
     ""
 )
@@ -34,22 +36,24 @@ ARTIFACTS=(
 expected_checksum=""
 for e in "${!EXAMPLES[@]}"; do
     EXE="${EXAMPLES[$e]}"
-    CMD="./examples/${EXE}/${EXE} ${PARAMS[$e]}"
+    # shellcheck disable=SC2206
+    CMD=("./examples/$EXE/$EXE" ${PARAMS[$e]})
     ARTIFACT="${ARTIFACTS[$e]}"
 
     for n in "${NUM_NODES[@]}"; do
-        echo -e "\n\n ---- Running \"$EXE\" on $n node(s) ----\n\n"
-        rm -rf ${ARTIFACT} # Delete artifact before each run to make sure it is actually created
-        mpirun -n ${n} ${CMD} || exit 1
-        if [ ! -z "${ARTIFACT}" ]; then
-            if [ "${n}" -eq "${NUM_NODES[0]}" ]; then
-                expected_checksum=$(md5sum ${ARTIFACT})
+        echo -e "\n\n ---- Running \"$EXE\" on $n node(s) ----\n\n" 1>&2
+        rm -rf "$ARTIFACT" # Delete artifact before each run to make sure it is actually created
+        mpirun -n "$n" "${CMD[@]}"
+        if [ -n "$ARTIFACT" ]; then
+            if [ "$n" -eq "${NUM_NODES[0]}" ]; then
+                expected_checksum=$(md5sum "$ARTIFACT")
             else
                 # We don't check whether tests with outputs produce the exact same result for every
                 # configuration (debug/release, hipSYCL/ComputeCpp, etc) because they don't. Instead
                 # we just check whether they produce the same result across runs with different nodes.
-                if [[ $(md5sum ${ARTIFACT}) != "${expected_checksum}" ]]; then
-                    echo "${EXE}: Wrong ARTIFACT checksum after running with ${n} nodes." && exit 1
+                if [[ $(md5sum "$ARTIFACT") != "$expected_checksum" ]]; then
+                    echo "$EXE: Wrong ARTIFACT checksum after running with $n nodes." 1>&2
+                    exit 1
                 fi
             fi
         fi


### PR DESCRIPTION
Previously a missing artifact would be silently ignored. By setting `-o errexit` the script now aborts if calculating the MD5 checksum
fails.

Properly quote variables where appropriate, and improve readability by removing unneeded curly braces.