### PR TITLE
Replace sycl::item with celerity::item in public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ queue.submit([=](celerity::handler& cgh) {
   );
   cgh.parallel_for<class MyKernel>(
     sycl::range<1>(1024),                       // 2
-    [=](sycl::item<1> item) {                   // 3
+    [=](celerity::item<1> item) {                   // 3
       acc[item] = sycl::sin(item[0] / 1024.f);  // 4
     });
 });

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -124,7 +124,7 @@ queue.submit([=](celerity::handler& cgh) {
     cgh.parallel_for<class MyEdgeDetectionKernel>(
         cl::sycl::range<2>(img_height - 2, img_width - 2),
         cl::sycl::id<2>(1, 1),
-        [=](cl::sycl::item<2> item) {
+        [=](celerity::item<2> item) {
             // TODO: Kernel code
         }
     );
@@ -162,7 +162,7 @@ main axes surrounding the current result pixel and computing the difference
 to the current pixel value. We then subtract the resulting value from the
 maximum value a `uint8_t` can store (255) in order to get a white image with
 black edges. The current pixel position is described by the
-`cl::sycl::item<2>` we receive as an argument to our kernel function. This
+`celerity::item<2>` we receive as an argument to our kernel function. This
 two-dimensional item corresponds to a `y/x` position in our input and output
 images and can be used to index into the respective buffers. However, we're
 not using the buffers directly; instead we are indexing into the

--- a/examples/convolution/convolution.cc
+++ b/examples/convolution/convolution.cc
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
 		auto gauss = gaussian_mat_buf.get_access<cl::sycl::access::mode::read>(cgh, celerity::access::all{});
 		auto out = image_tmp_buf.get_access<cl::sycl::access::mode::discard_write>(cgh, celerity::access::one_to_one{});
 
-		cgh.parallel_for<class gaussian_blur>(cl::sycl::range<2>(image_height, image_width), [=, fs = FILTER_SIZE](cl::sycl::item<2> item) {
+		cgh.parallel_for<class gaussian_blur>(cl::sycl::range<2>(image_height, image_width), [=, fs = FILTER_SIZE](celerity::item<2> item) {
 			using cl::sycl::float3;
 			if(is_on_boundary(cl::sycl::range<2>(image_height, image_width), fs, item)) {
 				out[item] = float3(0.f, 0.f, 0.f);
@@ -84,7 +84,7 @@ int main(int argc, char* argv[]) {
 	queue.submit([=](celerity::handler& cgh) {
 		auto in = image_tmp_buf.get_access<cl::sycl::access::mode::read>(cgh, celerity::access::neighborhood{1, 1});
 		auto out = image_output_buf.get_access<cl::sycl::access::mode::discard_write>(cgh, celerity::access::one_to_one{});
-		cgh.parallel_for<class sharpen>(cl::sycl::range<2>(image_height, image_width), [=, fs = FILTER_SIZE](cl::sycl::item<2> item) {
+		cgh.parallel_for<class sharpen>(cl::sycl::range<2>(image_height, image_width), [=, fs = FILTER_SIZE](celerity::item<2> item) {
 			using cl::sycl::float3;
 			if(is_on_boundary(cl::sycl::range<2>(image_height, image_width), fs, item)) {
 				out[item] = float3(0.f, 0.f, 0.f);

--- a/examples/distr_io/distr_io.cc
+++ b/examples/distr_io/distr_io.cc
@@ -121,7 +121,7 @@ int main(int argc, char* argv[]) {
 		q.submit([=](celerity::handler& cgh) {
 			auto a = in.get_access<cl::sycl::access::mode::read>(cgh, celerity::access::one_to_one{});
 			auto b = out.get_access<cl::sycl::access::mode::discard_write>(cgh, transposed);
-			cgh.parallel_for<class transpose>(cl::sycl::range<2>{N, N}, [=](cl::sycl::item<2> item) {
+			cgh.parallel_for<class transpose>(cl::sycl::range<2>{N, N}, [=](celerity::item<2> item) {
 				auto id = item.get_id();
 				b[{id[1], id[0]}] = a[id];
 			});

--- a/examples/matmul/matmul.cc
+++ b/examples/matmul/matmul.cc
@@ -8,7 +8,7 @@ template <typename T>
 void set_identity(celerity::distr_queue queue, celerity::buffer<T, 2> mat) {
 	queue.submit([=](celerity::handler& cgh) {
 		celerity::accessor dw{mat, cgh, celerity::access::one_to_one{}, celerity::write_only, celerity::no_init};
-		cgh.parallel_for<class set_identity_kernel>(mat.get_range(), [=](cl::sycl::item<2> item) { dw[item] = item[0] == item[1]; });
+		cgh.parallel_for<class set_identity_kernel>(mat.get_range(), [=](celerity::item<2> item) { dw[item] = item[0] == item[1]; });
 	});
 }
 
@@ -19,7 +19,7 @@ void multiply(celerity::distr_queue queue, celerity::buffer<T, 2> mat_a, celerit
 		celerity::accessor b{mat_b, cgh, celerity::access::slice<2>(0), celerity::read_only};
 		celerity::accessor c{mat_c, cgh, celerity::access::one_to_one{}, celerity::write_only, celerity::no_init};
 
-		cgh.parallel_for<class mat_mul>(cl::sycl::range<2>(MAT_SIZE, MAT_SIZE), [=](cl::sycl::item<2> item) {
+		cgh.parallel_for<class mat_mul>(cl::sycl::range<2>(MAT_SIZE, MAT_SIZE), [=](celerity::item<2> item) {
 			auto sum = 0.f;
 			for(size_t k = 0; k < MAT_SIZE; ++k) {
 				const auto a_ik = a[{item[0], k}];

--- a/examples/syncing/syncing.cc
+++ b/examples/syncing/syncing.cc
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
 
 	q.submit([=](handler& cgh) {
 		celerity::accessor b{buff, cgh, access::one_to_one{}, celerity::write_only, celerity::no_init};
-		cgh.parallel_for<class mat_mul>(cl::sycl::range<1>(N), [=](celerity::item<1> item) { b[item] = item[0]; });
+		cgh.parallel_for<class mat_mul>(cl::sycl::range<1>(N), [=](celerity::item<1> item) { b[item] = item.get_linear_id(); });
 	});
 
 	q.submit(celerity::allow_by_ref, [=, &host_buff](handler& cgh) {

--- a/examples/syncing/syncing.cc
+++ b/examples/syncing/syncing.cc
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
 
 	q.submit([=](handler& cgh) {
 		celerity::accessor b{buff, cgh, access::one_to_one{}, celerity::write_only, celerity::no_init};
-		cgh.parallel_for<class mat_mul>(cl::sycl::range<1>(N), [=](cl::sycl::item<1> item) { b[item] = item[0]; });
+		cgh.parallel_for<class mat_mul>(cl::sycl::range<1>(N), [=](celerity::item<1> item) { b[item] = item[0]; });
 	});
 
 	q.submit(celerity::allow_by_ref, [=, &host_buff](handler& cgh) {

--- a/examples/wave_sim/wave_sim.cc
+++ b/examples/wave_sim/wave_sim.cc
@@ -10,7 +10,7 @@
 void setup_wave(celerity::distr_queue& queue, celerity::buffer<float, 2> u, cl::sycl::float2 center, float amplitude, cl::sycl::float2 sigma) {
 	queue.submit([=](celerity::handler& cgh) {
 		celerity::accessor dw_u{u, cgh, celerity::access::one_to_one{}, celerity::write_only, celerity::no_init};
-		cgh.parallel_for<class setup_wave>(u.get_range(), [=, c = center, a = amplitude, s = sigma](cl::sycl::item<2> item) {
+		cgh.parallel_for<class setup_wave>(u.get_range(), [=, c = center, a = amplitude, s = sigma](celerity::item<2> item) {
 			const float dx = item[1] - c.x();
 			const float dy = item[0] - c.y();
 			dw_u[item] = a * cl::sycl::exp(-(dx * dx / (2.f * s.x() * s.x()) + dy * dy / (2.f * s.y() * s.y())));
@@ -21,7 +21,7 @@ void setup_wave(celerity::distr_queue& queue, celerity::buffer<float, 2> u, cl::
 void zero(celerity::distr_queue& queue, celerity::buffer<float, 2> buf) {
 	queue.submit([=](celerity::handler& cgh) {
 		celerity::accessor dw_buf{buf, cgh, celerity::access::one_to_one{}, celerity::write_only, celerity::no_init};
-		cgh.parallel_for<class zero>(buf.get_range(), [=](cl::sycl::item<2> item) { dw_buf[item] = 0.f; });
+		cgh.parallel_for<class zero>(buf.get_range(), [=](celerity::item<2> item) { dw_buf[item] = 0.f; });
 	});
 }
 
@@ -44,7 +44,7 @@ void step(celerity::distr_queue& queue, celerity::buffer<T, 2> up, celerity::buf
 		celerity::accessor r_u{u, cgh, celerity::access::neighborhood{1, 1}, celerity::read_only};
 
 		const auto size = up.get_range();
-		cgh.parallel_for<KernelName>(size, [=](cl::sycl::item<2> item) {
+		cgh.parallel_for<KernelName>(size, [=](celerity::item<2> item) {
 			const size_t py = item[0] < size[0] - 1 ? item[0] + 1 : item[0];
 			const size_t my = item[0] > 0 ? item[0] - 1 : item[0];
 			const size_t px = item[1] < size[1] - 1 ? item[1] + 1 : item[1];

--- a/include/buffer_storage.h
+++ b/include/buffer_storage.h
@@ -12,14 +12,6 @@
 namespace celerity {
 namespace detail {
 
-	inline size_t get_linear_index(const cl::sycl::range<1>& buffer_range, const cl::sycl::id<1>& index) { return index[0]; }
-
-	inline size_t get_linear_index(const cl::sycl::range<2>& buffer_range, const cl::sycl::id<2>& index) { return index[0] * buffer_range[1] + index[1]; }
-
-	inline size_t get_linear_index(const cl::sycl::range<3>& buffer_range, const cl::sycl::id<3>& index) {
-		return index[0] * buffer_range[1] * buffer_range[2] + index[1] * buffer_range[2] + index[2];
-	}
-
 	void memcpy_strided(const void* source_base_ptr, void* target_base_ptr, size_t elem_size, const cl::sycl::range<1>& source_range,
 	    const cl::sycl::id<1>& source_offset, const cl::sycl::range<1>& target_range, const cl::sycl::id<1>& target_offset,
 	    const cl::sycl::range<1>& copy_range);

--- a/include/item.h
+++ b/include/item.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "buffer_storage.h"
+#include "ranges.h"
 
 namespace celerity {
 

--- a/include/item.h
+++ b/include/item.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "buffer_storage.h"
+
+namespace celerity {
+
+template <int Dims>
+class item;
+
+namespace detail {
+
+	template <int Dims>
+	item<Dims> make_item(cl::sycl::id<Dims> global_id, cl::sycl::range<Dims> global_range) {
+		return item<Dims>{global_id, global_range};
+	}
+
+} // namespace detail
+
+// We replace sycl::item with celerity::item to correctly expose the cluster global size instead of the chunk size to the user.
+template <int Dims>
+class item {
+  public:
+	item() = delete;
+
+	cl::sycl::id<Dims> get_id() const { return id; }
+
+	size_t get_id(int dimension) const { return id[dimension]; }
+
+	operator cl::sycl::id<Dims>() const { return id; } // NOLINT(google-explicit-constructor)
+
+	size_t operator[](int dimension) const { return id[dimension]; }
+
+	cl::sycl::range<Dims> get_range() const { return range; }
+
+	size_t get_range(int dimension) const { return range[dimension]; }
+
+	size_t get_linear_id() const { return detail::get_linear_index(range, id); }
+
+  private:
+	template <int D>
+	friend item<D> celerity::detail::make_item(cl::sycl::id<D>, cl::sycl::range<D>);
+
+	cl::sycl::id<Dims> id;
+	cl::sycl::range<Dims> range;
+
+	explicit item(cl::sycl::id<Dims> id, cl::sycl::range<Dims> range) : id(id), range(range) {}
+};
+
+} // namespace celerity

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -7,6 +7,14 @@
 namespace celerity {
 namespace detail {
 
+	inline size_t get_linear_index(const cl::sycl::range<1>& range, const cl::sycl::id<1>& index) { return index[0]; }
+
+	inline size_t get_linear_index(const cl::sycl::range<2>& range, const cl::sycl::id<2>& index) { return index[0] * range[1] + index[1]; }
+
+	inline size_t get_linear_index(const cl::sycl::range<3>& range, const cl::sycl::id<3>& index) {
+		return index[0] * range[1] * range[2] + index[1] * range[2] + index[2];
+	}
+
 	template <int Dims, template <int> class Type>
 	auto make_range_type() {
 		if constexpr(Dims == 1) return Type<Dims>{0};


### PR DESCRIPTION
Re-using the SYCL item as we do currently has several issues:

- Kernel offsets are deprecated, so we will have to add a celerity item for transparently including per-chunk offsets at some point anyway. This will first become visible with reductions, where the SYCL spec does not mandate a `handler::parallel_for` overload accepting both an offset and reduction variables (and at least DPC++ does not implement such an overload).
- `item.get_range()` reports the range of the current chunk, not the cluster-global size as the user might expect
- `item.get_linear_id()` is broken in the presence of offsets in DPC++

This patch introduces a new `celerity::item` (an `id`/`range` pair internally) which will report the cluster-global size as its range. The change is backwards compatible and still allows kernels accepting a `cl::sycl::item<>` that will continue to work in the same fashion as it does now.