### PR TITLE
Expose SYCL 2020 ::sycl namespace to users

### DIFF
--- a/include/celerity.h
+++ b/include/celerity.h
@@ -24,4 +24,8 @@ namespace runtime {
 } // namespace runtime
 } // namespace celerity
 
+// Celerity includes <CL/sycl.hpp> internally, but we want to expose the SYCL 2020 ::sycl namespace to Celerity users.
+// TODO: Remove this once Celerity includes <sycl/sycl.hpp> internally.
+#include <sycl/sycl.hpp>
+
 #endif


### PR DESCRIPTION
This was already the case for ComputeCPP and DPC++, however hipSYCL requires an explicit alias.