### PR TITLE
Generate stack traces from crashed CI jobs

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -69,7 +69,8 @@ jobs:
         run: bash -o pipefail -c "bash /root/build-celerity.sh ${{ env.container-workspace }} --build-type ${{ matrix.build-type }} --target install 2>&1 | tee ${{ env.build-name }}.log"
       # Upload build log for report step
       - name: Upload build logs
-        uses: actions/upload-artifact@v1
+        if: always()
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.build-name }}
           path: ${{ env.build-name }}.log
@@ -78,8 +79,7 @@ jobs:
       - name: Run unit tests
         timeout-minutes: 5
         working-directory: ${{ env.build-dir }}
-        # Running "make test" is slow (why?), so we just call all test executables manually
-        run: find test -maxdepth 1 -executable -type f -print0 | xargs -0 -n1 bash -c
+        run: ${{ env.container-workspace }}/ci/run-unit-tests.sh
       - name: Run integration tests
         timeout-minutes: 5
         # We build examples twice, but only run the installed version (which probably has more failure modes)
@@ -88,6 +88,15 @@ jobs:
       - name: Run system tests
         working-directory: ${{ env.build-dir }}
         run: ${{ env.container-workspace }}/ci/run-system-tests.sh 2 4
+      - name: Upload stack traces (if any)
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.build-name }}
+          path: |
+            ${{ env.build-dir }}/*.trace
+            ${{ env.examples-build-dir }}/*.trace
+          if-no-files-found: ignore
 
   report:
     needs: [build-and-test]

--- a/ci/find-unformatted-files.sh
+++ b/ci/find-unformatted-files.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ ! -d src ]]; then
-    echo "Warning: This script should be run from within the repository root directory" 1>&2
+    echo "Warning: This script should be run from within the repository root directory" >&2
 fi
 
 SOURCES=$(find examples include src test \( -name "*.h" -o -name "*.cc" \) ! -name "stb*")

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -65,7 +65,7 @@ for e in "${!EXAMPLES[@]}"; do
     for n in "${NUM_NODES[@]}"; do
         echo -e "\n\n ---- Running \"$NAME\" on $n node(s) ----\n\n" 1>&2
         rm -rf "$ARTIFACT" # Delete artifact before each run to make sure it is actually created
-        mpirun -n "$n" "${CMD[@]}"
+        mpirun -n "$n" bash /root/capture-backtrace.sh "${CMD[@]}"
         if [ -n "$ARTIFACT" ]; then
             if [ "$n" -eq "${NUM_NODES[0]}" ]; then
                 expected_checksum=$(md5sum "$ARTIFACT")

--- a/ci/run-integration-tests.sh
+++ b/ci/run-integration-tests.sh
@@ -3,11 +3,11 @@
 set -o errexit -o pipefail -o nounset
 
 if [[ ! -d CMakeFiles ]]; then
-    echo "Warning: This script should be run from within a build directory" 1>&2
+    echo "Warning: This script should be run from within a build directory" >&2
 fi
 
 if [[ $# -lt 2 ]]; then
-    echo "Usage: $0 <convolution image file> <num nodes> [<num nodes>...]" 1>&2
+    echo "Usage: $0 <convolution image file> <num nodes> [<num nodes>...]" >&2
     exit 1
 fi
 
@@ -63,7 +63,7 @@ for e in "${!EXAMPLES[@]}"; do
     ARTIFACT="${ARTIFACTS[$e]}"
 
     for n in "${NUM_NODES[@]}"; do
-        echo -e "\n\n ---- Running \"$NAME\" on $n node(s) ----\n\n" 1>&2
+        echo -e "\n\n ---- Running \"$NAME\" on $n node(s) ----\n\n" >&2
         rm -rf "$ARTIFACT" # Delete artifact before each run to make sure it is actually created
         mpirun -n "$n" bash /root/capture-backtrace.sh "${CMD[@]}"
         if [ -n "$ARTIFACT" ]; then
@@ -74,7 +74,7 @@ for e in "${!EXAMPLES[@]}"; do
                 # configuration (debug/release, hipSYCL/ComputeCpp, etc) because they don't. Instead
                 # we just check whether they produce the same result across runs with different nodes.
                 if [[ $(md5sum "$ARTIFACT") != "$expected_checksum" ]]; then
-                    echo "$NAME: Wrong ARTIFACT checksum after running with $n nodes." 1>&2
+                    echo "$NAME: Wrong ARTIFACT checksum after running with $n nodes." >&2
                     exit 1
                 fi
             fi

--- a/ci/run-system-tests.sh
+++ b/ci/run-system-tests.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if [[ ! -d examples || ! -d CMakeFiles ]]; then
-    echo "Warning: This script should be run from within a build directory" 1>&2
+    echo "Warning: This script should be run from within a build directory" >&2
 fi
 
 if [[ $# -le 1 ]]; then
-    echo "Usage: $0 <num nodes> [<num nodes>...]"
+    echo "Usage: $0 <num nodes> [<num nodes>...]" >&2
     exit 1
 fi
 
@@ -20,7 +20,7 @@ for e in "${!SYSTEM_TESTS[@]}"; do
     CMD="./test/system/${EXE}"
 
     for n in "${NUM_NODES[@]}"; do
-        echo -e "\n\n ---- Running \"$EXE\" on $n node(s) ----\n\n"
+        echo -e "\n\n ---- Running \"$EXE\" on $n node(s) ----\n\n" >&2
         mpirun -n ${n} bash /root/capture-backtrace.sh ${CMD} || exit 1
     done
 done

--- a/ci/run-system-tests.sh
+++ b/ci/run-system-tests.sh
@@ -21,6 +21,6 @@ for e in "${!SYSTEM_TESTS[@]}"; do
 
     for n in "${NUM_NODES[@]}"; do
         echo -e "\n\n ---- Running \"$EXE\" on $n node(s) ----\n\n"
-        mpirun -n ${n} ${CMD} || exit 1
+        mpirun -n ${n} bash /root/capture-backtrace.sh ${CMD} || exit 1
     done
 done

--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit -o pipefail -o nounset
+
+if [[ ! -d CMakeFiles ]]; then
+    echo "Warning: This script should be run from within a build directory" 1>&2
+fi
+
+if [[ $# -ne 0 ]]; then
+    echo "Usage: $0" >&2
+    exit 1
+fi
+
+# Running "make test" is slow because CTest will spawn one process per test case, adding significant start-up costs.
+# We just call all test executables manually to get around this.
+find test -maxdepth 1 -executable -type f | while read test; do
+    echo -e "\n\n ---- Running ${test##*/} ----\n\n" 1>&2
+    bash /root/capture-backtrace.sh "$test"
+done

--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit -o pipefail -o nounset
 
 if [[ ! -d CMakeFiles ]]; then
-    echo "Warning: This script should be run from within a build directory" 1>&2
+    echo "Warning: This script should be run from within a build directory" >&2
 fi
 
 if [[ $# -ne 0 ]]; then
@@ -14,6 +14,6 @@ fi
 # Running "make test" is slow because CTest will spawn one process per test case, adding significant start-up costs.
 # We just call all test executables manually to get around this.
 find test -maxdepth 1 -executable -type f | while read test; do
-    echo -e "\n\n ---- Running ${test##*/} ----\n\n" 1>&2
+    echo -e "\n\n ---- Running ${test##*/} ----\n\n" >&2
     bash /root/capture-backtrace.sh "$test"
 done


### PR DESCRIPTION
This PR uses a [script](https://github.com/celerity/celerity-runtime-ci/blob/master/common/capture-backtrace.sh) that is now part of our CI setup to generate stack traces whenever a test or example crashes. It operates by arranging a core dump to be generated that is then interpreted by GDB. It exports stack traces of all active threads as well as all available local variables.

The trace files are visible in the Github Actions log and are also uploaded as artifacts. See [this run](https://github.com/celerity/celerity-runtime/actions/runs/1633865071) for an example of a run that deliberately crashes for demonstration purposes.

## Open Questions
- Should we add debug info (`-g`) to release builds in order to make traces more useful?

## Example trace
(purpose-crashed `task_graph_tests` on ComputeCpp)
```
Reading symbols from test/task_graph_tests...
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `test/task_graph_tests'.
Program terminated with signal SIGABRT, Aborted.
#0  0x00007f2388f8d18b in raise () from /lib/x86_64-linux-gnu/libc.so.6
[Current thread is 1 (Thread 0x7f2388ab6780 (LWP 2160))]

Thread 2 (Thread 0x7f237a311700 (LWP 2172)):
#0  0x00007f2389497376 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f2389375e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#2  0x00007f237a60e067 in ?? () from /usr/lib/x86_64-linux-gnu/intel-opencl/libigdrcl.so
#3  0x00007f2389490609 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#4  0x00007f2389069293 in clone () from /lib/x86_64-linux-gnu/libc.so.6

Thread 1 (Thread 0x7f2388ab6780 (LWP 2160)):
#0  0x00007f2388f8d18b in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f2388f6c859 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00005650b5a48c81 in celerity::detail::task_manager::notify_horizon_executed (this=0x7ffd0c42ec30, tid=...) at /__w/celerity-runtime/celerity-runtime/src/task_manager.cc:46
    __PRETTY_FUNCTION__ = "void celerity::detail::task_manager::notify_horizon_executed(celerity::detail::task_id)"
#3  0x00005650b582101a in celerity::detail::____C_A_T_C_H____T_E_S_T____48 () at /__w/celerity-runtime/celerity-runtime/test/task_graph_tests.cc:486
    tid = {value = 7}
    current_horizon = 0x5650b69d4060
    i = 4
    buf = {id = {value = 1}, size = {<cl::sycl::detail::id_range_base<unsigned long, 1, cl::sycl::range<1> >> = {static dimensions = 1, m_data = {_M_elems = {1}}}, <No data fields>}}
    last_executed_horizon = {value = 8}
    tm = {_vptr.task_manager = 0x5650b5cfe560 <vtable for celerity::detail::task_manager+16>, num_collective_nodes = 1, queue = 0x0, reduction_mngr = 0x0, next_task_id = {value = 9}, current_init_task_id = {value = 5}, task_map = std::unordered_map with 9 elements = {[{value = 8}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69d4060}, [{value = 7}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69d42e0}, [{value = 6}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69d4d80}, [{value = 5}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69d3b90}, [{value = 4}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69a33e0}, [{value = 3}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69d25e0}, [{value = 2}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69abfc0}, [{value = 1}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69d4720}, [{value = 0}] = std::unique_ptr<celerity::detail::task> = {get() = 0x5650b69d4510}}, buffers_last_writers = std::unordered_map with 2 elements = {[{value = 1}] = {extent = {<cl::sycl::detail::id_range_base<unsigned long, 3, cl::sycl::range<3> >> = {static dimensions = 3, m_data = {_M_elems = {1, 1, 1}}}, <No data fields>}, default_initialized = {regions = std::vector of length 0, capacity 0}, region_values = std::vector of length 1, capacity 2 = {{first = {regions = std::vector of length 1, capacity 1 = {{min = {x = 0, y = 0, z = 0}, max = {x = 1, y = 1, z = 1}}}}, second = std::optional<celerity::detail::PhantomType<unsigned long, celerity::detail::task_id_PhantomType>> = {[contained value] = {value = 7}}}}}, [{value = 0}] = {extent = {<cl::sycl::detail::id_range_base<unsigned long, 3, cl::sycl::range<3> >> = {static dimensions = 3, m_data = {_M_elems = {1, 1, 1}}}, <No data fields>}, default_initialized = {regions = std::vector of length 0, capacity 0}, region_values = std::vector of length 1, capacity 2 = {{first = {regions = std::vector of length 1, capacity 1 = {{min = {x = 0, y = 0, z = 0}, max = {x = 1, y = 1, z = 1}}}}, second = std::optional<celerity::detail::PhantomType<unsigned long, celerity::detail::task_id_PhantomType>> = {[contained value] = {value = 5}}}}}}, last_collective_tasks = std::unordered_map with 0 elements, task_mutex = {<std::__mutex_base> = {_M_mutex = {__data = {__lock = 0, __count = 0, __owner = 0, __nusers = 0, __kind = 0, __spins = 0, __elision = 0, __list = {__prev = 0x0, __next = 0x0}}, __size = '\000' <repeats 39 times>, __align = 0}}, <No data fields>}, task_callbacks = std::vector of length 0, capacity 0, task_horizon_step_size = 2, max_pseudo_critical_path_length = 5, current_horizon_critical_path_length = 4, current_horizon_task = 0x5650b69d4060, executed_horizons = std::queue wrapping: std::deque with 1 element = {{value = 5}}, static nothing_to_delete = {value = 0}, horizon_task_id_for_deletion = {static _S_min_alignment = 8, static _S_alignment = 8, _M_i = {value = 0}, static is_always_lock_free = <error reading variable: Missing ELF symbol "std::atomic<celerity::detail::PhantomType<unsigned long, celerity::detail::task_id_PhantomType> >::is_always_lock_free".>}, static horizon_deletion_lag = 3, execution_front = std::unordered_set with 1 element = {[0] = 0x5650b69d4060}}
    mbf = {task_mngr = 0x7ffd0c42ec30, ggen = 0x0, next_buffer_id = {value = 2}}
    initial_last_writer_id = {value = 0}
    buf = {id = {value = 453}, size = {<cl::sycl::detail::id_range_base<unsigned long, 1, cl::sycl::range<1> >> = {static dimensions = 1, m_data = {_M_elems = {94904645631632}}}, <No data fields>}}
    tid = {value = 94901597372417}
    deps = <error reading variable>
    new_last_writer = 0x3
    current_horizon = 0x4
#4  0x00005650b59207f2 in Catch::TestInvokerAsFunction::invoke (this=0x5650b6861100) at /__w/celerity-runtime/celerity-runtime/vendor/Catch2/single_include/catch2/catch.hpp:14028
#5  0x00005650b591fdf3 in Catch::TestCase::invoke (this=0x5650b69d35d0) at /__w/celerity-runtime/celerity-runtime/vendor/Catch2/single_include/catch2/catch.hpp:13921
#6  0x00005650b591a2dc in Catch::RunContext::invokeActiveTestCase (this=0x7ffd0c42f400) at /__w/celerity-runtime/celerity-runtime/vendor/Catch2/single_include/catch2/catch.hpp:12749
#7  0x00005650b591a00f in Catch::RunContext::runCurrentTest (this=0x7ffd0c42f400, redirectedCout="", redirectedCerr="") at /__w/celerity-runtime/celerity-runtime/vendor/Catch2/single_include/catch2/catch.hpp:12722
    testCaseSection = {name = "previous task horizon is used as last writer for host-initialized buffers", description = "", lineInfo = {file = 0x5650b5b0afc0 "/__w/celerity-runtime/celerity-runtime/test/task_graph_tests.cc", line = 459}}
    prevAssertions = {passed = 114, failed = 0, failedButOk = 0}
    duration = 0
    timer = {m_nanoseconds = 1640787339934295974}
    assertions = {passed = 94904645782132, failed = 9, failedButOk = 0}
    missingAssertions = false
    testCaseSectionStats = {_vptr.SectionStats = 0x7ffd0c42f000, sectionInfo = {name = "\220\311\303\220\363\017\036\372UH\211\345H\211}\370H\215\025U\312;\000H\213E\370H\211\020\220]\303\220\363\017\036\372UH\211\345H\203\354\020H\211}\370H\211u\360H\213E\370H\213U\360H\211\326H\211\307\350\263\237\354\377H\213M\370H\213E\360H\213P(H\213@ H\211A H\211Q(\220\311\303\363\017\036\372UH\211\345H\203\354\020H\211}\370H\213E\370H\211\307\350\260\265\000\000\220\311\303\220\363\017\036\372UH\211\345H\203\354\020H\211}\370H\213E\370H\211\307\350d\265\000\000\220\311\303\220\363\017\036\372UH\211\345H\203\354\020H\211}\370H\213E\370H\211\307\350\304\377\377\377\220\311\303\220\363\017\036\372"..., description = "H\211\330H\213M\350dH3\f%(\000\000\000tO\353H\363\017\036\372H\211\303H\215E\320H\211\307\350Ic\002\000\353\a\363\017\036\372H\211\303H\215E\300H\211\307\350\064c\002\000\353\a\363\017\036\372H\211\303H\215E\260H\211\307\350-y\002\000H\211\330H\211\307\350\032\b\357\377\350\005\b\357\377H\203\304h[]\303\363\017\036\372UH\211\345H\203\354\020H\211}\370H\213E\370H\213\000H\203\300\030H\213\020H\213E\370H\211\307\377\322\203\360\001\204\300t\fH\213E\370H\211\307\350\350\366\377\377\220\311\303\220\363\017\036\372UH\211\345AUATSH\203\354XH\211}\230H\211u\220dH\213\004%(\000\000\000"..., lineInfo = {file = 0xfb3c68b64318600 <error: Cannot access memory at address 0xfb3c68b64318600>, line = 94904661076512}}, assertions = {passed = 0, failed = 140724809166976, failedButOk = 1}, durationInSeconds = 6.9527293728225073e-310, missingAssertions = false}
#8  0x00005650b5918a2f in Catch::RunContext::runTest (this=0x7ffd0c42f400, testCase=...) at /__w/celerity-runtime/celerity-runtime/vendor/Catch2/single_include/catch2/catch.hpp:12483
    prevTotals = {error = 0, assertions = {passed = 114, failed = 0, failedButOk = 0}, testCases = {passed = 10, failed = 0, failedButOk = 0}}
    redirectedCout = ""
    redirectedCerr = ""
    deltaTotals = {error = 0, assertions = {passed = 9, failed = 0, failedButOk = 0}, testCases = {passed = 1, failed = 0, failedButOk = 0}}
#9  0x00005650b591bb42 in Catch::(anonymous namespace)::TestGroup::execute (this=0x7ffd0c42f3f0) at /__w/celerity-runtime/celerity-runtime/vendor/Catch2/single_include/catch2/catch.hpp:13077
    testCase = @0x5650b6b20750: 0x5650b69d35d0
    __for_range = std::set with 11 elements = {[0] = 0x5650b69d2ea0, [1] = 0x5650b69d2f58, [2] = 0x5650b69d3010, [3] = 0x5650b69d30c8, [4] = 0x5650b69d3180, [5] = 0x5650b69d3238, [6] = 0x5650b69d32f0, [7] = 0x5650b69d33a8, [8] = 0x5650b69d3460, [9] = 0x5650b69d3518, [10] = 0x5650b69d35d0}
    __for_begin = 0x5650b69d35d0
    __for_end = 0xb
    invalidArgs = std::vector of length 0, capacity 0
    totals = {error = 0, assertions = {passed = 114, failed = 0, failedButOk = 0}, testCases = {passed = 10, failed = 0, failedButOk = 0}}
#10 0x00005650b591cf5b in Catch::Session::runInternal (this=0x7ffd0c42f7f0) at /__w/celerity-runtime/celerity-runtime/vendor/Catch2/single_include/catch2/catch.hpp:13283
    totals = {error = 0, assertions = {passed = 114, failed = 0, failedButOk = 0}, testCases = {passed = 10, failed = 0, failedButOk = 0}}
#11 0x00005650b591cc51 in Catch::Session::run (this=0x7ffd0c42f7f0) at /__w/celerity-runtime/celerity-runtime/vendor/Catch2/single_include/catch2/catch.hpp:13239
    exitCode = 22096
#12 0x00005650b5932495 in main (argc=1, argv=0x7ffd0c42fa78) at /__w/celerity-runtime/celerity-runtime/test/unit_test_suite.cc:22
    returnCode = 0
```