### PR TITLE
Fix deprecation warnings for ComputeCpp & DPC++

### DIFF
--- a/include/accessor.h
+++ b/include/accessor.h
@@ -253,7 +253,10 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 
   private:
 #if WORKAROUND_COMPUTECPP || WORKAROUND_DPCPP
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations" // target::gobal_buffer is now target::device, but only for very recent versions of DPC++
 	using sycl_accessor_t = cl::sycl::accessor<DataT, Dims, Mode, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::true_t>;
+#pragma GCC diagnostic pop
 #else
 	using sycl_accessor_t = cl::sycl::accessor<DataT, Dims, Mode, cl::sycl::target::device>;
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ file(GLOB_RECURSE TEST_INCLUDES *.h)
 
 set(TEST_TARGETS
   runtime_tests
+  runtime_deprecation_tests
   graph_generation_tests
   graph_compaction_tests
   intrusive_graph_tests
@@ -52,14 +53,5 @@ foreach(TEST_TARGET ${TEST_TARGETS})
   ParseAndAddCatchTests_ParseFile(${TEST_SOURCE} ${TEST_TARGET})
 
 endforeach()
-
-# runtime_tests explicitly tests deprecated APIs to ensure backwards compatibility, but
-# compilers may fail to suppress -Wno-deprecated-declarations locally through #pragma GCC diagnostic
-# when deprecations manifest through a template instantiated elsewhere.
-# TODO split off a separate translation unit from runtime_tests that only tests deprecated APIs
-# so we can leave deprecation warnings active for the remainder of runtime_tests
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
-    target_compile_options(runtime_tests PRIVATE -Wno-deprecated-declarations)
-endif ()
 
 add_subdirectory(system)

--- a/test/runtime_deprecation_tests.cc
+++ b/test/runtime_deprecation_tests.cc
@@ -1,0 +1,182 @@
+// This diagnostic must be disabled here, because ComputeCpp appears to override it when specified on the command line.
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+#include "sycl_wrappers.h"
+#include "unit_test_suite_celerity.h"
+
+#include <algorithm>
+#include <memory>
+#include <random>
+
+#include <catch2/catch.hpp>
+
+#include <celerity.h>
+
+#include "ranges.h"
+#include "region_map.h"
+
+#include "test_utils.h"
+
+namespace celerity {
+namespace detail {
+
+	using celerity::access::all;
+	using celerity::access::fixed;
+	using celerity::access::neighborhood;
+	using celerity::access::one_to_one;
+	using celerity::access::slice;
+	using celerity::experimental::access::even_split;
+
+	TEST_CASE("deprecated range mapper templates continue to work", "[range-mapper][deprecated]") {
+		const auto chunk1d = chunk<1>{1, 2, 3};
+		const auto chunk2d = chunk<2>{{1, 1}, {2, 2}, {3, 3}};
+		const auto chunk3d = chunk<3>{{1, 1, 1}, {2, 2, 2}, {3, 3, 3}};
+		const auto range1d = cl::sycl::range<1>{4};
+		const auto range2d = cl::sycl::range<2>{4, 4};
+		const auto range3d = cl::sycl::range<3>{4, 4, 4};
+		const auto subrange1d = subrange<1>{{}, range1d};
+		const auto subrange2d = subrange<2>{{}, range2d};
+		const auto subrange3d = subrange<3>{{}, range3d};
+
+		CHECK(one_to_one<1>{}(chunk1d) == subrange{chunk1d});
+		CHECK(one_to_one<2>{}(chunk2d) == subrange{chunk2d});
+		CHECK(one_to_one<3>{}(chunk3d) == subrange{chunk3d});
+
+		CHECK(fixed<1, 3>{subrange3d}(chunk1d) == subrange3d);
+		CHECK(fixed<2, 2>{subrange2d}(chunk2d) == subrange2d);
+		CHECK(fixed<3, 1>{subrange1d}(chunk3d) == subrange1d);
+
+		CHECK(all<1>{}(chunk1d, range1d) == subrange1d);
+		CHECK(all<2>{}(chunk2d, range2d) == subrange2d);
+		CHECK(all<3>{}(chunk3d, range3d) == subrange3d);
+		CHECK(all<1, 3>{}(chunk1d, range3d) == subrange3d);
+		CHECK(all<2, 2>{}(chunk2d, range2d) == subrange2d);
+		CHECK(all<3, 1>{}(chunk3d, range1d) == subrange1d);
+	}
+
+	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "device accessor supports atomic access", "[accessor][deprecated]") {
+		auto& bm = get_buffer_manager();
+		auto& dq = get_device_queue();
+		int host_data = 0;
+		auto bid = bm.register_buffer<int, 1>(cl::sycl::range<3>(1, 1, 1), &host_data);
+
+		auto range = cl::sycl::range<1>(2048);
+		auto sr = subrange<3>({}, range_cast<3>(range));
+		live_pass_device_handler cgh(nullptr, sr, true, dq);
+
+		auto device_acc = get_device_accessor<int, 1, cl::sycl::access::mode::atomic>(cgh, bid, {1}, {0});
+		cgh.parallel_for<class UKN(atomic_increment)>(range, [=](cl::sycl::id<1> id) { device_acc[0].fetch_add(2); });
+		cgh.get_submission_event().wait();
+
+		auto host_acc = get_host_accessor<int, 1, cl::sycl::access::mode::read>(bid, {1}, {0});
+		REQUIRE(host_acc[0] == 4096);
+	}
+
+	TEST_CASE("deprecated host_memory_layout continues to work", "[task][deprecated]") {
+		distr_queue q;
+
+		std::vector<char> memory1d(10);
+		buffer<char, 1> buf1d(memory1d.data(), cl::sycl::range<1>(10));
+
+		q.submit([=](handler& cgh) {
+			auto b = buf1d.get_access<cl::sycl::access::mode::discard_write, target::host_task>(cgh, all{});
+			cgh.host_task(on_master_node, [=](partition<0> part) {
+				auto [ptr, layout] = b.get_host_memory(part);
+				auto& dims = layout.get_dimensions();
+				REQUIRE(dims.size() == 1);
+				CHECK(dims[0].get_global_offset() == 0);
+				CHECK(dims[0].get_local_offset() == 0);
+				CHECK(dims[0].get_global_size() == 10);
+				CHECK(dims[0].get_local_size() >= 10);
+				CHECK(dims[0].get_extent() == 10);
+			});
+		});
+
+		q.submit([=](handler& cgh) {
+			auto b = buf1d.get_access<cl::sycl::access::mode::discard_write, target::host_task>(cgh, one_to_one{});
+			cgh.host_task(cl::sycl::range<1>(6), cl::sycl::id<1>(2), [=](partition<1> part) {
+				auto [ptr, layout] = b.get_host_memory(part);
+				auto& dims = layout.get_dimensions();
+				REQUIRE(dims.size() == 1);
+				CHECK(dims[0].get_global_offset() == 2);
+				CHECK(dims[0].get_local_offset() <= 2);
+				CHECK(dims[0].get_global_size() == 10);
+				CHECK(dims[0].get_local_size() >= 6);
+				CHECK(dims[0].get_local_size() <= 10);
+				CHECK(dims[0].get_extent() == 6);
+			});
+		});
+
+		std::vector<char> memory2d(10 * 10);
+		buffer<char, 2> buf2d(memory2d.data(), cl::sycl::range<2>(10, 10));
+
+		q.submit([=](handler& cgh) {
+			auto b = buf2d.get_access<cl::sycl::access::mode::discard_write, target::host_task>(cgh, one_to_one{});
+			cgh.host_task(cl::sycl::range<2>(5, 6), cl::sycl::id<2>(1, 2), [=](partition<2> part) {
+				auto [ptr, layout] = b.get_host_memory(part);
+				auto& dims = layout.get_dimensions();
+				REQUIRE(dims.size() == 2);
+				CHECK(dims[0].get_global_offset() == 1);
+				CHECK(dims[0].get_global_size() == 10);
+				CHECK(dims[0].get_local_offset() <= 1);
+				CHECK(dims[0].get_local_size() >= 6);
+				CHECK(dims[0].get_local_size() <= 10);
+				CHECK(dims[0].get_extent() == 5);
+				CHECK(dims[1].get_global_offset() == 2);
+				CHECK(dims[1].get_global_size() == 10);
+				CHECK(dims[1].get_extent() == 6);
+			});
+		});
+
+		std::vector<char> memory3d(10 * 10 * 10);
+		buffer<char, 3> buf3d(memory3d.data(), cl::sycl::range<3>(10, 10, 10));
+
+		q.submit([=](handler& cgh) {
+			auto b = buf3d.get_access<cl::sycl::access::mode::discard_write, target::host_task>(cgh, one_to_one{});
+			cgh.host_task(cl::sycl::range<3>(5, 6, 7), cl::sycl::id<3>(1, 2, 3), [=](partition<3> part) {
+				auto [ptr, layout] = b.get_host_memory(part);
+				auto& dims = layout.get_dimensions();
+				REQUIRE(dims.size() == 3);
+				CHECK(dims[0].get_global_offset() == 1);
+				CHECK(dims[0].get_local_offset() <= 1);
+				CHECK(dims[0].get_global_size() == 10);
+				CHECK(dims[0].get_local_size() >= 5);
+				CHECK(dims[0].get_local_size() <= 10);
+				CHECK(dims[0].get_extent() == 5);
+				CHECK(dims[1].get_global_offset() == 2);
+				CHECK(dims[1].get_local_offset() <= 2);
+				CHECK(dims[1].get_global_size() == 10);
+				CHECK(dims[1].get_local_size() >= 6);
+				CHECK(dims[1].get_local_size() <= 10);
+				CHECK(dims[1].get_extent() == 6);
+				CHECK(dims[2].get_global_offset() == 3);
+				CHECK(dims[2].get_global_size() == 10);
+				CHECK(dims[2].get_extent() == 7);
+			});
+		});
+	}
+
+	TEST_CASE("Kernels receiving cl::sycl::item<Dims> (deprecated) continue to work", "[handler][deprecated]") {
+		distr_queue q;
+
+		buffer<int, 1> buf1d{{1}};
+		q.submit([=](handler& cgh) {
+			accessor acc{buf1d, cgh, celerity::access::one_to_one{}, celerity::read_write, celerity::no_init};
+			cgh.parallel_for<class UKN(kernel)>(cl::sycl::range<1>{1}, [=](cl::sycl::item<1> id) { acc[id] = 0; });
+		});
+
+		buffer<int, 2> buf2d{{1, 1}};
+		q.submit([=](handler& cgh) {
+			accessor acc{buf2d, cgh, celerity::access::one_to_one{}, celerity::read_write, celerity::no_init};
+			cgh.parallel_for<class UKN(kernel)>(cl::sycl::range<2>{1, 1}, [=](cl::sycl::item<2> id) { acc[id] = 0; });
+		});
+
+		buffer<int, 3> buf3d{{1, 1, 1}};
+		q.submit([=](handler& cgh) {
+			accessor acc{buf3d, cgh, celerity::access::one_to_one{}, celerity::read_write, celerity::no_init};
+			cgh.parallel_for<class UKN(kernel)>(cl::sycl::range<3>{1, 1, 1}, [=](cl::sycl::item<3> id) { acc[id] = 0; });
+		});
+	}
+
+} // namespace detail
+} // namespace celerity

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -317,7 +317,8 @@ namespace test_utils {
 				dq->get_sycl_queue()
 				    .submit([&](cl::sycl::handler& cgh) {
 					    auto acc = info.buffer.template get_access<Mode>(cgh);
-					    cgh.parallel_for<detail::bind_kernel_name<KernelName>>(range, offset, [=](cl::sycl::id<Dims> global_idx) {
+					    cgh.parallel_for<detail::bind_kernel_name<KernelName>>(range, [=](cl::sycl::id<Dims> global_idx) {
+						    global_idx += offset;
 						    const auto local_idx = global_idx - buf_offset;
 						    cb(global_idx, acc[local_idx]);
 					    });


### PR DESCRIPTION
ComputeCpp's Clang 8 has trouble handling `#pragma GCC diagnostic` sections whenever that code triggers a deprecation warning on instantiating a template. This is solved by moving all tests of deprecated APIs from `runtime_tests.cc` to a separate test binary `runtime_deprecation_tests.cc`, which centrally disables `-Wdeprecated-declarations`. This also moves `buffer_manager_fixture` from `runtime_tests.cpp` to `test_utils.hh` in order to avoid duplication between the old and new runtime tests `.cc` file.

We were also still using deprecated kernel offsets and enum variants for which DPC++ emits a warning. These were refactored according to SYCL 2020.