### PR TITLE
Make kernel names optional

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -13,7 +13,7 @@
 
 namespace celerity {
 
-template <typename DataT, int Dims>
+template <typename DataT, int Dims = 1>
 class buffer;
 
 namespace detail {


### PR DESCRIPTION
In SYCL 2020, explicit device kernel names are optional. This is implemented in hipSYCL and DPC++ so far. With this PR, Celerity will expose that feature for both of these backends.

For ComputeCpp, kernel names are still required, but Celerity will now wrap them to suppress the `-Rsycl-kernel-naming` diagnostic for locally-declared types such as `parallel_for<class kernel>`, since this diagnostic triggers on idiomatic Celerity code and cannot be disabled otherwise.