### PR TITLE
Silence unused variable warning

### DIFF
--- a/src/platform_specific/affinity.unix.cc
+++ b/src/platform_specific/affinity.unix.cc
@@ -1,4 +1,3 @@
-
 #include <cassert>
 #include <cstdint>
 
@@ -13,6 +12,7 @@ namespace detail {
 	uint32_t affinity_cores_available() {
 		cpu_set_t available_cores;
 		const auto affinity_error = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &available_cores);
+		(void)affinity_error;
 		assert(affinity_error == 0 && "Error retrieving affinity mask.");
 		return CPU_COUNT(&available_cores);
 	}

--- a/src/platform_specific/affinity.unix.cc
+++ b/src/platform_specific/affinity.unix.cc
@@ -11,9 +11,8 @@ namespace detail {
 
 	uint32_t affinity_cores_available() {
 		cpu_set_t available_cores;
-		const auto affinity_error = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &available_cores);
-		(void)affinity_error;
-		assert(affinity_error == 0 && "Error retrieving affinity mask.");
+		[[maybe_unused]] const auto ret = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &available_cores);
+		assert(ret == 0 && "Error retrieving affinity mask.");
 		return CPU_COUNT(&available_cores);
 	}
 

--- a/src/platform_specific/affinity.win.cc
+++ b/src/platform_specific/affinity.win.cc
@@ -13,9 +13,8 @@ namespace detail {
 
 		native_cpu_set available_cores;
 		[[maybe_unused]] native_cpu_set sys_affinity_mask;
-		const auto affinity_error = GetProcessAffinityMask(GetCurrentProcess(), &available_cores, &sys_affinity_mask);
-		(void)affinity_error;
-		assert(affinity_error != 0 && "Error retrieving affinity mask.");
+		[[maybe_unused]] const auto ret = GetProcessAffinityMask(GetCurrentProcess(), &available_cores, &sys_affinity_mask);
+		assert(ret != FALSE && "Error retrieving affinity mask.");
 		return utils::popcount(available_cores);
 	}
 

--- a/src/platform_specific/affinity.win.cc
+++ b/src/platform_specific/affinity.win.cc
@@ -14,7 +14,8 @@ namespace detail {
 		native_cpu_set available_cores;
 		[[maybe_unused]] native_cpu_set sys_affinity_mask;
 		const auto affinity_error = GetProcessAffinityMask(GetCurrentProcess(), &available_cores, &sys_affinity_mask);
-		assert(affinity_error != FALSE && "Error retrieving affinity mask.");
+		(void)affinity_error;
+		assert(affinity_error != 0 && "Error retrieving affinity mask.");
 		return utils::popcount(available_cores);
 	}
 


### PR DESCRIPTION
Also I've changed the check for `GetProcessAffinityMask` to compare against `0`. Even though the [signature](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getprocessaffinitymask) says `BOOL`, the description talks about zero and non-zero return values, and I found a check `assert(error != false)` to be confusing.