### PR TITLE
Fix init task/command handling for host-initialized buffers

### DIFF
--- a/include/command_graph.h
+++ b/include/command_graph.h
@@ -113,6 +113,8 @@ namespace detail {
 
 		void erase_if(std::function<bool(abstract_command*)> condition);
 
+		bool has(command_id cid) const { return commands.count(cid) == 1; }
+
 		template <typename T = abstract_command>
 		T* get(command_id cid) {
 			assert(commands.find(cid) != commands.end());

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -60,8 +60,9 @@ namespace detail {
 		using buffer_writer_map = std::unordered_map<buffer_id, region_map<std::optional<command_id>>>;
 
 		struct per_node_data {
-			// For each node we generate a separate INIT command which acts as a proxy last writer for host-initialized buffers.
-			command_id init_cid;
+			// An "init command" is used as the last writer for host-initialized buffers.
+			// This is useful so we can correctly generate anti-dependencies onto commands that read host-initialized buffers.
+			command_id current_init_cid;
 			// We store for each node which command last wrote to a buffer region. This includes both newly generated data (from a execution command),
 			// as well as already existing data that was pushed in from another node. This is used for determining anti-dependencies.
 			buffer_writer_map buffer_last_writer;

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -87,8 +87,8 @@ namespace detail {
 		command_graph& cdag;
 
 		// The most recent horizon command per node.
-		std::vector<horizon_command*> prev_horizon_cmds;
-		// The id for the next cleanup horizon (after which we can delete commands)
+		std::vector<horizon_command*> current_horizon_cmds;
+		// The id for the next cleanup horizon (commands with ids lower than the cleanup horizon will be deleted next)
 		detail::command_id cleanup_horizon_id = 0;
 
 		// NOTE: We have several data structures that keep track of the "global state" of the distributed program, across all tasks and nodes.

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -72,16 +72,6 @@ namespace detail {
 
 		const task* get_task(task_id tid) const;
 
-		/**
-		 * @brief Returns the id of the INIT task which acts as a surrogate for the host-initialization of buffers.
-		 *
-		 * While this is always 0, having this method makes code dealing with the INIT task more explicit.
-		 */
-		task_id get_init_task_id() const {
-			assert(init_task_id == 0);
-			return init_task_id;
-		}
-
 		void print_graph(logger& graph_logger) const;
 
 		/**
@@ -117,7 +107,9 @@ namespace detail {
 		reduction_manager* reduction_mngr;
 
 		task_id next_task_id = 0;
-		const task_id init_task_id;
+		// An "init task" is used as the last writer for host-initialized buffers.
+		// This is useful so we can correctly generate anti-dependencies onto tasks that read host-initialized buffers.
+		task_id current_init_task_id;
 		std::unordered_map<task_id, std::unique_ptr<task>> task_map;
 
 		// We store a map of which task last wrote to a certain region of a buffer.

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -141,8 +141,9 @@ namespace detail {
 			// In some cases (horizons, master node host task, weird discard_* constructs...)
 			// the last writer might not have any dependents. Just add the anti-dependency onto the writer itself then.
 			if(!has_dependents) {
-				// Don't add anti-dependencies onto the init command
-				if(last_writer_cid == node_data[write_cmd->get_nid()].current_init_cid) continue;
+				// Don't add anti-dependencies onto the (first! the nop_command) init command
+				const auto init_cid = node_data[write_cmd->get_nid()].current_init_cid;
+				if(last_writer_cid == init_cid && isa<nop_command>(cdag.get(init_cid))) continue;
 
 				cdag.add_dependency(write_cmd, last_writer_cmd, dependency_kind::ANTI_DEP);
 

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -19,7 +19,7 @@ namespace detail {
 			const auto init_cmd = cdag.create<nop_command>(i);
 			node_data[i].init_cid = init_cmd->get_cid();
 		}
-		std::fill_n(std::back_inserter(prev_horizon_cmds), num_nodes, nullptr);
+		std::fill_n(std::back_inserter(current_horizon_cmds), num_nodes, nullptr);
 	}
 
 	void graph_generator::add_buffer(buffer_id bid, const cl::sycl::range<3>& range) {
@@ -481,7 +481,8 @@ namespace detail {
 				cdag.add_dependency(horizon_cmd, front_cmd);
 			}
 			// Apply the previous horizon to data structures
-			auto prev_horizon = prev_horizon_cmds[node];
+			auto* prev_horizon = current_horizon_cmds[node];
+			current_horizon_cmds[node] = horizon_cmd;
 			if(prev_horizon != nullptr) {
 				// update "buffer_last_writer" structures to subsume pre-horizon commands
 				auto prev_hid = prev_horizon->get_cid();
@@ -498,7 +499,6 @@ namespace detail {
 					lowest_prev_hid = std::min(lowest_prev_hid, prev_hid);
 				}
 			}
-			prev_horizon_cmds[node] = horizon_cmd;
 		}
 		// After updating all the data structures, delete before-cleanup-horizon commands
 		// Also remove commands from command_buffer_reads (if it exists)

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -234,7 +234,7 @@ namespace detail {
 	void runtime::handle_buffer_unregistered(buffer_id bid) {
 		// If the runtime is still active, and at least one task (other than the init task) has been submitted, report an error.
 		// TODO: This is overly restrictive. Can we instead check whether any tasks that require this particular buffer are still pending?
-		if(is_active && task_mngr->get_current_task_count() > 1) {
+		if(is_active && task_mngr->get_total_task_count() > 1) {
 			// We cannot throw here, as this is being called from buffer destructors.
 			default_logger->error(
 			    "The Celerity runtime detected that a buffer is going out of scope before all tasks have been completed. This is not allowed.");

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -8,8 +8,9 @@ namespace celerity {
 namespace detail {
 
 	task_manager::task_manager(size_t num_collective_nodes, host_queue* queue, reduction_manager* reduction_mgr)
-	    : num_collective_nodes(num_collective_nodes), queue(queue), reduction_mngr(reduction_mgr), current_init_task_id(next_task_id++) {
+	    : num_collective_nodes(num_collective_nodes), queue(queue), reduction_mngr(reduction_mgr) {
 		// We manually generate the first init task; horizons are used later on (see generate_task_horizon).
+		current_init_task_id = get_new_tid();
 		task_map[current_init_task_id] = task::make_nop(current_init_task_id);
 	}
 

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -2584,7 +2584,7 @@ namespace detail {
 
 			// need to wait for commands to actually be executed, otherwise no tasks are deleted
 			q.slow_full_sync();
-			CHECK(task_manager_testspy::num_tasks(tm) < task_limit);
+			CHECK(tm.get_current_task_count() < task_limit);
 		}
 	}
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -30,7 +30,7 @@ namespace celerity {
 namespace detail {
 
 	struct task_manager_testspy {
-		static task* get_previous_horizon_task(task_manager& tm) { return tm.previous_horizon_task; }
+		static task* get_current_horizon_task(task_manager& tm) { return tm.current_horizon_task; }
 
 		static int get_num_horizons(task_manager& tm) {
 			int horizon_counter = 0;
@@ -41,8 +41,6 @@ namespace detail {
 		}
 
 		static region_map<std::optional<task_id>> get_last_writer(task_manager& tm, const buffer_id bid) { return tm.buffers_last_writers.at(bid); }
-
-		static int num_tasks(task_manager& tm) { return tm.task_map.size(); }
 
 		static int get_max_pseudo_critical_path_length(task_manager& tm) { return tm.get_max_pseudo_critical_path_length(); }
 
@@ -163,7 +161,7 @@ namespace test_utils {
 		detail::graph_serializer& get_graph_serializer() { return *gsrlzr; }
 
 		void build_task_horizons() {
-			auto most_recently_generated_task_horizon = detail::task_manager_testspy::get_previous_horizon_task(get_task_manager());
+			auto most_recently_generated_task_horizon = detail::task_manager_testspy::get_current_horizon_task(get_task_manager());
 			if(most_recently_generated_task_horizon != most_recently_built_task_horizon) {
 				most_recently_built_task_horizon = most_recently_generated_task_horizon;
 				if(most_recently_built_task_horizon != nullptr) {


### PR DESCRIPTION
Host initialized buffers use a proxy "init" task/command as last writer to properly handle anti-dependencies. Previously this task/command was generated once (per node, in the case of commands) in the beginning and then used as last writer for all newly created buffers.

This breaks once enough tasks/commands have been generated to trigger a horizon cleanup (which then deletes the init task/commands). To work around this, we now also replace init task/commands by the previous horizon upon applying the latter (similarly to how last writer data structures are being updated).

While implementing tests for this I noticed some inconsistencies in the language surrounding horizons, in particular what constitutes the "previous" and "current" horizons. This has been cleared up as well.