### PR TITLE
Replace cl::sycl::{id,range} with celerity::{id,range} alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Celerity without much hassle. If you know SYCL already, this will probably
 look very familiar to you:
 
 ```cpp
-celerity::buffer<float, 1> buf(sycl::range<1>(1024));
+celerity::buffer<float, 1> buf(celerity::range<1>(1024));
 queue.submit([=](celerity::handler& cgh) {
   auto acc = buf.get_access<sycl::access::mode::discard_write>(
     cgh,
     celerity::access::one_to_one()              // 1
   );
   cgh.parallel_for<class MyKernel>(
-    sycl::range<1>(1024),                       // 2
+    celerity::range<1>(1024),                   // 2
     [=](celerity::item<1> item) {               // 3
       acc[item] = sycl::sin(item[0] / 1024.f);  // 4
     });

--- a/docs/host-tasks.md
+++ b/docs/host-tasks.md
@@ -60,7 +60,7 @@ this node receives:
 ```cpp
 celerity::distr_queue q;
 q.submit([=](celerity::handler &cgh) {
-    cgh.host_task(cl::sycl::range<1>(100), [=](celerity::partition<1> part) {
+    cgh.host_task(celerity::range<1>(100), [=](celerity::partition<1> part) {
         printf("This node received %zu items\n", part.get_subrange().range[0]);
     });
 });

--- a/docs/reductions.md
+++ b/docs/reductions.md
@@ -14,7 +14,7 @@ celerity::distr_queue q;
 celerity::buffer<size_t, 1> sum_buf{{1}};
 q.submit([=](celerity::handler& cgh) {
     auto rd = celerity::reduction(sum_buf, cgh, cl::sycl::plus<size_t>{},
-                                  cl::sycl::property::reduction::initialize_to_identity{});
+                                  celerity::property::reduction::initialize_to_identity{});
     cgh.parallel_for(celerity::range<1>{1000}, rd,
                      [=](celerity::item<1> item, auto& sum) { sum += item.get_id(0); });
 });
@@ -31,7 +31,7 @@ these are known implicitly, for user-provided functors like lambdas, an explicit
 ```c++
 auto parity = [](unsigned a, unsigned b) { return (a ^ b) & 1u; };
 auto rd = celerity::reduction(buf, cgh, parity, 0u /* explicit identity */,
-                              cl::sycl::property::reduction::initialize_to_identity{});
+                              celerity::property::reduction::initialize_to_identity{});
 ```
 
 ## Limitations

--- a/docs/reductions.md
+++ b/docs/reductions.md
@@ -15,7 +15,7 @@ celerity::buffer<size_t, 1> sum_buf{{1}};
 q.submit([=](celerity::handler& cgh) {
     auto rd = celerity::reduction(sum_buf, cgh, cl::sycl::plus<size_t>{},
                                   cl::sycl::property::reduction::initialize_to_identity{});
-    cgh.parallel_for(cl::sycl::range<1>{1000}, rd,
+    cgh.parallel_for(celerity::range<1>{1000}, rd,
                      [=](celerity::item<1> item, auto& sum) { sum += item.get_id(0); });
 });
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -97,9 +97,9 @@ by the GPU. Let's create our two buffers and the distributed queue now:
 #include <celerity/celerity.h>
 ...
 uint8_t* img_data = stbi_load(argv[1], &img_width, &img_height, nullptr, 1);
-celerity::buffer<uint8_t, 2> input_buf(img_data, cl::sycl::range<2>(img_height, img_width));
+celerity::buffer<uint8_t, 2> input_buf(img_data, celerity::range<2>(img_height, img_width));
 stbi_image_free(img_data);
-celerity::buffer<uint8_t, 2> edge_buf(cl::sycl::range<2>(img_height, img_width));
+celerity::buffer<uint8_t, 2> edge_buf(celerity::range<2>(img_height, img_width));
 celerity::distr_queue queue;
 ...
 ```
@@ -122,8 +122,8 @@ are specified in Celerity is very similar to how it is done in SYCL:
 queue.submit([=](celerity::handler& cgh) {
     // TODO: Buffer accessors
     cgh.parallel_for<class MyEdgeDetectionKernel>(
-        cl::sycl::range<2>(img_height - 2, img_width - 2),
-        cl::sycl::id<2>(1, 1),
+        celerity::range<2>(img_height - 2, img_width - 2),
+        celerity::id<2>(1, 1),
         [=](celerity::item<2> item) {
             // TODO: Kernel code
         }

--- a/examples/distr_io/distr_io.cc
+++ b/examples/distr_io/distr_io.cc
@@ -106,13 +106,13 @@ int main(int argc, char* argv[]) {
 		auto gen = std::minstd_rand{seed};
 		auto dist = std::uniform_real_distribution{-1.0f, 1.0f};
 		std::generate(initial.begin(), initial.end(), [&] { return dist(gen); });
-		celerity::buffer<float, 2> out(initial.data(), cl::sycl::range<2>{N, N});
+		celerity::buffer<float, 2> out(initial.data(), celerity::range<2>{N, N});
 
 		celerity::distr_queue q;
 		write_hdf5_file(q, out, argv[2]);
 	} else if(argc == 4 && strcmp(argv[1], "--transpose") == 0) {
-		celerity::buffer<float, 2> in(cl::sycl::range<2>{N, N});
-		celerity::buffer<float, 2> out(cl::sycl::range<2>{N, N});
+		celerity::buffer<float, 2> in(celerity::range<2>{N, N});
+		celerity::buffer<float, 2> out(celerity::range<2>{N, N});
 
 		celerity::distr_queue q;
 
@@ -121,7 +121,7 @@ int main(int argc, char* argv[]) {
 		q.submit([=](celerity::handler& cgh) {
 			auto a = in.get_access<cl::sycl::access::mode::read>(cgh, celerity::access::one_to_one{});
 			auto b = out.get_access<cl::sycl::access::mode::discard_write>(cgh, transposed);
-			cgh.parallel_for<class transpose>(cl::sycl::range<2>{N, N}, [=](celerity::item<2> item) {
+			cgh.parallel_for<class transpose>(celerity::range<2>{N, N}, [=](celerity::item<2> item) {
 				auto id = item.get_id();
 				b[{id[1], id[0]}] = a[id];
 			});
@@ -133,8 +133,8 @@ int main(int argc, char* argv[]) {
 		{
 			celerity::distr_queue q;
 
-			celerity::buffer<float, 2> left(cl::sycl::range<2>{N, N});
-			celerity::buffer<float, 2> right(cl::sycl::range<2>{N, N});
+			celerity::buffer<float, 2> left(celerity::range<2>{N, N});
+			celerity::buffer<float, 2> right(celerity::range<2>{N, N});
 
 			read_hdf5_file(q, left, argv[2]);
 			read_hdf5_file(q, right, argv[3]);

--- a/examples/matmul/matmul.cc
+++ b/examples/matmul/matmul.cc
@@ -46,7 +46,7 @@ void multiply(celerity::distr_queue queue, celerity::buffer<T, 2> mat_a, celerit
 
 #else
 
-		cgh.parallel_for<class mat_mul>(cl::sycl::range<2>(MAT_SIZE, MAT_SIZE), [=](celerity::item<2> item) {
+		cgh.parallel_for<class mat_mul>(celerity::range<2>(MAT_SIZE, MAT_SIZE), [=](celerity::item<2> item) {
 			T sum{};
 			for(size_t k = 0; k < MAT_SIZE; ++k) {
 				const auto a_ik = a[{item[0], k}];
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
 	{
 		celerity::distr_queue queue;
 
-		auto range = cl::sycl::range<2>(MAT_SIZE, MAT_SIZE);
+		auto range = celerity::range<2>(MAT_SIZE, MAT_SIZE);
 		celerity::buffer<float, 2> mat_a_buf(range);
 		celerity::buffer<float, 2> mat_b_buf(range);
 		celerity::buffer<float, 2> mat_c_buf(range);

--- a/examples/reduction/reduction.cc
+++ b/examples/reduction/reduction.cc
@@ -72,7 +72,7 @@ int main(int argc, char* argv[]) {
 	q.submit([=](celerity::handler& cgh) {
 		celerity::accessor srgb_255_acc{srgb_255_buf, cgh, celerity::access::one_to_one{}, celerity::read_only};
 		celerity::accessor rgb_acc{lab_buf, cgh, celerity::access::one_to_one{}, celerity::write_only, celerity::no_init};
-		auto minmax_r = celerity::reduction(minmax_buf, cgh, minmax_identity, minmax, cl::sycl::property::reduction::initialize_to_identity{});
+		auto minmax_r = celerity::reduction(minmax_buf, cgh, minmax_identity, minmax, celerity::property::reduction::initialize_to_identity{});
 		cgh.parallel_for<class linearize_and_accumulate>(image_size, minmax_r, [=](celerity::item<2> item, auto& minmax) {
 			const auto rgb = srgb_to_rgb(srgb_255_acc[item].convert<float>() / 255.0f);
 			rgb_acc[item] = rgb;

--- a/examples/reduction/reduction.cc
+++ b/examples/reduction/reduction.cc
@@ -64,10 +64,10 @@ int main(int argc, char* argv[]) {
 
 	celerity::distr_queue q;
 
-	cl::sycl::range<2> image_size{static_cast<size_t>(image_height), static_cast<size_t>(image_width)};
+	celerity::range<2> image_size{static_cast<size_t>(image_height), static_cast<size_t>(image_width)};
 	celerity::buffer<cl::sycl::uchar4, 2> srgb_255_buf{reinterpret_cast<const cl::sycl::uchar4*>(srgb_255_data.get()), image_size};
 	celerity::buffer<cl::sycl::float4, 2> lab_buf{image_size};
-	celerity::buffer<cl::sycl::float2, 1> minmax_buf{cl::sycl::range{1}};
+	celerity::buffer<cl::sycl::float2, 1> minmax_buf{celerity::range{1}};
 
 	q.submit([=](celerity::handler& cgh) {
 		celerity::accessor srgb_255_acc{srgb_255_buf, cgh, celerity::access::one_to_one{}, celerity::read_only};

--- a/examples/syncing/syncing.cc
+++ b/examples/syncing/syncing.cc
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
 
 	q.submit([=](handler& cgh) {
 		celerity::accessor b{buff, cgh, access::one_to_one{}, celerity::write_only, celerity::no_init};
-		cgh.parallel_for<class mat_mul>(cl::sycl::range<1>(N), [=](celerity::item<1> item) { b[item] = item.get_linear_id(); });
+		cgh.parallel_for<class mat_mul>(celerity::range<1>(N), [=](celerity::item<1> item) { b[item] = item.get_linear_id(); });
 	});
 
 	q.submit(celerity::allow_by_ref, [=, &host_buff](handler& cgh) {

--- a/examples/wave_sim/wave_sim.cc
+++ b/examples/wave_sim/wave_sim.cc
@@ -149,8 +149,8 @@ int main(int argc, char* argv[]) {
 	{
 		celerity::distr_queue queue;
 
-		celerity::buffer<float, 2> up(nullptr, cl::sycl::range<2>(cfg.N, cfg.N)); // next
-		celerity::buffer<float, 2> u(nullptr, cl::sycl::range<2>(cfg.N, cfg.N));  // current
+		celerity::buffer<float, 2> up(nullptr, celerity::range<2>(cfg.N, cfg.N)); // next
+		celerity::buffer<float, 2> u(nullptr, celerity::range<2>(cfg.N, cfg.N));  // current
 
 		MPI_Barrier(MPI_COMM_WORLD);
 		celerity::experimental::bench::begin("main program");

--- a/include/accessor.h
+++ b/include/accessor.h
@@ -202,7 +202,7 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 	accessor(const buffer<DataT, Dims>& buff, handler& cgh, Functor rmfn, TagT tag, property::no_init no_init) : accessor(buff, cgh, rmfn) {}
 
 	template <typename Functor, typename TagT>
-	accessor(const buffer<DataT, Dims>& buff, handler& cgh, Functor rmfn, TagT tag, cl::sycl::property_list prop_list) {
+	accessor(const buffer<DataT, Dims>& buff, handler& cgh, Functor rmfn, TagT tag, property_list prop_list) {
 		// in this static assert it would be more relevant to use property_list type, but if a defined type is used then it is always false and
 		// always fails to compile. Hence we use a templated type so that it only produces a compile error when the ctr is called.
 		static_assert(detail::constexpr_false<TagT>,
@@ -364,7 +364,7 @@ accessor(const buffer<T, D>& buff, handler& cgh, Functor rmfn, TagT tag, propert
     -> accessor<T, D, detail::deduce_access_mode_discard<TagT>(), detail::deduce_access_target<std::remove_const_t<TagT>>()>;
 
 template <typename T, int D, typename Functor, typename TagT>
-accessor(const buffer<T, D>& buff, handler& cgh, Functor rmfn, TagT tag, cl::sycl::property_list prop_list)
+accessor(const buffer<T, D>& buff, handler& cgh, Functor rmfn, TagT tag, property_list prop_list)
     -> accessor<T, D, detail::deduce_access_mode_discard<TagT>(), detail::deduce_access_target<std::remove_const_t<TagT>>()>;
 
 //
@@ -413,7 +413,7 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 	accessor(const buffer<DataT, Dims>& buff, handler& cgh, Functor rmfn, TagT tag, property::no_init no_init) : accessor(buff, cgh, rmfn) {}
 
 	template <typename Functor, typename TagT>
-	accessor(const buffer<DataT, Dims>& buff, handler& cgh, Functor rmfn, TagT tag, cl::sycl::property_list prop_list) {
+	accessor(const buffer<DataT, Dims>& buff, handler& cgh, Functor rmfn, TagT tag, property_list prop_list) {
 		static_assert(detail::constexpr_false<TagT>,
 		    "Currently it is not accepted to pass a property list to an accessor constructor. Please use the property celerity::no_init "
 		    "as a last argument in the constructor");

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -21,7 +21,7 @@ namespace detail {
 	struct buffer_lifetime_tracker {
 		buffer_lifetime_tracker() = default;
 		template <typename DataT, int Dims>
-		buffer_id initialize(cl::sycl::range<3> range, const DataT* host_init_ptr) {
+		buffer_id initialize(celerity::range<3> range, const DataT* host_init_ptr) {
 			id = runtime::get_instance().get_buffer_manager().register_buffer<DataT, Dims>(range, host_init_ptr);
 			return id;
 		}
@@ -44,14 +44,14 @@ class buffer {
   public:
 	static_assert(Dims > 0, "0-dimensional buffers NYI");
 
-	buffer(const DataT* host_ptr, cl::sycl::range<Dims> range) : range(range) {
+	buffer(const DataT* host_ptr, celerity::range<Dims> range) : range(range) {
 		if(!detail::runtime::is_initialized()) { detail::runtime::init(nullptr, nullptr); }
 
 		lifetime_tracker = std::make_shared<detail::buffer_lifetime_tracker>();
 		id = lifetime_tracker->initialize<DataT, Dims>(detail::range_cast<3>(range), host_ptr);
 	}
 
-	buffer(cl::sycl::range<Dims> range) : buffer(nullptr, range) {}
+	buffer(celerity::range<Dims> range) : buffer(nullptr, range) {}
 
 	buffer(const buffer&) = default;
 	buffer(buffer&&) = default;
@@ -72,11 +72,11 @@ class buffer {
 		return accessor<DataT, Dims, Mode, Target>(*this, cgh, rmfn);
 	}
 
-	cl::sycl::range<Dims> get_range() const { return range; }
+	celerity::range<Dims> get_range() const { return range; }
 
   private:
 	std::shared_ptr<detail::buffer_lifetime_tracker> lifetime_tracker = nullptr;
-	cl::sycl::range<Dims> range;
+	celerity::range<Dims> range;
 	detail::buffer_id id;
 
 	template <typename T, int D>

--- a/include/handler.h
+++ b/include/handler.h
@@ -552,7 +552,7 @@ namespace detail {
 		}
 
 		auto bid = detail::get_buffer_id(vars);
-		auto include_current_buffer_value = !prop_list.has_property<cl::sycl::property::reduction::initialize_to_identity>();
+		auto include_current_buffer_value = !prop_list.has_property<celerity::property::reduction::initialize_to_identity>();
 		cl::sycl::buffer<DataT, Dims>* sycl_buffer = nullptr;
 
 		if(detail::is_prepass_handler(cgh)) {

--- a/include/host_queue.h
+++ b/include/host_queue.h
@@ -26,28 +26,28 @@ namespace detail {
 	template <int Dims>
 	class sized_partition_base {
 	  public:
-		explicit sized_partition_base(const cl::sycl::range<Dims>& global_size, const subrange<Dims>& range)
+		explicit sized_partition_base(const celerity::range<Dims>& global_size, const subrange<Dims>& range)
 		    : global_size(range_cast<Dims>(global_size)), range(range) {}
 
 		/** The subrange handled by this host. */
 		const subrange<Dims>& get_subrange() const { return range; }
 
 		/** The size of the entire iteration space */
-		const cl::sycl::range<Dims>& get_global_size() const { return global_size; }
+		const celerity::range<Dims>& get_global_size() const { return global_size; }
 
 	  private:
-		cl::sycl::range<Dims> global_size;
+		celerity::range<Dims> global_size;
 		subrange<Dims> range;
 	};
 
 	template <int Dims>
-	partition<Dims> make_partition(const cl::sycl::range<Dims>& global_size, const subrange<Dims>& range) {
+	partition<Dims> make_partition(const celerity::range<Dims>& global_size, const subrange<Dims>& range) {
 		return partition<Dims>(global_size, range);
 	}
 
 	partition<0> make_0d_partition();
 
-	experimental::collective_partition make_collective_partition(const cl::sycl::range<1>& global_size, const subrange<1>& range, MPI_Comm comm);
+	experimental::collective_partition make_collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm);
 
 } // namespace detail
 
@@ -57,9 +57,9 @@ namespace detail {
 template <int Dims>
 class partition : public detail::sized_partition_base<Dims> {
   protected:
-	friend partition<Dims> detail::make_partition<Dims>(const cl::sycl::range<Dims>& global_size, const subrange<Dims>& range);
+	friend partition<Dims> detail::make_partition<Dims>(const celerity::range<Dims>& global_size, const subrange<Dims>& range);
 
-	partition(const cl::sycl::range<Dims>& global_size, const subrange<Dims>& range) : detail::sized_partition_base<Dims>(global_size, range) {}
+	partition(const celerity::range<Dims>& global_size, const subrange<Dims>& range) : detail::sized_partition_base<Dims>(global_size, range) {}
 };
 
 /**
@@ -74,11 +74,11 @@ class experimental::collective_partition : public partition<1> {
 	size_t get_num_nodes() const { return get_global_size()[0]; }
 
   protected:
-	friend collective_partition detail::make_collective_partition(const cl::sycl::range<1>& global_size, const subrange<1>& range, MPI_Comm comm);
+	friend collective_partition detail::make_collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm);
 
 	MPI_Comm comm;
 
-	collective_partition(const cl::sycl::range<1>& global_size, const subrange<1>& range, MPI_Comm comm) : partition<1>(global_size, range), comm(comm) {}
+	collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm) : partition<1>(global_size, range), comm(comm) {}
 };
 
 template <>
@@ -92,7 +92,7 @@ class partition<0> {
 
 namespace detail {
 
-	inline experimental::collective_partition make_collective_partition(const cl::sycl::range<1>& global_size, const subrange<1>& range, MPI_Comm comm) {
+	inline experimental::collective_partition make_collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm) {
 		return experimental::collective_partition(global_size, range, comm);
 	}
 

--- a/include/item.h
+++ b/include/item.h
@@ -14,18 +14,18 @@ class nd_item;
 namespace detail {
 
 	template <int Dims>
-	inline item<Dims> make_item(cl::sycl::id<Dims> absolute_global_id, cl::sycl::id<Dims> global_offset, cl::sycl::range<Dims> global_range) {
+	inline item<Dims> make_item(id<Dims> absolute_global_id, id<Dims> global_offset, range<Dims> global_range) {
 		return item<Dims>{absolute_global_id, global_offset, global_range};
 	}
 
 	template <int Dims>
-	inline group<Dims> make_group(const cl::sycl::nd_item<Dims>& sycl_item, const cl::sycl::id<Dims>& group_id, const cl::sycl::range<Dims>& group_range) {
+	inline group<Dims> make_group(const cl::sycl::nd_item<Dims>& sycl_item, const id<Dims>& group_id, const range<Dims>& group_range) {
 		return group<Dims>{sycl_item, group_id, group_range};
 	}
 
 	template <int Dims>
-	nd_item<Dims> make_nd_item(const cl::sycl::nd_item<Dims>& sycl_item, const cl::sycl::range<Dims>& global_range, const cl::sycl::id<Dims>& global_offset,
-	    const cl::sycl::id<Dims>& chunk_offset, const cl::sycl::range<Dims>& group_range, const cl::sycl::id<Dims>& group_offset) {
+	nd_item<Dims> make_nd_item(const cl::sycl::nd_item<Dims>& sycl_item, const range<Dims>& global_range, const id<Dims>& global_offset,
+	    const id<Dims>& chunk_offset, const range<Dims>& group_range, const id<Dims>& group_offset) {
 		return nd_item<Dims>{sycl_item, global_range, global_offset, chunk_offset, group_range, group_offset};
 	}
 
@@ -40,7 +40,7 @@ namespace detail {
 	struct sycl_group_has_get_group_id<Group, std::void_t<decltype(std::declval<Group>().get_group_id())>> : public std::true_type {};
 
 	template <int Dims>
-	cl::sycl::id<Dims> get_sycl_group_id(const cl::sycl::group<Dims>& grp) {
+	id<Dims> get_sycl_group_id(const cl::sycl::group<Dims>& grp) {
 		if constexpr(sycl_group_has_get_group_id<cl::sycl::group<Dims>>::value) {
 			return grp.get_group_id();
 		} else {
@@ -83,31 +83,31 @@ class item {
 
 	friend bool operator!=(const item& lhs, const item& rhs) { return !(lhs == rhs); }
 
-	cl::sycl::id<Dims> get_id() const { return absolute_global_id; }
+	id<Dims> get_id() const { return absolute_global_id; }
 
 	size_t get_id(int dimension) const { return absolute_global_id[dimension]; }
 
-	operator cl::sycl::id<Dims>() const { return absolute_global_id; } // NOLINT(google-explicit-constructor)
+	operator id<Dims>() const { return absolute_global_id; } // NOLINT(google-explicit-constructor)
 
 	size_t operator[](int dimension) const { return absolute_global_id[dimension]; }
 
-	cl::sycl::range<Dims> get_range() const { return global_range; }
+	range<Dims> get_range() const { return global_range; }
 
 	size_t get_range(int dimension) const { return global_range[dimension]; }
 
 	size_t get_linear_id() const { return detail::get_linear_index(global_range, absolute_global_id - global_offset); }
 
-	cl::sycl::id<Dims> get_offset() const { return global_offset; }
+	id<Dims> get_offset() const { return global_offset; }
 
   private:
 	template <int D>
-	friend item<D> celerity::detail::make_item(cl::sycl::id<D>, cl::sycl::id<D>, cl::sycl::range<D>);
+	friend item<D> celerity::detail::make_item(id<D>, id<D>, range<D>);
 
-	cl::sycl::id<Dims> absolute_global_id;
-	cl::sycl::id<Dims> global_offset;
-	cl::sycl::range<Dims> global_range;
+	id<Dims> absolute_global_id;
+	id<Dims> global_offset;
+	range<Dims> global_range;
 
-	explicit item(cl::sycl::id<Dims> absolute_global_id, cl::sycl::id<Dims> global_offset, cl::sycl::range<Dims> global_range)
+	explicit item(id<Dims> absolute_global_id, id<Dims> global_offset, range<Dims> global_range)
 	    : absolute_global_id(absolute_global_id), global_offset(global_offset), global_range(global_range) {}
 };
 
@@ -115,29 +115,29 @@ class item {
 template <int Dims = 1>
 class group {
   public:
-	using id_type = cl::sycl::id<Dims>;
-	using range_type = cl::sycl::range<Dims>;
+	using id_type = id<Dims>;
+	using range_type = range<Dims>;
 	using linear_id_type = size_t;
 	static constexpr int dimensions = Dims;
 	static constexpr memory_scope fence_scope = memory_scope_work_group;
 
-	cl::sycl::id<Dims> get_group_id() const { return group_id; }
+	id<Dims> get_group_id() const { return group_id; }
 
 	size_t get_group_id(int dimension) const { return group_id[dimension]; }
 
-	cl::sycl::id<Dims> get_local_id() const { return sycl_item.get_local_id(); }
+	id<Dims> get_local_id() const { return sycl_item.get_local_id(); }
 
 	size_t get_local_id(int dimension) const { return sycl_item.get_local_id(dimension); }
 
-	cl::sycl::range<Dims> get_local_range() const { return sycl_item.get_local_range(); }
+	range<Dims> get_local_range() const { return sycl_item.get_local_range(); }
 
 	size_t get_local_range(int dimension) const { return sycl_item.get_local_range(dimension); }
 
-	cl::sycl::range<Dims> get_group_range() const { return group_range; }
+	range<Dims> get_group_range() const { return group_range; }
 
 	size_t get_group_range(int dimension) const { return group_range[dimension]; }
 
-	cl::sycl::range<Dims> get_max_local_range() const { return sycl_item.get_max_local_range(); }
+	range<Dims> get_max_local_range() const { return sycl_item.get_max_local_range(); }
 
 	size_t operator[](int dimension) const { return group_id[dimension]; }
 
@@ -149,7 +149,7 @@ class group {
 
 	size_t get_local_linear_range() const { return sycl_item.get_local_range().size(); }
 
-	bool leader() const { return sycl_item.get_local_id() == cl::sycl::id<Dims>{}; }
+	bool leader() const { return sycl_item.get_local_id() == id<Dims>{}; }
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_local_ptr<T> dest, decorated_global_ptr<T> src, size_t num_elements) const {
@@ -180,11 +180,11 @@ class group {
 	// We capture SYCL `item` instead of `group` to provide celerity::group_barrier based on SYCL 1.2.1 nd_item.barrier()
 	// TODO consider capturing `group` once ComputeCpp resolves this issue (if that benefits us e.g. wrt. struct size)
 	cl::sycl::nd_item<Dims> sycl_item;
-	cl::sycl::id<Dims> group_id;
-	cl::sycl::range<Dims> group_range;
+	id<Dims> group_id;
+	range<Dims> group_range;
 
 	template <int D>
-	friend group<D> celerity::detail::make_group(const cl::sycl::nd_item<D>& sycl_item, const cl::sycl::id<D>& group_id, const cl::sycl::range<D>& group_range);
+	friend group<D> celerity::detail::make_group(const cl::sycl::nd_item<D>& sycl_item, const id<D>& group_id, const range<D>& group_range);
 
 	template <int D>
 	friend cl::sycl::nd_item<D>& celerity::detail::get_sycl_item(group<D>&);
@@ -192,7 +192,7 @@ class group {
 	template <int D>
 	friend const cl::sycl::nd_item<D>& celerity::detail::get_sycl_item(const group<D>&);
 
-	explicit group(const cl::sycl::nd_item<Dims>& sycl_item, const cl::sycl::id<Dims>& group_id, const cl::sycl::range<Dims>& group_range)
+	explicit group(const cl::sycl::nd_item<Dims>& sycl_item, const id<Dims>& group_id, const range<Dims>& group_range)
 	    : sycl_item(sycl_item), group_id(group_id), group_range(group_range) {}
 };
 
@@ -203,13 +203,13 @@ class nd_item {
   public:
 	nd_item() = delete;
 
-	cl::sycl::id<Dims> get_global_id() const { return global_id; }
+	id<Dims> get_global_id() const { return global_id; }
 
 	size_t get_global_id(int dimension) const { return global_id[dimension]; }
 
 	size_t get_global_linear_id() const { return detail::get_linear_index(global_range, global_id); }
 
-	cl::sycl::id<Dims> get_local_id() const { return sycl_item.get_local_id(); }
+	id<Dims> get_local_id() const { return sycl_item.get_local_id(); }
 
 	size_t get_local_id(int dimension) const { return sycl_item.get_local_id(dimension); }
 
@@ -221,7 +221,7 @@ class nd_item {
 
 	size_t get_group_linear_id() const { return detail::get_linear_index(group_range, group_id); }
 
-	cl::sycl::range<Dims> get_group_range() const { return group_range; }
+	range<Dims> get_group_range() const { return group_range; }
 
 	size_t get_group_range(int dimension) const { return group_range[dimension]; }
 
@@ -229,15 +229,15 @@ class nd_item {
 	cl::sycl::sub_group get_sub_group() const { return sycl_item.get_sub_group(); }
 #endif
 
-	cl::sycl::range<Dims> get_global_range() const { return global_range; }
+	range<Dims> get_global_range() const { return global_range; }
 
 	size_t get_global_range(int dimension) const { return global_range[dimension]; }
 
-	cl::sycl::range<Dims> get_local_range() const { return sycl_item.get_local_range(); }
+	range<Dims> get_local_range() const { return sycl_item.get_local_range(); }
 
 	size_t get_local_range(int dimension) const { return sycl_item.get_local_range(dimension); }
 
-	cl::sycl::id<Dims> get_offset() const { return global_offset; }
+	id<Dims> get_offset() const { return global_offset; }
 
 	celerity::nd_range<Dims> get_nd_range() const { return celerity::nd_range<Dims>{global_range, sycl_item.get_local_range(), global_offset}; }
 
@@ -268,15 +268,14 @@ class nd_item {
 
   private:
 	cl::sycl::nd_item<Dims> sycl_item;
-	cl::sycl::id<Dims> global_id;
-	cl::sycl::id<Dims> global_offset;
-	cl::sycl::range<Dims> global_range;
-	cl::sycl::id<Dims> group_id;
-	cl::sycl::range<Dims> group_range;
+	id<Dims> global_id;
+	id<Dims> global_offset;
+	range<Dims> global_range;
+	id<Dims> group_id;
+	range<Dims> group_range;
 
 	template <int D>
-	friend nd_item<D> celerity::detail::make_nd_item(const cl::sycl::nd_item<D>&, const cl::sycl::range<D>&, const cl::sycl::id<D>&, const cl::sycl::id<D>&,
-	    const cl::sycl::range<D>&, const cl::sycl::id<D>&);
+	friend nd_item<D> celerity::detail::make_nd_item(const cl::sycl::nd_item<D>&, const range<D>&, const id<D>&, const id<D>&, const range<D>&, const id<D>&);
 
 	template <int D>
 	friend cl::sycl::nd_item<D>& celerity::detail::get_sycl_item(group<D>& nd_item);
@@ -284,8 +283,8 @@ class nd_item {
 	template <int D>
 	friend const cl::sycl::nd_item<D>& celerity::detail::get_sycl_item(const group<D>& nd_item);
 
-	explicit nd_item(const cl::sycl::nd_item<Dims>& sycl_item, const cl::sycl::range<Dims>& global_range, const cl::sycl::id<Dims>& global_offset,
-	    const cl::sycl::id<Dims>& chunk_offset, const cl::sycl::range<Dims>& group_range, const cl::sycl::id<Dims>& group_offset)
+	explicit nd_item(const cl::sycl::nd_item<Dims>& sycl_item, const range<Dims>& global_range, const id<Dims>& global_offset, const id<Dims>& chunk_offset,
+	    const range<Dims>& group_range, const id<Dims>& group_offset)
 	    : sycl_item(sycl_item), global_id(chunk_offset + sycl_item.get_global_id()), global_offset(global_offset), global_range(global_range),
 	      group_id(group_offset + detail::get_sycl_group_id(sycl_item.get_group())), group_range(group_range) {}
 };
@@ -321,7 +320,7 @@ inline T group_broadcast(const group<Dims>& g, T x, size_t local_linear_id) {
 }
 
 template <int Dims, typename T>
-inline T group_broadcast(const group<Dims>& g, T x, const cl::sycl::id<Dims>& local_id) {
+inline T group_broadcast(const group<Dims>& g, T x, const id<Dims>& local_id) {
 	return cl::sycl::group_broadcast(detail::get_sycl_item(g).get_group(), x, local_id);
 };
 

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <CL/sycl.hpp>
-
-#include "workaround.h"
+#include "sycl_wrappers.h"
 
 namespace celerity {
 namespace detail {
@@ -69,13 +67,13 @@ struct chunk {
 
 	static constexpr int dims = Dims;
 
-	cl::sycl::id<Dims> offset;
-	cl::sycl::range<Dims> range = detail::range_cast<Dims>(cl::sycl::range<3>(0, 0, 0));
-	cl::sycl::range<Dims> global_size = detail::range_cast<Dims>(cl::sycl::range<3>(0, 0, 0));
+	celerity::id<Dims> offset;
+	celerity::range<Dims> range = detail::range_cast<Dims>(celerity::range<3>(0, 0, 0));
+	celerity::range<Dims> global_size = detail::range_cast<Dims>(celerity::range<3>(0, 0, 0));
 
 	chunk() = default;
 
-	chunk(cl::sycl::id<Dims> offset, cl::sycl::range<Dims> range, cl::sycl::range<Dims> global_size) : offset(offset), range(range), global_size(global_size) {}
+	chunk(celerity::id<Dims> offset, celerity::range<Dims> range, celerity::range<Dims> global_size) : offset(offset), range(range), global_size(global_size) {}
 
 	friend bool operator==(const chunk& lhs, const chunk& rhs) {
 		return lhs.offset == rhs.offset && lhs.range == rhs.range && lhs.global_size == rhs.global_size;
@@ -89,8 +87,8 @@ struct subrange {
 
 	static constexpr int dims = Dims;
 
-	cl::sycl::id<Dims> offset;
-	cl::sycl::range<Dims> range = detail::range_cast<Dims>(cl::sycl::range<3>(0, 0, 0));
+	celerity::id<Dims> offset;
+	celerity::range<Dims> range = detail::range_cast<Dims>(celerity::range<3>(0, 0, 0));
 
 	subrange() = default;
 
@@ -108,7 +106,7 @@ struct subrange {
 	}
 #endif
 
-	subrange(cl::sycl::id<Dims> offset, cl::sycl::range<Dims> range) : offset(offset), range(range) {}
+	subrange(celerity::id<Dims> offset, celerity::range<Dims> range) : offset(offset), range(range) {}
 
 	subrange(chunk<Dims> other) : offset(other.offset), range(other.range) {}
 

--- a/include/reduction_manager.h
+++ b/include/reduction_manager.h
@@ -6,7 +6,6 @@
 
 #include <vector>
 
-
 namespace celerity {
 namespace detail {
 
@@ -93,5 +92,6 @@ namespace detail {
 		reduction_id next_rid = 1;
 		std::unordered_map<reduction_id, std::unique_ptr<abstract_buffer_reduction>> reductions;
 	};
+
 } // namespace detail
 } // namespace celerity

--- a/include/sycl_wrappers.h
+++ b/include/sycl_wrappers.h
@@ -35,13 +35,21 @@ inline constexpr detail::read_only_host_task_tag_t read_only_host_task;
 inline constexpr detail::read_write_host_task_tag_t read_write_host_task;
 inline constexpr detail::write_only_host_task_tag_t write_only_host_task;
 
+using cl::sycl::property_list;
+
 namespace property {
 #if WORKAROUND_COMPUTECPP
 	struct no_init : cl::sycl::detail::property_base {
 		no_init() : cl::sycl::detail::property_base(static_cast<cl::sycl::detail::property_enum>(0)) {}
 	};
 #else
-	using no_init = cl::sycl::property::no_init;
+	using cl::sycl::property::no_init;
+#endif
+
+#if CELERITY_FEATURE_SIMPLE_SCALAR_REDUCTIONS
+	namespace reduction {
+		using cl::sycl::property::reduction::initialize_to_identity;
+	}
 #endif
 } // namespace property
 

--- a/include/sycl_wrappers.h
+++ b/include/sycl_wrappers.h
@@ -70,6 +70,9 @@ using decorated_global_ptr = cl::sycl::global_ptr<T>;
 template <typename T>
 using decorated_local_ptr = cl::sycl::local_ptr<T>;
 
+using cl::sycl::id;
+using cl::sycl::range;
+
 // We re-implement nd_range to un-deprecate kernel offsets
 template <int Dims = 1>
 class nd_range {
@@ -80,8 +83,7 @@ class nd_range {
 	    : global_range(s_range.get_global_range()), local_range(s_range.get_local_range()), offset(s_range.get_offset()) {}
 #pragma GCC diagnostic pop
 
-	nd_range(cl::sycl::range<Dims> global_range, cl::sycl::range<Dims> local_range, cl::sycl::id<Dims> offset = {})
-	    : global_range(global_range), local_range(local_range), offset(offset) {
+	nd_range(range<Dims> global_range, range<Dims> local_range, id<Dims> offset = {}) : global_range(global_range), local_range(local_range), offset(offset) {
 #ifndef __SYCL_DEVICE_ONLY__
 		for(int d = 0; d < Dims; ++d) {
 			if(local_range[d] == 0 || global_range[d] % local_range[d] != 0) { throw std::invalid_argument("global_range is not divisible by local_range"); }
@@ -91,10 +93,10 @@ class nd_range {
 
 	operator cl::sycl::nd_range<Dims>() const { return cl::sycl::nd_range<Dims>{global_range, local_range, offset}; }
 
-	cl::sycl::range<Dims> get_global_range() const { return global_range; }
-	cl::sycl::range<Dims> get_local_range() const { return local_range; }
-	cl::sycl::range<Dims> get_group_range() const { return global_range / local_range; }
-	cl::sycl::id<Dims> get_offset() const { return offset; }
+	range<Dims> get_global_range() const { return global_range; }
+	range<Dims> get_local_range() const { return local_range; }
+	range<Dims> get_group_range() const { return global_range / local_range; }
+	id<Dims> get_offset() const { return offset; }
 
 	friend bool operator==(const nd_range& lhs, const nd_range& rhs) {
 		return lhs.global_range == rhs.global_range && lhs.local_range == rhs.local_range && lhs.offset == rhs.offset;
@@ -103,18 +105,18 @@ class nd_range {
 	friend bool operator!=(const nd_range& lhs, const nd_range& rhs) { return !(lhs == rhs); }
 
   private:
-	cl::sycl::range<Dims> global_range;
-	cl::sycl::range<Dims> local_range;
-	cl::sycl::id<Dims> offset;
+	range<Dims> global_range;
+	range<Dims> local_range;
+	id<Dims> offset;
 };
 
 // Non-templated deduction guides allow construction of nd_range from range initializer lists like so: nd_range{{1, 2}, {3, 4}}
 // ... except, currently, for ComputeCpp which uses an outdated Clang (TODO)
-nd_range(cl::sycl::range<1> global_range, cl::sycl::range<1> local_range, cl::sycl::id<1> offset)->nd_range<1>;
-nd_range(cl::sycl::range<1> global_range, cl::sycl::range<1> local_range)->nd_range<1>;
-nd_range(cl::sycl::range<2> global_range, cl::sycl::range<2> local_range, cl::sycl::id<2> offset)->nd_range<2>;
-nd_range(cl::sycl::range<2> global_range, cl::sycl::range<2> local_range)->nd_range<2>;
-nd_range(cl::sycl::range<3> global_range, cl::sycl::range<3> local_range, cl::sycl::id<3> offset)->nd_range<3>;
-nd_range(cl::sycl::range<3> global_range, cl::sycl::range<3> local_range)->nd_range<3>;
+nd_range(range<1> global_range, range<1> local_range, id<1> offset)->nd_range<1>;
+nd_range(range<1> global_range, range<1> local_range)->nd_range<1>;
+nd_range(range<2> global_range, range<2> local_range, id<2> offset)->nd_range<2>;
+nd_range(range<2> global_range, range<2> local_range)->nd_range<2>;
+nd_range(range<3> global_range, range<3> local_range, id<3> offset)->nd_range<3>;
+nd_range(range<3> global_range, range<3> local_range)->nd_range<3>;
 
 } // namespace celerity

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -2060,7 +2060,7 @@ namespace detail {
 				//   The following line is commented because it produces a compile error but it is still a case we wanted to test.
 				//   Since we can not check the content of a property list at compile time, for now it is only accepted to pass either the property
 				//   celerity::no_init or nothing.
-				// accessor acc0{buf_a, cgh, one_to_one{}, cl::sycl::write_only_host_task, cl::sycl::property_list{celerity::no_init}};
+				// accessor acc0{buf_a, cgh, one_to_one{}, cl::sycl::write_only_host_task, celerity::property_list{celerity::no_init}};
 
 				accessor acc1{buf_a, cgh, one_to_one{}, celerity::write_only_host_task};
 				static_assert(std::is_same_v<accessor<int, 1, access_mode::write, target::host_task>, decltype(acc1)>);


### PR DESCRIPTION
This aliases `id` and `range` in the Celerity namespace for namespacing consistency with `celerity::nd_range`.
Also re-exports `celerity::property_list` and `celerity::property::reduction::initialize_to_identity` (on SYCL backends that support this property).

Internal APIs are not refactored to avoid an unnecessarily large change, since we never plan to actually re-implement those types.