### PR TITLE
Skip and cancel duplicate CI workflows

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -6,7 +6,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  find-duplicate-workflows:
+    runs-on: self-hosted
+    outputs:
+      should_skip: ${{ steps.skip-check.outputs.should_skip }}
+    steps:
+      - id: skip-check
+        uses: fkirc/skip-duplicate-actions@v3.4.1
+        with:
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["**/*.md", "docs/**", "website/**"]'
+          do_not_skip: '["workflow_dispatch", "schedule"]'
+          cancel_others: 'true'
+
   build-and-test:
+    needs: find-duplicate-workflows
+    if: ${{ needs.find-duplicate-workflows.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -90,7 +106,8 @@ jobs:
         run: ${{ env.container-workspace }}/ci/run-system-tests.sh 2 4
 
   report:
-    needs: [build-and-test]
+    needs: [find-duplicate-workflows, build-and-test]
+    if: ${{ needs.find-duplicate-workflows.outputs.should_skip != 'true' }}
     runs-on: self-hosted
     env:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}


### PR DESCRIPTION
This uses [fkirc/skip-duplicate-actions](https://github.com/marketplace/actions/skip-duplicate-actions) to detect and skip/cancel duplicate CI workflows.

Proposed configuration:

- Detect duplicates on file contents, ignoring any documentation changes (.md files, docs, and website)
- Skip a workflow if a successful duplicate has completed before
- Skip newer workflows that are being started while a duplicate is already running
- Cancel running workflows if a new push invalidates them