### PR TITLE
Correctly apply horizons to collective-group dependencies

### DIFF
--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -66,6 +66,9 @@ namespace detail {
 			// We store for each node which command last wrote to a buffer region. This includes both newly generated data (from a execution command),
 			// as well as already existing data that was pushed in from another node. This is used for determining anti-dependencies.
 			buffer_writer_map buffer_last_writer;
+			// Collective host tasks have an implicit dependency on the previous task in the same collective group, which is required in order to guarantee
+			// they are executed in the same order on every node.
+			std::unordered_map<collective_group_id, command_id> last_collective_commands;
 		};
 
 	  public:
@@ -107,10 +110,6 @@ namespace detail {
 		std::unordered_map<command_id, buffer_read_map> command_buffer_reads;
 
 		std::unordered_map<node_id, per_node_data> node_data;
-
-		// Collective host tasks have an implicit dependency on the previous task in the same collective group, which is required in order to guarantee
-		// they are executed in the same order on every node.
-		std::unordered_map<std::pair<node_id, collective_group_id>, command_id, pair_hash> last_collective_commands;
 
 		// This mutex mainly serves to protect per-buffer data structures, as new buffers might be added at any time.
 		std::mutex buffer_mutex;

--- a/include/intrusive_graph.h
+++ b/include/intrusive_graph.h
@@ -71,8 +71,10 @@ namespace detail {
 			// Check for (direct) cycles
 			assert(!has_dependent(dep.node));
 
-			auto it = maybe_get_dep(dependencies, dep.node);
-			if(it != std::nullopt) {
+			if(const auto it = maybe_get_dep(dependencies, dep.node)) {
+				// We assume that for dependency kinds A and B, max(A, B) is strong enough to satisfy both.
+				static_assert(dependency_kind::ANTI_DEP < dependency_kind::ORDER_DEP && dependency_kind::ORDER_DEP < dependency_kind::TRUE_DEP);
+
 				// Already exists, potentially upgrade to full dependency
 				if((*it)->kind < dep.kind) {
 					(*it)->kind = dep.kind;

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -494,6 +494,10 @@ namespace detail {
 						return {std::max(prev_hid, *cid)};
 					});
 				}
+				for(auto& [nid_cgid, cid] : last_collective_commands) {
+					const auto [nid, cgid] = nid_cgid;
+					if(nid == node) { cid = std::max(prev_hid, cid); }
+				}
 				// update lowest previous horizon id (for later command deletion)
 				if(lowest_prev_hid == 0) {
 					lowest_prev_hid = prev_hid;

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -209,6 +209,9 @@ namespace detail {
 						return {std::max(prev_hid, *tid)};
 					});
 				}
+				for(auto& [cgid, tid] : last_collective_tasks) {
+					tid = std::max(prev_hid, tid);
+				}
 
 				// We also use the previous horizon as the new init task for host-initialized buffers
 				current_init_task_id = prev_hid;

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -200,7 +200,7 @@ namespace detail {
 				if(front_task != current_horizon_task) { add_dependency(current_horizon_task, front_task); }
 			}
 
-			// apply the previous horizon to buffers_last_writers data struct
+			// apply the previous horizon to buffers_last_writers and last_collective_tasks data structs
 			if(previous_horizon_task != nullptr) {
 				const task_id prev_hid = previous_horizon_task->get_id();
 				for(auto& [_, buffer_region_map] : buffers_last_writers) {

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -333,5 +333,48 @@ namespace detail {
 		maybe_print_graphs(ctx);
 	}
 
+	TEST_CASE("commands for collective host tasks do not order-depend on their predecessor if it is shadowed by a horizon",
+	    "[graph_generator][command-graph][horizon]") {
+		// Regression test: the order-dependencies between host tasks in the same collective group are built by tracking the last task command in each
+		// collective group. Once a horizon is inserted, commands for new collective host tasks must order-depend on that horizon command instead.
+
+		const size_t num_nodes = 1;
+		test_utils::cdag_test_context ctx(num_nodes);
+		auto& tm = ctx.get_task_manager();
+		tm.set_horizon_step(2);
+
+		const auto first_collective = test_utils::build_and_flush(ctx, test_utils::add_host_task(tm, experimental::collective, [&](handler& cgh) {}));
+
+		// generate exactly two horizons
+		auto& ggen = ctx.get_graph_generator();
+		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		auto buf = mbf.create_buffer(range<1>(1));
+		for(int i = 0; i < 5; ++i) {
+			test_utils::build_and_flush(
+			    ctx, test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); }));
+		}
+
+		// This must depend on the first horizon, not first_collective
+		const auto second_collective = test_utils::build_and_flush(ctx, test_utils::add_host_task(tm, experimental::collective, [&](handler& cgh) {}));
+
+		const auto& inspector = ctx.get_inspector();
+		auto& cdag = ctx.get_command_graph();
+		const auto first_commands = inspector.get_commands(first_collective, std::nullopt, std::nullopt);
+		const auto second_commands = inspector.get_commands(second_collective, std::nullopt, std::nullopt);
+		for(const auto second_cid : second_commands) {
+			for(const auto first_cid : first_commands) {
+				CHECK(!inspector.has_dependency(second_cid, first_cid));
+			}
+			const auto second_deps = cdag.get(second_cid)->get_dependencies();
+			CHECK(std::distance(second_deps.begin(), second_deps.end()) == 1);
+			for(const auto& dep : second_deps) {
+				CHECK(dep.kind == dependency_kind::ORDER_DEP);
+				CHECK(dynamic_cast<const horizon_command*>(dep.node));
+			}
+		}
+
+		maybe_print_graphs(ctx);
+	}
+
 } // namespace detail
 } // namespace celerity

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -122,7 +122,7 @@ namespace test_utils {
 			return result;
 		}
 
-		bool has_dependency(detail::command_id dependent, detail::command_id dependency) {
+		bool has_dependency(detail::command_id dependent, detail::command_id dependency) const {
 			const auto& deps = commands.at(dependent).dependencies;
 			return std::find(deps.cbegin(), deps.cend(), dependency) != deps.cend();
 		}


### PR DESCRIPTION
Tasks and commands in the same collective group are serialized using `ORDER_DEP` dependencies to guarantee a single total order of execution across all workers. To generate these dependencies, the last task / command in each group is tracked similar to the last writers of buffers.

When a new horizon is applied, the tracked last collective group task / command ids must be replaced by the previous horizon. This follows the same rule as last buffer writers. This was not done previously, which will cause access to dangling task and command ids once the last collective operation in a group is deleted from the graph.

This PR correctly replaces the tracked task / command ids when they are subsumed by a horizon and adds regression tests. Also, the `last_collective_commands` map in `graph_generator` is moved for consistency with last-buffer-writer tracking.

![BugGraph](https://user-images.githubusercontent.com/5698527/147276302-7232564c-7564-4a00-8739-8dc01d265637.png)


