### PR TITLE
Fix race conditions between task and command horizons

### DIFF
--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -134,7 +134,8 @@ namespace detail {
 		// The latest horizon task created. Will be applied as last writer once the next horizon is created.
 		task* current_horizon_task = nullptr;
 
-		// Queue of horizon tasks for which the associated commands were executed
+		// Queue of horizon tasks for which the associated commands were executed.
+		// Only accessed in task_manager::notify_horizon_executed, which is always called from the executor thread - no locking needed.
 		std::queue<task_id> executed_horizons;
 		// marker task id for "nothing to delete" - we can safely use 0 here
 		static constexpr task_id nothing_to_delete = 0;

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -159,7 +159,14 @@ namespace detail {
 
 	bool executor::handle_command(const command_pkg& pkg, const std::vector<command_id>& dependencies) {
 		switch(pkg.cmd) {
-		case command_type::HORIZON: create_job<horizon_job>(pkg, dependencies, task_mngr); break;
+		case command_type::HORIZON: {
+			// Similar to task commands, a worker might receive the horizon command before creating the corresponding horizon task
+			const auto horizon_tid = std::get<horizon_data>(pkg.data).horizon_tid;
+			if(!task_mngr.has_task(horizon_tid)) return false;
+
+			create_job<horizon_job>(pkg, dependencies, task_mngr);
+			break;
+		}
 		case command_type::PUSH: create_job<push_job>(pkg, dependencies, *btm, buffer_mngr); break;
 		case command_type::AWAIT_PUSH: create_job<await_push_job>(pkg, dependencies, *btm); break;
 		case command_type::REDUCTION: create_job<reduction_job>(pkg, dependencies, reduction_mngr); break;


### PR DESCRIPTION
This PR addresses two race conditions:

- A data race in an assertion within `task_manager::notify_horizon_executed`: `task_map` is accessed without a lock, but the function is called from the executor thread while the map is updated from the main thread.
- A race between horizon task creation in the main thread and horizon job execution in the executor thread: workers can receive horizon commands before reaching the corresponding horizon task, so the executor must delay notifying the task manager until the horizon task is available. A similar mechanism exists for (compute) task commands.

I could not come up with a good way to write a regression test (`distr_tests`) for this. Artificially delaying compute- or horizon task creation in workers does not seem to trigger the error. It does however occur somewhat reliably with `wave_sim` on 4 nodes and the Intel OpenCL platform. This explains some of the `wave_sim` failures after 0.3.0.