### PR TITLE
In-graph synchronization with Epochs

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -142,6 +142,10 @@ namespace detail {
 	// -------------------------------------------- SERIALIZED COMMANDS -----------------------------------------------
 	// ----------------------------------------------------------------------------------------------------------------
 
+	struct epoch_data {
+		task_id tid;
+	};
+
 	struct horizon_data {
 		task_id tid;
 	};
@@ -175,7 +179,7 @@ namespace detail {
 		uint64_t sync_id;
 	};
 
-	using command_data = std::variant<std::monostate, horizon_data, execution_data, push_data, await_push_data, reduction_data, sync_data>;
+	using command_data = std::variant<std::monostate, epoch_data, horizon_data, execution_data, push_data, await_push_data, reduction_data, sync_data>;
 
 	/**
 	 * A command package is what is actually transferred between nodes.

--- a/include/command.h
+++ b/include/command.h
@@ -10,8 +10,8 @@
 namespace celerity {
 namespace detail {
 
-	enum class command_type { EPOCH, HORIZON, EXECUTION, PUSH, AWAIT_PUSH, REDUCTION, SHUTDOWN, SYNC };
-	constexpr const char* command_string[] = {"EPOCH", "HORIZON", "EXECUTION", "PUSH", "AWAIT_PUSH", "REDUCTION", "SHUTDOWN", "SYNC"};
+	enum class command_type { EPOCH, HORIZON, EXECUTION, PUSH, AWAIT_PUSH, REDUCTION };
+	constexpr const char* command_string[] = {"EPOCH", "HORIZON", "EXECUTION", "PUSH", "AWAIT_PUSH", "REDUCTION"};
 
 	// ----------------------------------------------------------------------------------------------------------------
 	// ------------------------------------------------ COMMAND GRAPH -------------------------------------------------
@@ -111,7 +111,13 @@ namespace detail {
 
 	class epoch_command final : public task_command {
 		friend class command_graph;
-		using task_command::task_command;
+		epoch_command(const command_id& cid, const node_id& nid, const task_id& tid, epoch_action action) : task_command(cid, nid, tid), action(action) {}
+
+	  public:
+		epoch_action get_epoch_action() const { return action; }
+
+	  private:
+		epoch_action action;
 	};
 
 	class horizon_command final : public task_command {
@@ -144,6 +150,7 @@ namespace detail {
 
 	struct epoch_data {
 		task_id tid;
+		epoch_action action;
 	};
 
 	struct horizon_data {

--- a/include/command.h
+++ b/include/command.h
@@ -149,16 +149,10 @@ namespace detail {
 	// ----------------------------------------------------------------------------------------------------------------
 
 	struct epoch_data {
-		task_id tid;
 		epoch_action action;
 	};
 
-	struct horizon_data {
-		task_id tid;
-	};
-
 	struct execution_data {
-		task_id tid;
 		subrange<3> sr;
 		bool initialize_reductions;
 	};
@@ -182,22 +176,16 @@ namespace detail {
 		reduction_id rid;
 	};
 
-	struct sync_data {
-		uint64_t sync_id;
-	};
-
-	using command_data = std::variant<std::monostate, epoch_data, horizon_data, execution_data, push_data, await_push_data, reduction_data, sync_data>;
+	using command_data = std::variant<std::monostate, epoch_data, execution_data, push_data, await_push_data, reduction_data>;
 
 	/**
 	 * A command package is what is actually transferred between nodes.
 	 */
 	struct command_pkg {
 		command_id cid{};
+		std::optional<task_id> tid{};
 		command_type cmd{};
 		command_data data;
-
-		command_pkg() = default;
-		command_pkg(command_id cid, command_type cmd, command_data data) : cid(cid), cmd(cmd), data(data) {}
 	};
 
 } // namespace detail

--- a/include/command.h
+++ b/include/command.h
@@ -12,7 +12,6 @@ namespace celerity {
 namespace detail {
 
 	enum class command_type { EPOCH, HORIZON, EXECUTION, PUSH, AWAIT_PUSH, REDUCTION };
-	constexpr const char* command_string[] = {"EPOCH", "HORIZON", "EXECUTION", "PUSH", "AWAIT_PUSH", "REDUCTION"};
 
 	// ----------------------------------------------------------------------------------------------------------------
 	// ------------------------------------------------ COMMAND GRAPH -------------------------------------------------

--- a/include/command.h
+++ b/include/command.h
@@ -218,8 +218,6 @@ namespace detail {
 			);
 			// clang-format on
 		}
-
-		// clang-format on
 	};
 
 } // namespace detail

--- a/include/command_graph.h
+++ b/include/command_graph.h
@@ -93,9 +93,9 @@ namespace detail {
 	class command_graph {
 	  public:
 		template <typename T, typename... Args>
-		T* create(Args... args) {
+		T* create(Args&&... args) {
 			static_assert(std::is_base_of<abstract_command, T>::value, "T must be derived from abstract_command");
-			auto unique_cmd = std::unique_ptr<T>{new T(next_cmd_id++, std::forward<Args>(args)...)};
+			auto unique_cmd = std::unique_ptr<T>{new T(next_cmd_id++, std::forward<Args>(args)...)}; // new, because ctors are private, but we are friends
 			const auto cmd = unique_cmd.get();
 			commands.emplace(std::pair{cmd->get_cid(), std::move(unique_cmd)});
 			if constexpr(std::is_base_of_v<task_command, T>) { by_task[cmd->get_tid()].emplace_back(cmd); }

--- a/include/command_graph.h
+++ b/include/command_graph.h
@@ -14,6 +14,8 @@
 namespace celerity {
 namespace detail {
 
+	class task_manager;
+
 	// TODO: Could be extended (using SFINAE) to support additional iterator types (e.g. random access)
 	template <typename Iterator, typename PredicateFn>
 	class filter_iterator {
@@ -126,13 +128,13 @@ namespace detail {
 
 		auto& task_commands(task_id tid) { return by_task.at(tid); }
 
-		std::optional<std::string> print_graph(size_t max_nodes) const;
+		std::optional<std::string> print_graph(size_t max_nodes, const task_manager& tm) const;
 
 		// TODO unify dependency terminology to this
-		void add_dependency(abstract_command* depender, abstract_command* dependee, dependency_kind kind = dependency_kind::TRUE_DEP) {
+		void add_dependency(abstract_command* depender, abstract_command* dependee, dependency_kind kind, dependency_origin origin) {
 			assert(depender->get_nid() == dependee->get_nid()); // We cannot depend on commands executed on another node!
 			assert(dependee != depender);
-			depender->add_dependency({dependee, kind});
+			depender->add_dependency({dependee, kind, origin});
 			execution_fronts[depender->get_nid()].erase(dependee);
 		}
 

--- a/include/command_graph.h
+++ b/include/command_graph.h
@@ -96,8 +96,7 @@ namespace detail {
 			command_id cid = next_cmd_id++;
 			auto result = commands.emplace(std::make_pair(cid, new T(cid, std::forward<Args>(args)...)));
 			auto cmd = result.first->second.get();
-			auto& ef = execution_fronts[cmd->get_nid()];
-			if(!std::is_same<T, nop_command>::value) ef.insert(cmd);
+			execution_fronts[cmd->get_nid()].insert(cmd);
 			auto tcmd = static_cast<T*>(cmd);
 			if constexpr(std::is_base_of_v<task_command, T>) { by_task[tcmd->get_tid()].emplace_back(tcmd); }
 			return tcmd;

--- a/include/distr_queue.h
+++ b/include/distr_queue.h
@@ -48,7 +48,7 @@ class distr_queue {
 	template <typename CGF>
 	void submit(allow_by_ref_t, CGF cgf) { // NOLINT(readability-convert-member-functions-to-static)
 		// (Note while this function could be made static, it must not be! Otherwise we can't be sure the runtime has been initialized.)
-		detail::runtime::get_instance().get_task_manager().create_task(std::move(cgf));
+		detail::runtime::get_instance().get_task_manager().submit_command_group(std::move(cgf));
 	}
 
 	/**

--- a/include/distr_queue.h
+++ b/include/distr_queue.h
@@ -46,7 +46,7 @@ class distr_queue {
 	 * preferred in the common case.
 	 */
 	template <typename CGF>
-	void submit(allow_by_ref_t, CGF cgf) {
+	void submit(allow_by_ref_t, CGF cgf) { // NOLINT(readability-convert-member-functions-to-static)
 		// (Note while this function could be made static, it must not be! Otherwise we can't be sure the runtime has been initialized.)
 		detail::runtime::get_instance().get_task_manager().create_task(std::move(cgf));
 	}
@@ -72,7 +72,7 @@ class distr_queue {
 	 * In production, it should only be used at very coarse granularity (second scale).
 	 * @warning { This is very slow, as it drains all queues and synchronizes accross the entire cluster. }
 	 */
-	void slow_full_sync() { detail::runtime::get_instance().sync(); }
+	void slow_full_sync() { detail::runtime::get_instance().sync(); } // NOLINT(readability-convert-member-functions-to-static)
 
   private:
 	std::shared_ptr<detail::distr_queue_tracker> tracker;

--- a/include/executor.h
+++ b/include/executor.h
@@ -53,11 +53,6 @@ namespace detail {
 		 */
 		void shutdown();
 
-		/**
-		 * @brief Get the id of the highest executed global sync operation.
-		 */
-		uint64_t get_highest_executed_sync_id() const noexcept;
-
 	  private:
 		node_id local_nid;
 		host_queue& h_queue;
@@ -69,7 +64,6 @@ namespace detail {
 		std::unique_ptr<buffer_transfer_manager> btm;
 		std::thread exec_thrd;
 		size_t running_device_compute_jobs = 0;
-		std::atomic<uint64_t> highest_executed_sync_id = {0};
 
 		// Jobs are identified by the command id they're processing
 

--- a/include/executor.h
+++ b/include/executor.h
@@ -81,7 +81,7 @@ namespace detail {
 
 		template <typename Job, typename... Args>
 		void create_job(const command_pkg& pkg, const std::vector<command_id>& dependencies, Args&&... args) {
-			jobs[pkg.cid] = {std::make_unique<Job>(pkg, std::forward<Args>(args)...), pkg.cmd, {}, 0};
+			jobs[pkg.cid] = {std::make_unique<Job>(pkg, std::forward<Args>(args)...), pkg.get_command_type(), {}, 0};
 
 			// If job doesn't exist we assume it has already completed.
 			// This is true as long as we're respecting task-graph (anti-)dependencies when processing tasks.

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -61,9 +61,10 @@ namespace detail {
 		using side_effect_map = std::unordered_map<host_object_id, command_id>;
 
 		struct per_node_data {
-			// An "init command" is used as the last writer for host-initialized buffers.
+			// The epoch command is used as the last writer for host-initialized buffers.
+			// To ensure correct ordering, all commands that have no other true-dependencies depend on this command.
 			// This is useful so we can correctly generate anti-dependencies onto commands that read host-initialized buffers.
-			command_id current_init_cid;
+			command_id current_epoch_cid;
 			// We store for each node which command last wrote to a buffer region. This includes both newly generated data (from a execution command),
 			// as well as already existing data that was pushed in from another node. This is used for determining anti-dependencies.
 			buffer_writer_map buffer_last_writer;

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -97,7 +97,7 @@ namespace detail {
 		// The most recent horizon command per node.
 		std::vector<horizon_command*> current_horizon_cmds;
 		// The id for the next cleanup horizon (commands with ids lower than the cleanup horizon will be deleted next)
-		detail::command_id cleanup_horizon_id = 0;
+		detail::command_id current_min_epoch_cid = 0;
 
 		// NOTE: We have several data structures that keep track of the "global state" of the distributed program, across all tasks and nodes.
 		// While it might seem that this is problematic when the ordering of tasks can be chosen freely (by the scheduler),
@@ -125,7 +125,10 @@ namespace detail {
 
 		void process_task_side_effect_requirements(task_id tid);
 
-		void generate_horizon(task_id tid);
+		template <typename TaskCommand>
+		TaskCommand* reduce_execution_front(task_id reducer_tid, node_id nid);
+
+		void apply_epoch(abstract_command* epoch);
 	};
 
 } // namespace detail

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -64,8 +64,8 @@ namespace detail {
 			// The most recent horizon command. Depends on the previous execution front and will become the current_epoch once the next horizon is generated.
 			std::optional<command_id> current_horizon;
 			// The current epoch command is used as the last writer for host-initialized buffers.
-			// To ensure correct ordering, all commands that have no other true-dependencies depend on this command.
 			// This is useful so we can correctly generate anti-dependencies onto commands that read host-initialized buffers.
+			// To ensure correct ordering, all commands that have no other true-dependencies depend on this command.
 			command_id current_epoch;
 			// We store for each node which command last wrote to a buffer region. This includes both newly generated data (from a execution command),
 			// as well as already existing data that was pushed in from another node. This is used for determining anti-dependencies.
@@ -98,7 +98,7 @@ namespace detail {
 		const size_t num_nodes;
 		command_graph& cdag;
 
-		// After completing an epoch, we need to wait until it is flushed before proving predecessors from the CDAG, otherwise dependencies will not be flushed.
+		// After completing an epoch, we need to wait until it is flushed before pruning predecessors from the CDAG, otherwise dependencies will not be flushed.
 		// We generate the initial epoch commands manually starting from cid 0, so initializing these to 0 is correct.
 		detail::command_id last_completed_epoch = 0;
 		// Used to skip the pruning step if no new epoch has been completed.

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -125,8 +125,8 @@ namespace detail {
 
 		void process_task_side_effect_requirements(task_id tid);
 
-		template <typename TaskCommand>
-		TaskCommand* reduce_execution_front(task_id reducer_tid, node_id nid);
+		template <typename TaskCommand, typename... CtorParams>
+		TaskCommand* reduce_execution_front(task_id reducer_tid, node_id nid, CtorParams... args);
 
 		void apply_epoch(abstract_command* epoch);
 	};

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -133,7 +133,7 @@ namespace detail {
 
 		void process_task_side_effect_requirements(task_id tid);
 
-		void process_epoch_dependencies(const task_id tid);
+		void generate_epoch_dependencies(abstract_command* cmd);
 
 		void generate_epoch_commands(const task* tsk);
 

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -76,8 +76,6 @@ namespace detail {
 			std::unordered_map<collective_group_id, command_id> last_collective_commands;
 			// Side effects on the same host object create true dependencies between task commands, so we track the last effect per host object on each node.
 			side_effect_map host_object_last_effects;
-
-			void set_epoch_for_new_commands(const command_id epoch);
 		};
 
 	  public:
@@ -101,9 +99,9 @@ namespace detail {
 
 		// After completing an epoch, we need to wait until it is flushed before pruning predecessors from the CDAG, otherwise dependencies will not be flushed.
 		// We generate the initial epoch commands manually starting from cid 0, so initializing these to 0 is correct.
-		detail::command_id min_epoch_for_new_commands = 0;
+		command_id min_epoch_for_new_commands = 0;
 		// Used to skip the pruning step if no new epoch has been completed.
-		detail::command_id min_epoch_last_pruned_before = 0;
+		command_id min_epoch_last_pruned_before = 0;
 
 		// NOTE: We have several data structures that keep track of the "global state" of the distributed program, across all tasks and nodes.
 		// While it might seem that this is problematic when the ordering of tasks can be chosen freely (by the scheduler),
@@ -123,6 +121,8 @@ namespace detail {
 
 		// This mutex mainly serves to protect per-buffer data structures, as new buffers might be added at any time.
 		std::mutex buffer_mutex;
+
+		void set_epoch_for_new_commands(per_node_data& node_data, const command_id epoch);
 
 		void reduce_execution_front_to(abstract_command* new_front);
 

--- a/include/intrusive_graph.h
+++ b/include/intrusive_graph.h
@@ -12,15 +12,15 @@ namespace celerity {
 namespace detail {
 
 	enum class dependency_kind {
-		ANTI_DEP, // Data anti-dependency, can be resolved by duplicating buffers
-		TRUE_DEP, // True data flow or temporal dependency
+		ANTI_DEP = 0, // Data anti-dependency, can be resolved by duplicating buffers
+		TRUE_DEP = 1, // True data flow or temporal dependency
 	};
 
 	enum class dependency_origin {
 		dataflow,                       // buffer access dependencies generate task and command dependencies
 		collective_group_serialization, // all nodes must execute kernels within the same collective group in the same order
-		horizon_ordering,               // horizons are temporally ordered after all preceding tasks or commands on the same node
-		epoch_fallback,                 // nodes without other true-dependencies require an edge to the last epoch for temporal ordering
+		execution_front,                // horizons and epochs are temporally ordered after all preceding tasks or commands on the same node
+		current_epoch,                  // nodes without other true-dependencies require an edge to the current epoch for temporal ordering
 	};
 
 	// TODO: Move to utility header..?

--- a/include/intrusive_graph.h
+++ b/include/intrusive_graph.h
@@ -20,7 +20,7 @@ namespace detail {
 		dataflow,                       // buffer access dependencies generate task and command dependencies
 		collective_group_serialization, // all nodes must execute kernels within the same collective group in the same order
 		execution_front,                // horizons and epochs are temporally ordered after all preceding tasks or commands on the same node
-		current_epoch,                  // nodes without other true-dependencies require an edge to the current epoch for temporal ordering
+		last_epoch,                     // nodes without other true-dependencies require an edge to the last epoch for temporal ordering
 	};
 
 	// TODO: Move to utility header..?

--- a/include/log.h
+++ b/include/log.h
@@ -56,18 +56,19 @@ namespace detail {
 #define CELERITY_DETAIL_LOG_SET_SCOPED_CTX(ctx)                                                                                                                \
 	log_ctx_setter _set_log_ctx_##__COUNTER__ { ctx }
 
-	template <typename A, typename B, typename... Rest, size_t... Is, typename Callback>
-	constexpr void tuple_for_each_pair_impl(const std::tuple<A, B, Rest...>& tuple, Callback&& cb, std::index_sequence<Is...>) {
-		cb(std::get<0>(tuple), std::get<1>(tuple));
-		if constexpr(sizeof...(Rest) > 0) {
-			tuple_for_each_pair_impl(std::tuple{std::get<2 + Is>(tuple)...}, std::forward<Callback>(cb), std::make_index_sequence<sizeof...(Rest)>{});
-		}
+	template <typename Tuple, typename Callback>
+	constexpr void tuple_for_each_pair_impl(const Tuple&, Callback&&, std::index_sequence<>) {}
+
+	template <typename Tuple, size_t I1, size_t I2, size_t... Is, typename Callback>
+	constexpr void tuple_for_each_pair_impl(const Tuple& tuple, Callback&& cb, std::index_sequence<I1, I2, Is...>) {
+		cb(std::get<I1>(tuple), std::get<I2>(tuple));
+		tuple_for_each_pair_impl(tuple, cb, std::index_sequence<Is...>{});
 	}
 
 	template <typename... Es, typename Callback>
 	constexpr void tuple_for_each_pair(const std::tuple<Es...>& tuple, Callback&& cb) {
 		static_assert(sizeof...(Es) % 2 == 0, "an even number of entries is required");
-		tuple_for_each_pair_impl(tuple, std::forward<Callback>(cb), std::make_index_sequence<sizeof...(Es) - 2>{});
+		tuple_for_each_pair_impl(tuple, std::forward<Callback>(cb), std::make_index_sequence<sizeof...(Es)>{});
 	}
 
 } // namespace detail

--- a/include/log.h
+++ b/include/log.h
@@ -60,15 +60,15 @@ namespace detail {
 	constexpr void tuple_for_each_pair_impl(const Tuple&, Callback&&, std::index_sequence<>) {}
 
 	template <typename Tuple, size_t I1, size_t I2, size_t... Is, typename Callback>
-	constexpr void tuple_for_each_pair_impl(const Tuple& tuple, Callback&& cb, std::index_sequence<I1, I2, Is...>) {
+	constexpr void tuple_for_each_pair_impl(const Tuple& tuple, const Callback& cb, std::index_sequence<I1, I2, Is...>) {
 		cb(std::get<I1>(tuple), std::get<I2>(tuple));
 		tuple_for_each_pair_impl(tuple, cb, std::index_sequence<Is...>{});
 	}
 
-	template <typename... Es, typename Callback>
-	constexpr void tuple_for_each_pair(const std::tuple<Es...>& tuple, Callback&& cb) {
-		static_assert(sizeof...(Es) % 2 == 0, "an even number of entries is required");
-		tuple_for_each_pair_impl(tuple, std::forward<Callback>(cb), std::make_index_sequence<sizeof...(Es)>{});
+	template <typename Tuple, typename Callback>
+	constexpr void tuple_for_each_pair(const Tuple& tuple, const Callback& cb) {
+		static_assert(std::tuple_size_v<Tuple> % 2 == 0, "an even number of entries is required");
+		tuple_for_each_pair_impl(tuple, cb, std::make_index_sequence<std::tuple_size_v<Tuple>>{});
 	}
 
 } // namespace detail

--- a/include/print_graph.h
+++ b/include/print_graph.h
@@ -10,9 +10,10 @@ namespace celerity {
 namespace detail {
 
 	class command_graph;
+	class task_manager;
 
-	std::string print_graph(const std::unordered_map<task_id, std::unique_ptr<task>>& tdag);
-	std::string print_graph(const command_graph& cdag);
+	std::string print_task_graph(const std::unordered_map<task_id, std::unique_ptr<task>>& tdag);
+	std::string print_command_graph(const command_graph& cdag, const task_manager& tm);
 
 } // namespace detail
 } // namespace celerity

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -76,12 +76,6 @@ namespace detail {
 
 		host_object_manager& get_host_object_manager() const;
 
-		/**
-		 * @brief Broadcasts the specified control command to all workers.
-		 * @internal
-		 */
-		void broadcast_control_command(command_type cmd, const command_data& data);
-
 	  private:
 		inline static bool mpi_initialized = false;
 		inline static bool mpi_finalized = false;
@@ -102,11 +96,6 @@ namespace detail {
 		std::unique_ptr<device_queue> d_queue;
 		size_t num_nodes;
 		node_id local_nid;
-
-		uint64_t sync_id = 0;
-
-		// We reserve the upper half of command IDs for control commands.
-		command_id next_control_command_id = command_id(1) << (std::numeric_limits<command_id::underlying_t>::digits - 1);
 
 		// These management classes are only constructed on the master node.
 		std::unique_ptr<command_graph> cdag;

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -36,11 +36,6 @@ namespace detail {
 		 */
 		void notify_task_created(task_id tid) { notify(scheduler_event_type::TASK_AVAILABLE, tid); }
 
-		/**
-		 * @brief Returns true if the scheduler is idle (has no events to process).
-		 */
-		bool is_idle() const noexcept;
-
 	  protected:
 		/**
 		 * This is called by the worker thread.

--- a/include/task.h
+++ b/include/task.h
@@ -170,8 +170,7 @@ namespace detail {
 
 		static std::unique_ptr<task> make_master_node(
 		    task_id tid, std::unique_ptr<command_group_storage_base> cgf, buffer_access_map access_map, side_effect_map side_effect_map) {
-			return std::unique_ptr<task>(
-			    new task(tid, task_type::MASTER_NODE, collective_group_id{}, task_geometry{}, std::move(cgf), std::move(access_map),
+			return std::unique_ptr<task>(new task(tid, task_type::MASTER_NODE, collective_group_id{}, task_geometry{}, std::move(cgf), std::move(access_map),
 			    std::move(side_effect_map), {}, {}, {}));
 		}
 
@@ -192,10 +191,10 @@ namespace detail {
 		detail::epoch_action epoch_action;
 
 		task(task_id tid, task_type type, collective_group_id cgid, task_geometry geometry, std::unique_ptr<command_group_storage_base> cgf,
-		    buffer_access_map access_map, detail::side_effect_map side_effects, std::vector<reduction_id> reductions, std::string debug_name, detail::epoch_action epoch_action)
+		    buffer_access_map access_map, detail::side_effect_map side_effects, std::vector<reduction_id> reductions, std::string debug_name,
+		    detail::epoch_action epoch_action)
 		    : tid(tid), type(type), cgid(cgid), geometry(geometry), cgf(std::move(cgf)), access_map(std::move(access_map)),
-		      side_effects(std::move(side_effects)), reductions(std::move(reductions)), debug_name(std::move(debug_name)),
-		      epoch_action(epoch_action) {
+		      side_effects(std::move(side_effects)), reductions(std::move(reductions)), debug_name(std::move(debug_name)), epoch_action(epoch_action) {
 			assert(type == task_type::HOST_COMPUTE || type == task_type::DEVICE_COMPUTE || get_granularity().size() == 1);
 			assert((type != task_type::HOST_COMPUTE && type != task_type::COLLECTIVE && type != task_type::MASTER_NODE) || side_effects.empty());
 		}

--- a/include/task.h
+++ b/include/task.h
@@ -17,7 +17,7 @@ class handler;
 namespace detail {
 
 	enum class task_type {
-		NOP,
+		EPOCH,
 		HOST_COMPUTE,   ///< host task with explicit global size and celerity-defined split
 		DEVICE_COMPUTE, ///< device compute task
 		COLLECTIVE,     ///< host task with implicit 1d global size = #ranks and fixed split
@@ -125,7 +125,7 @@ namespace detail {
 
 		execution_target get_execution_target() const {
 			switch(type) {
-			case task_type::NOP: return execution_target::NONE;
+			case task_type::EPOCH: return execution_target::NONE;
 			case task_type::DEVICE_COMPUTE: return execution_target::DEVICE;
 			case task_type::HOST_COMPUTE:
 			case task_type::COLLECTIVE:
@@ -137,8 +137,8 @@ namespace detail {
 
 		const std::vector<reduction_id>& get_reductions() const { return reductions; }
 
-		static std::unique_ptr<task> make_nop(task_id tid) {
-			return std::unique_ptr<task>(new task(tid, task_type::NOP, collective_group_id{}, task_geometry{}, nullptr, {}, {}, {}, {}));
+		static std::unique_ptr<task> make_epoch(task_id tid) {
+			return std::unique_ptr<task>(new task(tid, task_type::EPOCH, collective_group_id{}, task_geometry{}, nullptr, {}, {}, {}, {}));
 		}
 
 		static std::unique_ptr<task> make_host_compute(task_id tid, task_geometry geometry, std::unique_ptr<command_group_storage_base> cgf,

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -64,6 +64,8 @@ namespace detail {
 		 */
 		void add_buffer(buffer_id bid, const cl::sycl::range<3>& range, bool host_initialized);
 
+		const task* find_task(task_id tid) const;
+
 		/**
 		 * @brief Checks whether a task has already been registered with the queue.
 		 *
@@ -159,7 +161,7 @@ namespace detail {
 
 		void invoke_callbacks(task_id tid, task_type type);
 
-		void add_dependency(task* depender, task* dependee, dependency_kind kind = dependency_kind::TRUE_DEP);
+		void add_dependency(task* depender, task* dependee, dependency_kind kind, dependency_origin origin);
 
 		inline bool need_new_horizon() const { return max_pseudo_critical_path_length - current_horizon_critical_path_length >= task_horizon_step_size; }
 

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -53,6 +53,8 @@ namespace detail {
 			return tid;
 		}
 
+		task_id end_epoch();
+
 		/**
 		 * @brief Registers a new callback that will be called whenever a new task is created.
 		 */
@@ -166,6 +168,10 @@ namespace detail {
 		inline bool need_new_horizon() const { return max_pseudo_critical_path_length - current_horizon_critical_path_length >= task_horizon_step_size; }
 
 		int get_max_pseudo_critical_path_length() const { return max_pseudo_critical_path_length; }
+
+		task& reduce_execution_front(std::unique_ptr<task> reducer);
+
+		void apply_epoch(task* epoch);
 
 		const std::unordered_set<task*>& get_execution_front() { return execution_front; }
 

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -95,6 +95,8 @@ namespace detail {
 		 */
 		void notify_horizon_executed(task_id tid);
 
+		void notify_epoch_ended(task_id epoch_tid);
+
 		/**
 		 * Returns the number of tasks created during the lifetime of the task_manager,
 		 * including tasks that have already been deleted.
@@ -146,11 +148,11 @@ namespace detail {
 
 		// Queue of horizon tasks for which the associated commands were executed.
 		// Only accessed in task_manager::notify_horizon_executed, which is always called from the executor thread - no locking needed.
-		std::queue<task_id> executed_horizons;
+		std::queue<task_id> horizon_deletion_queue;
 		// marker task id for "nothing to delete" - we can safely use 0 here
 		static constexpr task_id nothing_to_delete = 0;
 		// task_id ready for deletion, 0 if nothing to delete (set on notify, used on new task creation)
-		std::atomic<task_id> horizon_task_id_for_deletion = nothing_to_delete;
+		std::atomic<task_id> delete_before_epoch = nothing_to_delete;
 		// How many horizons to delay before deleting tasks
 		static constexpr int horizon_deletion_lag = 3;
 

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -200,11 +200,9 @@ namespace detail {
 		// The latest horizon task created. Will be applied as last writer once the next horizon is created.
 		std::optional<task_id> current_horizon;
 
-		// Queue of horizon tasks for which the associated commands were executed.
+		// The last horizon completed in the executor, will become the last_completed_epoch once the next horizon is completed as well.
 		// Only accessed in task_manager::notify_*, which are always called from the executor thread - no locking needed.
-		std::queue<task_id> horizon_completion_queue;
-		// How many horizons have to be completed before the first one can be regarded as a completed epoch.
-		static constexpr int horizon_epoch_lag = 3;
+		std::optional<task_id> last_completed_horizon;
 
 		// The last epoch task that has been completed in the executor. Behind a monitor to allow awaiting this change from the main thread.
 		epoch_monitor last_completed_epoch{initial_epoch_task};

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -24,6 +24,8 @@ namespace detail {
 		using buffer_writers_map = std::unordered_map<buffer_id, region_map<std::optional<task_id>>>;
 
 	  public:
+		constexpr inline static task_id initial_epoch_task = 0;
+
 		task_manager(size_t num_collective_nodes, host_queue* queue, reduction_manager* reduction_mgr);
 
 		virtual ~task_manager() = default;
@@ -106,10 +108,11 @@ namespace detail {
 
 		reduction_manager* reduction_mngr;
 
-		task_id next_task_id = 0;
-		// An "init task" is used as the last writer for host-initialized buffers.
+		task_id next_task_id = 1;
+		// The current epoch is used as the last writer for host-initialized buffers.
+		// To ensure correct ordering, all tasks that have no other true-dependencies depend on this task.
 		// This is useful so we can correctly generate anti-dependencies onto tasks that read host-initialized buffers.
-		task_id current_init_task_id;
+		task_id current_epoch;
 		std::unordered_map<task_id, std::unique_ptr<task>> task_map;
 
 		// We store a map of which task last wrote to a certain region of a buffer.

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -75,7 +75,7 @@ namespace detail {
 
 				compute_dependencies(tid);
 				if(queue) queue->require_collective_group(task_ref.get_collective_group_id());
-				prune_tasks_before_last_epoch_reached();
+				prune_tasks_before_latest_epoch_reached();
 			}
 			invoke_callbacks(tid);
 			if(need_new_horizon()) { generate_horizon_task(); }
@@ -171,8 +171,8 @@ namespace detail {
 		std::unordered_map<task_id, std::unique_ptr<task>> task_map;
 
 		// The active epoch is used as the last writer for host-initialized buffers.
-		// To ensure correct ordering, all tasks that have no other true-dependencies depend on this task.
 		// This is useful so we can correctly generate anti-dependencies onto tasks that read host-initialized buffers.
+		// To ensure correct ordering, all tasks that have no other true-dependencies depend on this task.
 		task_id epoch_for_new_tasks{initial_epoch_task};
 
 		// We store a map of which task last wrote to a certain region of a buffer.
@@ -207,7 +207,7 @@ namespace detail {
 		// The last epoch task that has been processed by the executor. Behind a monitor to allow awaiting this change from the main thread.
 		epoch_monitor latest_epoch_reached{initial_epoch_task};
 
-		// The last epoch that was used in task pruning after being reached. This allows skipping the pruning step if no new was completed since.
+		// The last epoch that was used in task pruning after being reached. This allows skipping the pruning step if no new epoch was completed since.
 		task_id last_pruned_before{initial_epoch_task};
 
 		// Set of tasks with no dependents
@@ -234,7 +234,7 @@ namespace detail {
 		task_id generate_horizon_task();
 
 		// Needs to be called while task map accesses are safe (ie. mutex is locked)
-		void prune_tasks_before_last_epoch_reached();
+		void prune_tasks_before_latest_epoch_reached();
 
 		void compute_dependencies(task_id tid);
 	};

--- a/include/utils.h
+++ b/include/utils.h
@@ -3,21 +3,28 @@
 #include <cstdint>
 #include <type_traits>
 
-namespace celerity {
-namespace detail {
-	namespace utils {
+namespace celerity::detail::utils {
 
-		template <typename BitMaskT>
-		constexpr inline uint32_t popcount(const BitMaskT bit_mask) noexcept {
-			static_assert(std::is_integral_v<BitMaskT> && std::is_unsigned_v<BitMaskT>, "popcount argument needs to be an unsigned integer type.");
+template <typename BitMaskT>
+constexpr inline uint32_t popcount(const BitMaskT bit_mask) noexcept {
+	static_assert(std::is_integral_v<BitMaskT> && std::is_unsigned_v<BitMaskT>, "popcount argument needs to be an unsigned integer type.");
 
-			uint32_t counter = 0;
-			for(auto b = bit_mask; b; b >>= 1) {
-				counter += b & 1;
-			}
-			return counter;
-		}
+	uint32_t counter = 0;
+	for(auto b = bit_mask; b; b >>= 1) {
+		counter += b & 1;
+	}
+	return counter;
+}
 
-	} // namespace utils
-} // namespace detail
-} // namespace celerity
+template <typename... F>
+struct overload : F... {
+	explicit constexpr overload(F... f) : F(f)... {}
+	using F::operator()...;
+};
+
+template <typename Variant, typename... Arms>
+decltype(auto) match(Variant&& v, Arms&&... arms) {
+	return std::visit(overload{std::forward<Arms>(arms)...}, std::forward<Variant>(v));
+}
+
+} // namespace celerity::detail::utils

--- a/include/worker_job.h
+++ b/include/worker_job.h
@@ -37,9 +37,7 @@ namespace detail {
 
 	  protected:
 		template <typename... Es>
-		explicit worker_job(command_pkg pkg, std::tuple<Es...> ctx = {})
-		    : pkg(pkg), lctx(pkg.tid.has_value() ? log_context{std::tuple_cat(std::tuple{"task", *pkg.tid, "job", pkg.cid}, ctx)}
-		                                         : log_context{std::tuple_cat(std::tuple{"job", pkg.cid}, ctx)}) {}
+		explicit worker_job(command_pkg pkg, std::tuple<Es...> ctx = {}) : pkg(pkg), lctx(make_log_context(pkg, ctx)) {}
 
 	  private:
 		command_pkg pkg;
@@ -54,6 +52,15 @@ namespace detail {
 		std::chrono::microseconds bench_min = std::numeric_limits<std::chrono::microseconds>::max();
 		std::chrono::microseconds bench_max = std::numeric_limits<std::chrono::microseconds>::min();
 
+		template <typename... Es>
+		log_context make_log_context(const command_pkg& pkg, const std::tuple<Es...>& ctx = {}) {
+			if(const auto tid = pkg.get_tid()) {
+				return log_context{std::tuple_cat(std::tuple{"task", *tid, "job", pkg.cid}, ctx)};
+			} else {
+				return log_context{std::tuple_cat(std::tuple{"job", pkg.cid}, ctx)};
+			}
+		}
+
 		virtual bool execute(const command_pkg& pkg) = 0;
 
 		/**
@@ -64,7 +71,7 @@ namespace detail {
 
 	class horizon_job : public worker_job {
 	  public:
-		horizon_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm) { assert(pkg.cmd == command_type::HORIZON); }
+		horizon_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm) { assert(pkg.get_command_type() == command_type::HORIZON); }
 
 	  private:
 		task_manager& task_mngr;
@@ -76,7 +83,7 @@ namespace detail {
 	class epoch_job : public worker_job {
 	  public:
 		epoch_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm), action(std::get<epoch_data>(pkg.data).action) {
-			assert(pkg.cmd == command_type::EPOCH);
+			assert(pkg.get_command_type() == command_type::EPOCH);
 		}
 
 		epoch_action get_epoch_action() const { return action; }
@@ -94,7 +101,9 @@ namespace detail {
 	 */
 	class await_push_job : public worker_job {
 	  public:
-		await_push_job(command_pkg pkg, buffer_transfer_manager& btm) : worker_job(pkg), btm(btm) { assert(pkg.cmd == command_type::AWAIT_PUSH); }
+		await_push_job(command_pkg pkg, buffer_transfer_manager& btm) : worker_job(pkg), btm(btm) {
+			assert(pkg.get_command_type() == command_type::AWAIT_PUSH);
+		}
 
 	  private:
 		buffer_transfer_manager& btm;
@@ -107,7 +116,7 @@ namespace detail {
 	class push_job : public worker_job {
 	  public:
 		push_job(command_pkg pkg, buffer_transfer_manager& btm, buffer_manager& bm) : worker_job(pkg), btm(btm), buffer_mngr(bm) {
-			assert(pkg.cmd == command_type::PUSH);
+			assert(pkg.get_command_type() == command_type::PUSH);
 		}
 
 	  private:
@@ -122,7 +131,7 @@ namespace detail {
 	class reduction_job : public worker_job {
 	  public:
 		reduction_job(command_pkg pkg, reduction_manager& rm) : worker_job(pkg, std::tuple{"rid", std::get<reduction_data>(pkg.data).rid}), rm(rm) {
-			assert(pkg.cmd == command_type::REDUCTION);
+			assert(pkg.get_command_type() == command_type::REDUCTION);
 		}
 
 	  private:
@@ -137,7 +146,7 @@ namespace detail {
 	  public:
 		host_execute_job(command_pkg pkg, detail::host_queue& queue, detail::task_manager& tm, buffer_manager& bm)
 		    : worker_job(pkg), queue(queue), task_mngr(tm), buffer_mngr(bm) {
-			assert(pkg.cmd == command_type::EXECUTION);
+			assert(pkg.get_command_type() == command_type::EXECUTION);
 		}
 
 	  private:
@@ -159,7 +168,7 @@ namespace detail {
 	  public:
 		device_execute_job(command_pkg pkg, detail::device_queue& queue, detail::task_manager& tm, buffer_manager& bm, reduction_manager& rm, node_id local_nid)
 		    : worker_job(pkg), queue(queue), task_mngr(tm), buffer_mngr(bm), reduction_mngr(rm), local_nid(local_nid) {
-			assert(pkg.cmd == command_type::EXECUTION);
+			assert(pkg.get_command_type() == command_type::EXECUTION);
 		}
 
 	  private:

--- a/include/worker_job.h
+++ b/include/worker_job.h
@@ -77,8 +77,11 @@ namespace detail {
 	  public:
 		epoch_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm) { assert(pkg.cmd == command_type::EPOCH); }
 
+		epoch_action get_epoch_action() const { return action; }
+
 	  private:
 		task_manager& task_mngr;
+		epoch_action action;
 
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;

--- a/include/worker_job.h
+++ b/include/worker_job.h
@@ -73,6 +73,17 @@ namespace detail {
 		std::string get_description(const command_pkg& pkg) override;
 	};
 
+	class epoch_job : public worker_job {
+	  public:
+		epoch_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm) { assert(pkg.cmd == command_type::EPOCH); }
+
+	  private:
+		task_manager& task_mngr;
+
+		bool execute(const command_pkg& pkg) override;
+		std::string get_description(const command_pkg& pkg) override;
+	};
+
 	/**
 	 * Informs the data_transfer_manager about the awaited push, then waits until the transfer has been received and completed.
 	 */

--- a/src/buffer_transfer_manager.cc
+++ b/src/buffer_transfer_manager.cc
@@ -12,7 +12,7 @@ namespace celerity {
 namespace detail {
 
 	std::shared_ptr<const buffer_transfer_manager::transfer_handle> buffer_transfer_manager::push(const command_pkg& pkg) {
-		assert(pkg.cmd == command_type::PUSH);
+		assert(pkg.get_command_type() == command_type::PUSH);
 		auto t_handle = std::make_shared<transfer_handle>();
 		// We are blocking the caller until the buffer has been copied and submitted to MPI
 		// TODO: Investigate doing this in worker thread
@@ -42,7 +42,7 @@ namespace detail {
 	}
 
 	std::shared_ptr<const buffer_transfer_manager::transfer_handle> buffer_transfer_manager::await_push(const command_pkg& pkg) {
-		assert(pkg.cmd == command_type::AWAIT_PUSH);
+		assert(pkg.get_command_type() == command_type::AWAIT_PUSH);
 		const auto& data = std::get<await_push_data>(pkg.data);
 
 		std::shared_ptr<incoming_transfer_handle> t_handle;

--- a/src/command_graph.cc
+++ b/src/command_graph.cc
@@ -25,8 +25,8 @@ namespace detail {
 		}
 	}
 
-	std::optional<std::string> command_graph::print_graph(size_t max_nodes) const {
-		if(command_count() <= max_nodes) { return detail::print_graph(*this); }
+	std::optional<std::string> command_graph::print_graph(size_t max_nodes, const task_manager& tm) const {
+		if(command_count() <= max_nodes) { return detail::print_command_graph(*this, tm); }
 		return std::nullopt;
 	}
 

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -152,7 +152,7 @@ namespace detail {
 	}
 
 	bool executor::handle_command(const command_pkg& pkg, const std::vector<command_id>& dependencies) {
-		// A worker might receive a task command before creating the corresponding horizon task itself
+		// A worker might receive a task command before creating the corresponding task graph node
 		if(const auto tid = pkg.get_tid()) {
 			if(!task_mngr.has_task(*tid)) { return false; }
 		}

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -170,6 +170,14 @@ namespace detail {
 			create_job<horizon_job>(pkg, dependencies, task_mngr);
 			break;
 		}
+		case command_type::EPOCH: {
+			// Similar to task commands, a worker might receive the horizon command before creating the corresponding horizon task
+			const auto epoch_tid = std::get<epoch_data>(pkg.data).tid;
+			if(!task_mngr.has_task(epoch_tid)) return false;
+
+			create_job<epoch_job>(pkg, dependencies, task_mngr);
+			break;
+		}
 		case command_type::PUSH: create_job<push_job>(pkg, dependencies, *btm, buffer_mngr); break;
 		case command_type::AWAIT_PUSH: create_job<await_push_job>(pkg, dependencies, *btm); break;
 		case command_type::REDUCTION: create_job<reduction_job>(pkg, dependencies, reduction_mngr); break;

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -153,23 +153,18 @@ namespace detail {
 
 	bool executor::handle_command(const command_pkg& pkg, const std::vector<command_id>& dependencies) {
 		// A worker might receive a task command before creating the corresponding horizon task itself
-		if(pkg.tid && !task_mngr.has_task(*pkg.tid)) { return false; }
+		if(const auto tid = pkg.get_tid()) {
+			if(!task_mngr.has_task(*tid)) { return false; }
+		}
 
-		switch(pkg.cmd) {
-		case command_type::HORIZON:
-			assert(pkg.tid.has_value());
-			create_job<horizon_job>(pkg, dependencies, task_mngr);
-			break;
-		case command_type::EPOCH:
-			assert(pkg.tid.has_value());
-			create_job<epoch_job>(pkg, dependencies, task_mngr);
-			break;
+		switch(pkg.get_command_type()) {
+		case command_type::HORIZON: create_job<horizon_job>(pkg, dependencies, task_mngr); break;
+		case command_type::EPOCH: create_job<epoch_job>(pkg, dependencies, task_mngr); break;
 		case command_type::PUSH: create_job<push_job>(pkg, dependencies, *btm, buffer_mngr); break;
 		case command_type::AWAIT_PUSH: create_job<await_push_job>(pkg, dependencies, *btm); break;
 		case command_type::REDUCTION: create_job<reduction_job>(pkg, dependencies, reduction_mngr); break;
 		case command_type::EXECUTION:
-			assert(pkg.tid.has_value());
-			if(task_mngr.get_task(*pkg.tid)->get_execution_target() == execution_target::HOST) {
+			if(task_mngr.get_task(std::get<execution_data>(pkg.data).tid)->get_execution_target() == execution_target::HOST) {
 				create_job<host_execute_job>(pkg, dependencies, h_queue, task_mngr, buffer_mngr);
 			} else {
 				create_job<device_execute_job>(pkg, dependencies, d_queue, task_mngr, buffer_mngr, reduction_mngr, local_nid);

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -119,6 +119,7 @@ namespace detail {
 					return false;
 				});
 			}
+
 			current_min_epoch_cid = new_min_epoch_cid;
 			return;
 		}

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -497,7 +497,7 @@ namespace detail {
 				// need is mutual exclusion (i.e. a bi-directional pseudo-dependency).
 				nd.host_object_last_effects.insert_or_assign(hoid, cmd->get_cid());
 
-				cmd->debug_label += fmt::format("affect host-object {}\n", hoid);
+				cmd->debug_label += fmt::format("affect host-object {}\\n", hoid);
 			}
 		}
 	}

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -90,7 +90,10 @@ namespace detail {
 		command_pkg pkg;
 		pkg.cid = cmd->get_cid();
 
-		if(const auto* xcmd = dynamic_cast<execution_command*>(cmd)) {
+		if(const auto* ecmd = dynamic_cast<epoch_command*>(cmd)) {
+			pkg.cmd = command_type::EPOCH;
+			pkg.data = epoch_data{ecmd->get_tid()};
+		} else if(const auto* xcmd = dynamic_cast<execution_command*>(cmd)) {
 			pkg.cmd = command_type::EXECUTION;
 			pkg.data = execution_data{xcmd->get_tid(), xcmd->get_execution_range(), xcmd->is_reduction_initializer()};
 		} else if(const auto* pcmd = dynamic_cast<push_command*>(cmd)) {

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -92,7 +92,7 @@ namespace detail {
 
 		if(const auto* ecmd = dynamic_cast<epoch_command*>(cmd)) {
 			pkg.cmd = command_type::EPOCH;
-			pkg.data = epoch_data{ecmd->get_tid()};
+			pkg.data = epoch_data{ecmd->get_tid(), ecmd->get_epoch_action()};
 		} else if(const auto* xcmd = dynamic_cast<execution_command*>(cmd)) {
 			pkg.cmd = command_type::EXECUTION;
 			pkg.data = execution_data{xcmd->get_tid(), xcmd->get_execution_range(), xcmd->is_reduction_initializer()};

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -89,26 +89,19 @@ namespace detail {
 
 		command_pkg pkg;
 		pkg.cid = cmd->get_cid();
-		if(const auto* tcmd = dynamic_cast<task_command*>(cmd)) { pkg.tid = tcmd->get_tid(); }
-
 		if(const auto* ecmd = dynamic_cast<epoch_command*>(cmd)) {
-			pkg.cmd = command_type::EPOCH;
-			pkg.data = epoch_data{ecmd->get_epoch_action()};
+			pkg.data = epoch_data{ecmd->get_tid(), ecmd->get_epoch_action()};
 		} else if(const auto* xcmd = dynamic_cast<execution_command*>(cmd)) {
-			pkg.cmd = command_type::EXECUTION;
-			pkg.data = execution_data{xcmd->get_execution_range(), xcmd->is_reduction_initializer()};
+			pkg.data = execution_data{xcmd->get_tid(), xcmd->get_execution_range(), xcmd->is_reduction_initializer()};
 		} else if(const auto* pcmd = dynamic_cast<push_command*>(cmd)) {
-			pkg.cmd = command_type::PUSH;
 			pkg.data = push_data{pcmd->get_bid(), pcmd->get_rid(), pcmd->get_target(), pcmd->get_range()};
 		} else if(const auto* apcmd = dynamic_cast<await_push_command*>(cmd)) {
-			pkg.cmd = command_type::AWAIT_PUSH;
 			auto* source = apcmd->get_source();
 			pkg.data = await_push_data{source->get_bid(), source->get_rid(), source->get_nid(), source->get_cid(), source->get_range()};
 		} else if(const auto* rcmd = dynamic_cast<reduction_command*>(cmd)) {
-			pkg.cmd = command_type::REDUCTION;
 			pkg.data = reduction_data{rcmd->get_rid()};
 		} else if(const auto* hcmd = dynamic_cast<horizon_command*>(cmd)) {
-			pkg.cmd = command_type::HORIZON;
+			pkg.data = horizon_data{hcmd->get_tid()};
 		} else {
 			assert(false && "Unknown command");
 		}

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -36,7 +36,7 @@ namespace detail {
 			cad.first = cmd;
 
 			// Iterate over first level of dependencies.
-			// These might either be data transfer commands, or task commands from other tasks.
+			// These might either be commands from other tasks that have been flushed previously or generated data transfer / reduction commands.
 			for(auto d : cmd->get_dependencies()) {
 				if(!flushed_manually(d.node)) { cad.second.push_back(d.node->get_cid()); }
 

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -89,13 +89,14 @@ namespace detail {
 
 		command_pkg pkg;
 		pkg.cid = cmd->get_cid();
+		if(const auto* tcmd = dynamic_cast<task_command*>(cmd)) { pkg.tid = tcmd->get_tid(); }
 
 		if(const auto* ecmd = dynamic_cast<epoch_command*>(cmd)) {
 			pkg.cmd = command_type::EPOCH;
-			pkg.data = epoch_data{ecmd->get_tid(), ecmd->get_epoch_action()};
+			pkg.data = epoch_data{ecmd->get_epoch_action()};
 		} else if(const auto* xcmd = dynamic_cast<execution_command*>(cmd)) {
 			pkg.cmd = command_type::EXECUTION;
-			pkg.data = execution_data{xcmd->get_tid(), xcmd->get_execution_range(), xcmd->is_reduction_initializer()};
+			pkg.data = execution_data{xcmd->get_execution_range(), xcmd->is_reduction_initializer()};
 		} else if(const auto* pcmd = dynamic_cast<push_command*>(cmd)) {
 			pkg.cmd = command_type::PUSH;
 			pkg.data = push_data{pcmd->get_bid(), pcmd->get_rid(), pcmd->get_target(), pcmd->get_range()};
@@ -108,7 +109,6 @@ namespace detail {
 			pkg.data = reduction_data{rcmd->get_rid()};
 		} else if(const auto* hcmd = dynamic_cast<horizon_command*>(cmd)) {
 			pkg.cmd = command_type::HORIZON;
-			pkg.data = horizon_data{hcmd->get_tid()};
 		} else {
 			assert(false && "Unknown command");
 		}

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -66,6 +66,8 @@ namespace detail {
 		std::string label = fmt::format("[{}] Node {}:\\n", cmd->get_cid(), cmd->get_nid());
 		if(const auto ecmd = dynamic_cast<const epoch_command*>(cmd)) {
 			label += "EPOCH";
+			if(ecmd->get_epoch_action() == epoch_action::barrier) { label += " (barrier)"; }
+			if(ecmd->get_epoch_action() == epoch_action::shutdown) { label += " (shutdown)"; }
 		} else if(const auto xcmd = dynamic_cast<const execution_command*>(cmd)) {
 			label += fmt::format("EXECUTION {}\\n{}", subrange_to_grid_box(xcmd->get_execution_range()), cmd->debug_label);
 		} else if(const auto pcmd = dynamic_cast<const push_command*>(cmd)) {

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -18,8 +18,8 @@ namespace detail {
 		if(dep.kind == dependency_kind::ANTI_DEP) return "color=limegreen";
 		switch(dep.origin) {
 		case dependency_origin::collective_group_serialization: return "color=blue";
-		case dependency_origin::horizon_ordering: return "color=orange";
-		case dependency_origin::epoch_fallback: return "color=orchid";
+		case dependency_origin::execution_front: return "color=orange";
+		case dependency_origin::current_epoch: return "color=orchid";
 		default: return "";
 		}
 	}

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -19,7 +19,7 @@ namespace detail {
 		switch(dep.origin) {
 		case dependency_origin::collective_group_serialization: return "color=blue";
 		case dependency_origin::execution_front: return "color=orange";
-		case dependency_origin::current_epoch: return "color=orchid";
+		case dependency_origin::last_epoch: return "color=orchid";
 		default: return "";
 		}
 	}

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -209,7 +209,7 @@ namespace detail {
 				}
 			}
 			{
-				const auto graph_str = cdag->print_graph(print_max_nodes);
+				const auto graph_str = cdag->print_graph(print_max_nodes, *task_mngr);
 				if(graph_str.has_value()) {
 					CELERITY_TRACE("Command graph:\n\n{}\n", *graph_str);
 				} else {

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -140,7 +140,7 @@ namespace detail {
 			gsrlzr = std::make_unique<graph_serializer>(*cdag,
 			    [this](node_id target, const command_pkg& pkg, const std::vector<command_id>& dependencies) { flush_command(target, pkg, dependencies); });
 			schdlr = std::make_unique<scheduler>(*ggen, *gsrlzr, num_nodes);
-			task_mngr->register_task_callback([this](task_id tid, task_type type) { schdlr->notify_task_created(tid); });
+			task_mngr->register_task_callback([this](task_id tid) { schdlr->notify_task_created(tid); });
 		}
 
 		CELERITY_INFO(
@@ -188,12 +188,13 @@ namespace detail {
 	void runtime::shutdown() noexcept {
 		assert(is_active);
 		is_shutting_down = true;
-		const auto final_epoch = task_mngr->end_epoch(epoch_action::shutdown);
-		if(is_master_node()) {
-			schdlr->shutdown();
-		}
 
-		task_mngr->await_epoch(final_epoch);
+		const auto final_epoch = task_mngr->finish_epoch(epoch_action::shutdown);
+
+		if(is_master_node()) { schdlr->shutdown(); }
+
+		task_mngr->await_epoch_completed(final_epoch);
+
 		exec->shutdown();
 		d_queue->wait();
 		h_queue->wait();
@@ -229,8 +230,8 @@ namespace detail {
 	}
 
 	void runtime::sync() noexcept {
-		const auto new_epoch = task_mngr->end_epoch(epoch_action::barrier);
-		task_mngr->await_epoch(new_epoch);
+		const auto epoch = task_mngr->finish_epoch(epoch_action::barrier);
+		task_mngr->await_epoch_completed(epoch);
 	}
 
 	task_manager& runtime::get_task_manager() const { return *task_mngr; }

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -189,11 +189,11 @@ namespace detail {
 		assert(is_active);
 		is_shutting_down = true;
 
-		const auto final_epoch = task_mngr->finish_epoch(epoch_action::shutdown);
+		const auto shutdown_epoch = task_mngr->generate_epoch_task(epoch_action::shutdown);
 
 		if(is_master_node()) { schdlr->shutdown(); }
 
-		task_mngr->await_epoch_completed(final_epoch);
+		task_mngr->await_epoch(shutdown_epoch);
 
 		exec->shutdown();
 		d_queue->wait();
@@ -230,8 +230,8 @@ namespace detail {
 	}
 
 	void runtime::sync() noexcept {
-		const auto epoch = task_mngr->finish_epoch(epoch_action::barrier);
-		task_mngr->await_epoch_completed(epoch);
+		const auto epoch = task_mngr->generate_epoch_task(epoch_action::barrier);
+		task_mngr->await_epoch(epoch);
 	}
 
 	task_manager& runtime::get_task_manager() const { return *task_mngr; }

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -13,11 +13,6 @@ namespace detail {
 
 	void abstract_scheduler::shutdown() { notify(scheduler_event_type::SHUTDOWN, 0); }
 
-	bool abstract_scheduler::is_idle() const noexcept {
-		std::lock_guard<std::mutex> lock(events_mutex);
-		return events.empty();
-	}
-
 	void abstract_scheduler::schedule() {
 		std::unique_lock<std::mutex> lk(events_mutex);
 

--- a/src/worker_job.cc
+++ b/src/worker_job.cc
@@ -59,6 +59,22 @@ namespace detail {
 	};
 
 	// --------------------------------------------------------------------------------------------------------------------
+	// ---------------------------------------------------- EPOCH ---------------------------------------------------------
+	// --------------------------------------------------------------------------------------------------------------------
+
+	std::string epoch_job::get_description(const command_pkg& pkg) { return "EPOCH"; }
+
+	bool epoch_job::execute(const command_pkg& pkg) {
+		// This barrier currently enables profiling Celerity programs on a cluster by issuing a queue.slow_full_sync() and
+		// then observing the execution times of barriers. TODO remove this once we have a better profiling workflow.
+		MPI_Barrier(MPI_COMM_WORLD);
+
+		const auto data = std::get<epoch_data>(pkg.data);
+		task_mngr.notify_epoch_ended(data.tid);
+		return true;
+	};
+
+	// --------------------------------------------------------------------------------------------------------------------
 	// --------------------------------------------------- AWAIT PUSH -----------------------------------------------------
 	// --------------------------------------------------------------------------------------------------------------------
 

--- a/src/worker_job.cc
+++ b/src/worker_job.cc
@@ -54,7 +54,7 @@ namespace detail {
 
 	bool horizon_job::execute(const command_pkg& pkg) {
 		const auto data = std::get<horizon_data>(pkg.data);
-		task_mngr.notify_horizon_completed(data.tid);
+		task_mngr.notify_horizon_reached(data.tid);
 		return true;
 	};
 
@@ -72,7 +72,7 @@ namespace detail {
 		// then observing the execution times of barriers. TODO remove this once we have a better profiling workflow.
 		if(action == epoch_action::barrier) { MPI_Barrier(MPI_COMM_WORLD); }
 
-		task_mngr.notify_epoch_completed(data.tid);
+		task_mngr.notify_epoch_reached(data.tid);
 		return true;
 	};
 

--- a/src/worker_job.cc
+++ b/src/worker_job.cc
@@ -65,11 +65,13 @@ namespace detail {
 	std::string epoch_job::get_description(const command_pkg& pkg) { return "EPOCH"; }
 
 	bool epoch_job::execute(const command_pkg& pkg) {
+		const auto data = std::get<epoch_data>(pkg.data);
+		action = data.action;
+
 		// This barrier currently enables profiling Celerity programs on a cluster by issuing a queue.slow_full_sync() and
 		// then observing the execution times of barriers. TODO remove this once we have a better profiling workflow.
-		MPI_Barrier(MPI_COMM_WORLD);
+		if(action == epoch_action::barrier) { MPI_Barrier(MPI_COMM_WORLD); }
 
-		const auto data = std::get<epoch_data>(pkg.data);
 		task_mngr.notify_epoch_ended(data.tid);
 		return true;
 	};

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -63,6 +63,8 @@ struct task_manager_benchmark_context {
 	task_manager tm{1, nullptr, nullptr};
 	test_utils::mock_buffer_factory mbf{&tm};
 
+	~task_manager_benchmark_context() { tm.generate_epoch_task(celerity::detail::epoch_action::shutdown); }
+
 	template <int KernelDims, typename CGF>
 	void create_task(range<KernelDims> global_range, CGF cgf) {
 		tm.submit_command_group([=](handler& cgh) {
@@ -88,6 +90,8 @@ struct graph_generator_benchmark_context {
 			gsrlzr.flush(tid);
 		});
 	}
+
+	~graph_generator_benchmark_context() { tm.generate_epoch_task(celerity::detail::epoch_action::shutdown); }
 
 	template <int KernelDims, typename CGF>
 	void create_task(range<KernelDims> global_range, CGF cgf) {
@@ -187,6 +191,7 @@ struct scheduler_benchmark_context {
 	}
 
 	~scheduler_benchmark_context() {
+		tm.generate_epoch_task(celerity::detail::epoch_action::shutdown);
 		// scheduler operates in a FIFO manner, so awaiting shutdown will await processing of all pending tasks first
 		schdlr.shutdown();
 	}

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -65,7 +65,7 @@ struct task_manager_benchmark_context {
 
 	template <int KernelDims, typename CGF>
 	void create_task(range<KernelDims> global_range, CGF cgf) {
-		tm.create_task([=](handler& cgh) {
+		tm.submit_command_group([=](handler& cgh) {
 			cgf(cgh);
 			cgh.host_task(global_range, [](partition<KernelDims>) {});
 		});
@@ -92,7 +92,7 @@ struct graph_generator_benchmark_context {
 	template <int KernelDims, typename CGF>
 	void create_task(range<KernelDims> global_range, CGF cgf) {
 		// note: This ignores communication overhead with the scheduler thread
-		tm.create_task([=](handler& cgh) {
+		tm.submit_command_group([=](handler& cgh) {
 			cgf(cgh);
 			cgh.host_task(global_range, [](partition<KernelDims>) {});
 		});
@@ -193,7 +193,7 @@ struct scheduler_benchmark_context {
 
 	template <int KernelDims, typename CGF>
 	void create_task(range<KernelDims> global_range, CGF cgf) {
-		const auto tid = tm.create_task([=](handler& cgh) {
+		const auto tid = tm.submit_command_group([=](handler& cgh) {
 			cgf(cgh);
 			cgh.host_task(global_range, [](partition<KernelDims>) {});
 		});

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -28,7 +28,7 @@ TEMPLATE_TEST_CASE_SIG("benchmark intrusive graph dependency handling with N nod
 		bench_graph_node n0;
 		bench_graph_node nodes[N];
 		for(int i = 0; i < N; ++i) {
-			n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP});
+			n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 		}
 		return n0.get_dependencies();
 	};
@@ -37,7 +37,7 @@ TEMPLATE_TEST_CASE_SIG("benchmark intrusive graph dependency handling with N nod
 	bench_graph_node nodes[N];
 	BENCHMARK("adding and removing dependencies") {
 		for(int i = 0; i < N; ++i) {
-			n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP});
+			n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 		}
 		for(int i = 0; i < N; ++i) {
 			n0.remove_dependency(&nodes[i]);
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE_SIG("benchmark intrusive graph dependency handling with N nod
 	};
 
 	for(int i = 0; i < N; ++i) {
-		n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP});
+		n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 	}
 	BENCHMARK("checking for dependencies") {
 		int d = 0;
@@ -389,5 +389,5 @@ TEST_CASE("printing benchmark task graphs", "[.][debug-graphs][task-graph]") {
 }
 
 TEST_CASE("printing benchmark command graphs", "[.][debug-graphs][command-graph]") {
-	debug_graphs([] { return graph_generator_benchmark_context{2}; }, [](auto&& ctx) { test_utils::maybe_print_graph(ctx.cdag); });
+	debug_graphs([] { return graph_generator_benchmark_context{2}; }, [](auto&& ctx) { test_utils::maybe_print_graph(ctx.cdag, ctx.tm); });
 }

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -82,7 +82,7 @@ struct graph_generator_benchmark_context {
 	test_utils::mock_buffer_factory mbf{&tm, &ggen};
 
 	explicit graph_generator_benchmark_context(size_t num_nodes) : num_nodes{num_nodes} {
-		tm.register_task_callback([this](const task_id tid, const task_type) {
+		tm.register_task_callback([this](const task_id tid) {
 			naive_split_transformer transformer{this->num_nodes, this->num_nodes};
 			ggen.build_task(tid, {&transformer});
 			gsrlzr.flush(tid);

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -92,10 +92,8 @@ namespace detail {
 			        full_range));
 		}
 
-		// -1: The first task has no dependencies and thus does not increase the critical path length
-		const auto tasks_increasing_critical_path_length = num_timesteps - 1;
 		// ggen cleans up before the applied horizon as soon as the first task after the current horizon is created
-		const auto commands_after_last_horizon = tasks_increasing_critical_path_length % horizon_step_size;
+		const auto commands_after_last_horizon = num_timesteps % horizon_step_size;
 		const auto commands_contributing_to_writer_map = 1 /* horizon */ + horizon_step_size /* commands between horizons */ + commands_after_last_horizon;
 		const auto applied_horizons_remaining = commands_after_last_horizon > 0 ? 1 : 2;
 
@@ -107,7 +105,7 @@ namespace detail {
 		CHECK(buf_a_last_writer_map_size <= num_nodes * commands_contributing_to_writer_map);
 
 		// count all horizons that ever existed, because we compare against inspector recordings
-		const auto total_horizons_per_node = tasks_increasing_critical_path_length / horizon_step_size;
+		const auto total_horizons_per_node = num_timesteps / horizon_step_size;
 		for(node_id n = 0; n < num_nodes; ++n) {
 			CAPTURE(n);
 			const auto total_horizons = static_cast<int>(inspector.get_commands(std::nullopt, n, command_type::HORIZON).size());

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -460,7 +460,7 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(writer)>(
 		        tm, [&](handler& cgh) { buf_written_from_kernel.get_access<mode::discard_write>(cgh, one_to_one{}); }, node_range));
 
-		const auto epoch_tid = test_utils::build_and_flush(ctx, num_nodes, tm.end_epoch());
+		const auto epoch_tid = test_utils::build_and_flush(ctx, num_nodes, tm.end_epoch(epoch_action::none));
 
 		const auto reader_writer_tid = test_utils::build_and_flush(ctx, num_nodes,
 		    test_utils::add_compute_task<class UKN(reader_writer)>(

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -371,7 +371,7 @@ namespace detail {
 			REQUIRE(master_node_dep != second_deps.end());
 			CHECK(master_node_dep->kind == dependency_kind::TRUE_DEP);
 			REQUIRE(horizon_dep != second_deps.end());
-			CHECK(horizon_dep->kind == dependency_kind::ORDER_DEP);
+			CHECK(horizon_dep->kind == dependency_kind::TRUE_DEP);
 		}
 
 		test_utils::maybe_print_graphs(ctx);

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -298,7 +298,7 @@ namespace detail {
 				const auto current_horizon = task_manager_testspy::get_current_horizon(ctx.get_task_manager());
 				if(current_horizon && *current_horizon > last_executed_horizon) {
 					last_executed_horizon = *current_horizon;
-					ctx.get_task_manager().notify_horizon_completed(last_executed_horizon);
+					ctx.get_task_manager().notify_horizon_reached(last_executed_horizon);
 				}
 			}
 		}
@@ -466,7 +466,7 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(writer)>(
 		        tm, [&](handler& cgh) { buf_written_from_kernel.get_access<mode::discard_write>(cgh, one_to_one{}); }, node_range));
 
-		const auto epoch_tid = test_utils::build_and_flush(ctx, num_nodes, tm.finish_epoch(epoch_action::none));
+		const auto epoch_tid = test_utils::build_and_flush(ctx, num_nodes, tm.generate_epoch_task(epoch_action::none));
 
 		const auto reader_writer_tid = test_utils::build_and_flush(ctx, num_nodes,
 		    test_utils::add_compute_task<class UKN(reader_writer)>(
@@ -487,7 +487,7 @@ namespace detail {
 		REQUIRE(tm.has_task(epoch_tid));
 		check_task_has_exact_dependencies("epoch before", epoch_tid, {{writer_tid, dependency_kind::TRUE_DEP, dependency_origin::execution_front}});
 
-		tm.notify_epoch_completed(epoch_tid);
+		tm.notify_epoch_reached(epoch_tid);
 
 		const auto reader_tid = test_utils::build_and_flush(ctx, num_nodes,
 		    test_utils::add_compute_task<class UKN(reader)>(

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -135,9 +135,10 @@ namespace detail {
 		// For this test, we need to generate 2 horizons but still have the first one be relevant
 		// after the second is generated -> use 2 buffers A and B, with a longer task chan on A, and write to B later
 		// step size is set to ensure expected horizons
-		ctx.get_task_manager().set_horizon_step(1);
+		ctx.get_task_manager().set_horizon_step(2);
 
 		auto& inspector = ctx.get_inspector();
+		auto& cdag = ctx.get_command_graph();
 		test_utils::mock_buffer_factory mbf(ctx);
 		auto full_range = cl::sycl::range<1>(100);
 		auto buf_a = mbf.create_buffer<1>(full_range);
@@ -160,8 +161,8 @@ namespace detail {
 
 		// here, the first horizon should have been generated
 
-		// do 1 more read/writes on buf_a to generate another horizon and apply the first one
-		for(int i = 0; i < 1; ++i) {
+		// do 3 more read/writes on buf_a to generate another horizon and apply the first one
+		for(int i = 0; i < 3; ++i) {
 			test_utils::build_and_flush(ctx, NUM_NODES,
 			    test_utils::add_compute_task<class UKN(buf_a_rw)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read_write>(cgh, one_to_one{}); }, full_range));
@@ -171,19 +172,30 @@ namespace detail {
 
 		auto write_b_after_first_horizon = test_utils::build_and_flush(ctx, NUM_NODES,
 		    test_utils::add_compute_task<class UKN(write_b_after_first_horizon)>(
-		        ctx.get_task_manager(), [&](handler& cgh) { buf_b.get_access<mode::discard_write>(cgh, one_to_one{}); }, full_range));
+		        ctx.get_task_manager(),
+		        [&](handler& cgh) {
+			        // introduce an artificial true dependency to avoid the fallback epoch dependency generated for ordering
+			        buf_a.get_access<mode::read>(cgh, one_to_one{});
+			        buf_b.get_access<mode::discard_write>(cgh, one_to_one{});
+		        },
+		        full_range));
 
 		// Now we need to check various graph properties
 
 		auto cmds = inspector.get_commands(write_b_after_first_horizon, {}, {});
 		CHECK(cmds.size() == 1);
 		auto deps = inspector.get_dependencies(*cmds.cbegin());
-		CHECK(deps.size() == 1);
+		CHECK(deps.size() == 2);
+
+		const auto buffer_a_dep = std::find_if(deps.begin(), deps.end(), [&](const command_id cid) { return isa<execution_command>(cdag.get(cid)); });
+		const auto horizon_dep = std::find_if(deps.begin(), deps.end(), [&](const command_id cid) { return isa<horizon_command>(cdag.get(cid)); });
+		REQUIRE(buffer_a_dep != deps.end());
+		REQUIRE(horizon_dep != deps.end());
 
 		// check that the dependee is the first horizon
 		auto horizon_cmds = inspector.get_commands({}, {}, command_type::HORIZON);
-		CHECK(horizon_cmds.size() == 3);
-		CHECK(deps[0] == *horizon_cmds.cbegin());
+		CHECK(horizon_cmds.size() == 2);
+		CHECK(*horizon_dep == *horizon_cmds.cbegin());
 
 		// and that it's an anti-dependence
 		auto write_b_cmd = ctx.get_command_graph().get(*cmds.cbegin());
@@ -260,7 +272,7 @@ namespace detail {
 			const auto cmds = inspector.get_commands(tid, std::nullopt, std::nullopt);
 			CHECK(cmds.size() == 2);
 			std::transform(cmds.begin(), cmds.end(), initial_last_writer_ids.begin(), [&](auto cid) {
-				// (Implementation detail: We can't use the inspector here b/c NOP commands are not flushed)
+				// (Implementation detail: We can't use the inspector here b/c EPOCH commands are not flushed)
 				const auto deps = ctx.get_command_graph().get(cid)->get_dependencies();
 				REQUIRE(std::distance(deps.begin(), deps.end()) == 1);
 				return deps.begin()->node->get_cid();
@@ -315,25 +327,6 @@ namespace detail {
 		test_utils::maybe_print_graphs(ctx);
 	}
 
-	static void check_task_commands_depend_on_horizon_only(
-	    task_id dependency_without_horizon, task_id task, dependency_kind kind, test_utils::cdag_test_context& ctx) {
-		const auto& inspector = ctx.get_inspector();
-		auto& cdag = ctx.get_command_graph();
-		const auto first_commands = inspector.get_commands(dependency_without_horizon, std::nullopt, std::nullopt);
-		const auto second_commands = inspector.get_commands(task, std::nullopt, std::nullopt);
-		for(const auto second_cid : second_commands) {
-			for(const auto first_cid : first_commands) {
-				CHECK(!inspector.has_dependency(second_cid, first_cid));
-			}
-			const auto second_deps = cdag.get(second_cid)->get_dependencies();
-			CHECK(std::distance(second_deps.begin(), second_deps.end()) == 1);
-			for(const auto& dep : second_deps) {
-				CHECK(dep.kind == kind);
-				CHECK(isa<horizon_command>(dep.node));
-			}
-		}
-	}
-
 	TEST_CASE("commands for collective host tasks do not order-depend on their predecessor if it is shadowed by a horizon",
 	    "[graph_generator][command-graph][horizon]") {
 		// Regression test: the order-dependencies between host tasks in the same collective group are built by tracking the last task command in each
@@ -350,15 +343,36 @@ namespace detail {
 		auto& ggen = ctx.get_graph_generator();
 		test_utils::mock_buffer_factory mbf(&tm, &ggen);
 		auto buf = mbf.create_buffer(range<1>(1));
-		for(int i = 0; i < 5; ++i) {
+		for(int i = 0; i < 4; ++i) {
 			test_utils::build_and_flush(
 			    ctx, test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); }));
 		}
 
 		// This must depend on the first horizon, not first_collective
-		const auto second_collective = test_utils::build_and_flush(ctx, test_utils::add_host_task(tm, experimental::collective, [&](handler& cgh) {}));
+		const auto second_collective = test_utils::build_and_flush(
+		    ctx, test_utils::add_host_task(tm, experimental::collective, [&](handler& cgh) { buf.get_access<access_mode::read>(cgh, all{}); }));
 
-		check_task_commands_depend_on_horizon_only(first_collective, second_collective, dependency_kind::ORDER_DEP, ctx);
+		const auto& inspector = ctx.get_inspector();
+		auto& cdag = ctx.get_command_graph();
+		const auto first_commands = inspector.get_commands(first_collective, std::nullopt, std::nullopt);
+		const auto second_commands = inspector.get_commands(second_collective, std::nullopt, std::nullopt);
+		for(const auto second_cid : second_commands) {
+			for(const auto first_cid : first_commands) {
+				CHECK(!inspector.has_dependency(second_cid, first_cid));
+			}
+
+			const auto second_deps = cdag.get(second_cid)->get_dependencies();
+			const auto master_node_dep =
+			    std::find_if(second_deps.begin(), second_deps.end(), [&](const abstract_command::dependency d) { return isa<execution_command>(d.node); });
+			const auto horizon_dep =
+			    std::find_if(second_deps.begin(), second_deps.end(), [&](const abstract_command::dependency d) { return isa<horizon_command>(d.node); });
+
+			CHECK(std::distance(second_deps.begin(), second_deps.end()) == 2);
+			REQUIRE(master_node_dep != second_deps.end());
+			CHECK(master_node_dep->kind == dependency_kind::TRUE_DEP);
+			REQUIRE(horizon_dep != second_deps.end());
+			CHECK(horizon_dep->kind == dependency_kind::ORDER_DEP);
+		}
 
 		test_utils::maybe_print_graphs(ctx);
 	}
@@ -387,7 +401,21 @@ namespace detail {
 		const auto second_task = test_utils::build_and_flush(
 		    ctx, test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { ho.add_side_effect(cgh, experimental::side_effect_order::sequential); }));
 
-		check_task_commands_depend_on_horizon_only(first_task, second_task, dependency_kind::TRUE_DEP, ctx);
+		const auto& inspector = ctx.get_inspector();
+		auto& cdag = ctx.get_command_graph();
+		const auto first_commands = inspector.get_commands(first_task, std::nullopt, std::nullopt);
+		const auto second_commands = inspector.get_commands(second_task, std::nullopt, std::nullopt);
+		for(const auto second_cid : second_commands) {
+			for(const auto first_cid : first_commands) {
+				CHECK(!inspector.has_dependency(second_cid, first_cid));
+			}
+			const auto second_deps = cdag.get(second_cid)->get_dependencies();
+			CHECK(std::distance(second_deps.begin(), second_deps.end()) == 1);
+			for(const auto& dep : second_deps) {
+				CHECK(dep.kind == dependency_kind::TRUE_DEP);
+				CHECK(isa<horizon_command>(dep.node));
+			}
+		}
 
 		test_utils::maybe_print_graphs(ctx);
 	}

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -37,7 +37,7 @@ namespace detail {
 		command_graph cdag;
 		std::unordered_set<abstract_command*> cmds;
 		cmds.insert(cdag.create<execution_command>(0, 0, subrange<3>{}));
-		cmds.insert(cdag.create<nop_command>(0));
+		cmds.insert(cdag.create<epoch_command>(0, task_manager::initial_epoch_task));
 		cmds.insert(cdag.create<push_command>(0, 0, 0, 0, subrange<3>{}));
 		for(auto cmd : cdag.all_commands()) {
 			REQUIRE(cmds.find(cmd) != cmds.end());
@@ -76,7 +76,7 @@ namespace detail {
 
 	TEST_CASE("isa<> RTTI helper correctly handles command hierarchies", "[rtti][command-graph]") {
 		command_graph cdag;
-		auto np = cdag.create<nop_command>(0);
+		auto np = cdag.create<epoch_command>(0, task_manager::initial_epoch_task);
 		REQUIRE(isa<abstract_command>(np));
 		auto hec = cdag.create<execution_command>(0, 0, subrange<3>{});
 		REQUIRE(isa<execution_command>(hec));
@@ -602,7 +602,8 @@ namespace detail {
 		for(auto tid : {tid_0, tid_1}) {
 			for(auto cid : inspector.get_commands(tid, std::nullopt, std::nullopt)) {
 				const auto deps = cdag.get(cid)->get_dependencies();
-				CHECK(deps.empty());
+				REQUIRE(std::distance(deps.begin(), deps.end()) == 1);
+				CHECK(isa<epoch_command>(deps.front().node));
 			}
 		}
 

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -15,6 +15,7 @@
 namespace celerity {
 namespace detail {
 
+	using celerity::access::all;
 	using celerity::access::fixed;
 	using celerity::access::one_to_one;
 
@@ -618,6 +619,79 @@ namespace detail {
 			}
 		}
 	}
+
+	TEST_CASE("epochs serialize commands on every node", "[graph_generator][command-graph][epoch]") {
+		using namespace cl::sycl::access;
+
+		const size_t num_nodes = 2;
+		const range<2> node_range{num_nodes, 1};
+		test_utils::cdag_test_context ctx(num_nodes);
+		auto& tm = ctx.get_task_manager();
+		auto& ggen = ctx.get_graph_generator();
+
+		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+
+		const auto tid_a = test_utils::build_and_flush(ctx, num_nodes,
+		    test_utils::add_compute_task<class UKN(task_a)>(
+		        tm, [&](handler& cgh) {}, node_range));
+		const auto tid_b = test_utils::build_and_flush(ctx, num_nodes,
+		    test_utils::add_compute_task<class UKN(task_b)>(
+		        tm, [&](handler& cgh) {}, node_range));
+
+		const auto tid_epoch = test_utils::build_and_flush(ctx, num_nodes, tm.end_epoch());
+
+		auto buf = mbf.create_buffer(range<1>{1}, true /* host_initialized */);
+		const auto tid_c = test_utils::build_and_flush(ctx, num_nodes,
+		    test_utils::add_compute_task<class UKN(task_c)>(
+		        tm, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); }, node_range));
+		const auto tid_d = test_utils::build_and_flush(ctx, num_nodes,
+		    test_utils::add_compute_task<class UKN(task_d)>(
+		        tm, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); }, node_range));
+
+		auto& inspector = ctx.get_inspector();
+		auto& cdag = ctx.get_command_graph();
+
+		const auto get_single_command = [&](const char* const info, const task_id tid, const node_id nid) {
+			INFO(info);
+			const auto set = inspector.get_commands(tid, nid, {});
+			REQUIRE(set.size() == 1);
+			return cdag.get(*set.begin());
+		};
+
+		for(node_id nid = 0; nid < num_nodes; ++nid) {
+			CAPTURE(nid);
+
+			const auto cmd_a = get_single_command("tid_a", tid_a, nid);
+			const auto a_deps = cmd_a->get_dependencies();
+			REQUIRE(std::distance(a_deps.begin(), a_deps.end()) == 1);
+			CHECK(a_deps.front().origin == dependency_origin::epoch_fallback);
+
+			const auto cmd_b = get_single_command("tid_b", tid_b, nid);
+			const auto b_deps = cmd_b->get_dependencies();
+			REQUIRE(std::distance(b_deps.begin(), b_deps.end()) == 1);
+			CHECK(b_deps.front().origin == dependency_origin::epoch_fallback);
+
+			const auto cmd_epoch = get_single_command("tid_epoch", tid_epoch, nid);
+			const auto epoch_deps = cmd_epoch->get_dependencies();
+			CHECK(std::distance(epoch_deps.begin(), epoch_deps.end()) == 2);
+			CHECK(inspector.has_dependency(cmd_epoch->get_cid(), cmd_a->get_cid()));
+			CHECK(inspector.has_dependency(cmd_epoch->get_cid(), cmd_b->get_cid()));
+
+			const auto cmd_c = get_single_command("tid_c", tid_c, nid);
+			const auto c_deps = cmd_c->get_dependencies();
+			CHECK(std::distance(c_deps.begin(), c_deps.end()) == 1);
+			CHECK(inspector.has_dependency(cmd_c->get_cid(), cmd_epoch->get_cid()));
+
+			const auto cmd_d = get_single_command("tid_d", tid_d, nid);
+			const auto d_deps = cmd_d->get_dependencies();
+			CHECK(std::distance(d_deps.begin(), d_deps.end()) == 2);
+			CHECK(inspector.has_dependency(cmd_d->get_cid(), cmd_epoch->get_cid()));
+			CHECK(inspector.has_dependency(cmd_d->get_cid(), cmd_c->get_cid()));
+		}
+
+		maybe_print_graphs(ctx);
+	}
+
 
 } // namespace detail
 } // namespace celerity

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -38,7 +38,7 @@ namespace detail {
 		command_graph cdag;
 		std::unordered_set<abstract_command*> cmds;
 		cmds.insert(cdag.create<execution_command>(0, 0, subrange<3>{}));
-		cmds.insert(cdag.create<epoch_command>(0, task_manager::initial_epoch_task));
+		cmds.insert(cdag.create<epoch_command>(0, task_manager::initial_epoch_task, epoch_action::none));
 		cmds.insert(cdag.create<push_command>(0, 0, 0, 0, subrange<3>{}));
 		for(auto cmd : cdag.all_commands()) {
 			REQUIRE(cmds.find(cmd) != cmds.end());
@@ -77,7 +77,7 @@ namespace detail {
 
 	TEST_CASE("isa<> RTTI helper correctly handles command hierarchies", "[rtti][command-graph]") {
 		command_graph cdag;
-		auto np = cdag.create<epoch_command>(0, task_manager::initial_epoch_task);
+		auto np = cdag.create<epoch_command>(0, task_manager::initial_epoch_task, epoch_action::none);
 		REQUIRE(isa<abstract_command>(np));
 		auto hec = cdag.create<execution_command>(0, 0, subrange<3>{});
 		REQUIRE(isa<execution_command>(hec));
@@ -638,7 +638,7 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(task_b)>(
 		        tm, [&](handler& cgh) {}, node_range));
 
-		const auto tid_epoch = test_utils::build_and_flush(ctx, num_nodes, tm.end_epoch());
+		const auto tid_epoch = test_utils::build_and_flush(ctx, num_nodes, tm.end_epoch(epoch_action::none));
 
 		auto buf = mbf.create_buffer(range<1>{1}, true /* host_initialized */);
 		const auto tid_c = test_utils::build_and_flush(ctx, num_nodes,

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -656,12 +656,12 @@ namespace detail {
 			const auto cmd_a = get_single_command("a", tid_a, nid);
 			const auto a_deps = cmd_a->get_dependencies();
 			REQUIRE(std::distance(a_deps.begin(), a_deps.end()) == 1);
-			CHECK(a_deps.front().origin == dependency_origin::current_epoch);
+			CHECK(a_deps.front().origin == dependency_origin::last_epoch);
 
 			const auto cmd_b = get_single_command("b", tid_b, nid);
 			const auto b_deps = cmd_b->get_dependencies();
 			REQUIRE(std::distance(b_deps.begin(), b_deps.end()) == 1);
-			CHECK(b_deps.front().origin == dependency_origin::current_epoch);
+			CHECK(b_deps.front().origin == dependency_origin::last_epoch);
 
 			const auto cmd_epoch = get_single_command("epoch", tid_epoch, nid);
 			const auto epoch_deps = cmd_epoch->get_dependencies();

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -62,7 +62,7 @@ namespace detail {
 			expected_front.erase(t0);
 			auto t2 = cdag.create<execution_command>(node, 2, subrange<3>{});
 			expected_front.insert(t2);
-			cdag.add_dependency(t2, t0);
+			cdag.add_dependency(t2, t0, dependency_kind::TRUE_DEP, dependency_origin::dataflow);
 			REQUIRE(expected_front == cdag.get_execution_front(node));
 			return expected_front;
 		};
@@ -510,7 +510,7 @@ namespace detail {
 
 		auto has_dependencies_on_same_node = [&](task_id depender, task_id dependency) {
 			return all_command_dependencies(depender, dependency, [](auto depender_cmd, auto dependency_cmd) {
-				return depender_cmd->has_dependency(dependency_cmd, dependency_kind::ORDER_DEP) == (depender_cmd->get_nid() == dependency_cmd->get_nid());
+				return depender_cmd->has_dependency(dependency_cmd, dependency_kind::TRUE_DEP) == (depender_cmd->get_nid() == dependency_cmd->get_nid());
 			});
 		};
 

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -648,7 +648,7 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(task_b)>(
 		        tm, [&](handler& cgh) {}, node_range));
 
-		const auto tid_epoch = test_utils::build_and_flush(ctx, num_nodes, tm.finish_epoch(epoch_action::none));
+		const auto tid_epoch = test_utils::build_and_flush(ctx, num_nodes, tm.generate_epoch_task(epoch_action::none));
 
 		for(node_id nid = 0; nid < num_nodes; ++nid) {
 			CAPTURE(nid);
@@ -707,7 +707,7 @@ namespace detail {
 
 		auto tid_before = task_manager::initial_epoch_task;
 		for(const auto action : {epoch_action::barrier, epoch_action::shutdown}) {
-			const auto tid = test_utils::build_and_flush(ctx, num_nodes, tm.finish_epoch(action));
+			const auto tid = test_utils::build_and_flush(ctx, num_nodes, tm.generate_epoch_task(action));
 			CAPTURE(tid_before, tid);
 			for(const auto cid : inspector.get_commands(tid, std::nullopt, std::nullopt)) {
 				CAPTURE(cid);

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -743,7 +743,7 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(produce)>(
 		        tm,
 		        [&](handler& cgh) {
-			        buf_2.get_access<access_mode::discard_write>(cgh, all{});
+			        buf_2.get_access<access_mode::discard_write>(cgh, one_to_one{});
 			        test_utils::add_reduction(cgh, ctx.get_reduction_manager(), buf_3, false);
 		        },
 		        range<1>{num_nodes}));

--- a/test/intrusive_graph_tests.cc
+++ b/test/intrusive_graph_tests.cc
@@ -12,7 +12,7 @@ namespace detail {
 			// Adding and removing true dependency
 			{
 				my_graph_node n0, n1;
-				n0.add_dependency({&n1, dependency_kind::TRUE_DEP});
+				n0.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 				REQUIRE(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
 				REQUIRE(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
 				n0.remove_dependency(&n1);
@@ -22,19 +22,15 @@ namespace detail {
 			// Pseudo- or anti-dependency is upgraded to true dependency
 			{
 				my_graph_node n0, n1, n2;
-				n0.add_dependency({&n1, dependency_kind::ANTI_DEP});
-				n0.add_dependency({&n2, dependency_kind::ORDER_DEP});
+				n0.add_dependency({&n1, dependency_kind::ANTI_DEP, dependency_origin::dataflow});
+				n0.add_dependency({&n2, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 				CHECK(n0.has_dependency(&n1, dependency_kind::ANTI_DEP));
 				CHECK(n1.has_dependent(&n0, dependency_kind::ANTI_DEP));
-				CHECK(n0.has_dependency(&n2, dependency_kind::ORDER_DEP));
-				CHECK(n2.has_dependent(&n0, dependency_kind::ORDER_DEP));
-				n0.add_dependency({&n1, dependency_kind::TRUE_DEP});
-				n0.add_dependency({&n2, dependency_kind::ANTI_DEP});
+				n0.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+				n0.add_dependency({&n2, dependency_kind::ANTI_DEP, dependency_origin::dataflow});
 				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::ANTI_DEP));
 				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::ANTI_DEP));
 				REQUIRE(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
-				REQUIRE(n0.has_dependency(&n2, dependency_kind::ORDER_DEP));
-				REQUIRE(n2.has_dependent(&n0, dependency_kind::ORDER_DEP));
 				REQUIRE(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
 				REQUIRE_FALSE(n0.has_dependency(&n2, dependency_kind::ANTI_DEP));
 				REQUIRE_FALSE(n2.has_dependent(&n0, dependency_kind::ANTI_DEP));
@@ -45,21 +41,17 @@ namespace detail {
 			// True dependency cannot be downgraded to anti-dependency
 			{
 				my_graph_node n0, n1;
-				n0.add_dependency({&n1, dependency_kind::TRUE_DEP});
+				n0.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 				CHECK(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
 				CHECK(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
-				n0.add_dependency({&n1, dependency_kind::ANTI_DEP});
+				n0.add_dependency({&n1, dependency_kind::ANTI_DEP, dependency_origin::dataflow});
 				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::ANTI_DEP));
 				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::ANTI_DEP));
-				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::ORDER_DEP));
-				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::ORDER_DEP));
 				REQUIRE(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
 				REQUIRE(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
-				n0.add_dependency({&n1, dependency_kind::ORDER_DEP});
+				n0.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::ANTI_DEP));
 				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::ANTI_DEP));
-				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::ORDER_DEP));
-				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::ORDER_DEP));
 				REQUIRE(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
 				REQUIRE(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
 			}
@@ -69,8 +61,8 @@ namespace detail {
 	TEST_CASE("intrusive_graph_node removes itself from all connected nodes upon destruction", "[intrusive_graph_node]") {
 		my_graph_node n0, n2;
 		auto n1 = std::make_unique<my_graph_node>();
-		n0.add_dependency({n1.get(), dependency_kind::TRUE_DEP});
-		n1->add_dependency({&n2, dependency_kind::TRUE_DEP});
+		n0.add_dependency({n1.get(), dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+		n1->add_dependency({&n2, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 		CHECK(n0.has_dependency(n1.get(), dependency_kind::TRUE_DEP));
 		CHECK(n2.has_dependent(n1.get(), dependency_kind::TRUE_DEP));
 		n1.reset();
@@ -81,12 +73,12 @@ namespace detail {
 	TEST_CASE("intrusive_graph_node keeps track of the pseudo critical path length", "[intrusive_graph_node]") {
 		my_graph_node n0, n1, n2, n3;
 		REQUIRE(n3.get_pseudo_critical_path_length() == 0);
-		n3.add_dependency({&n2, dependency_kind::TRUE_DEP});
+		n3.add_dependency({&n2, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 		REQUIRE(n3.get_pseudo_critical_path_length() == 1);
-		n3.add_dependency({&n0, dependency_kind::TRUE_DEP});
+		n3.add_dependency({&n0, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 		REQUIRE(n3.get_pseudo_critical_path_length() == 1);
-		n1.add_dependency({&n0, dependency_kind::TRUE_DEP});
-		n3.add_dependency({&n1, dependency_kind::TRUE_DEP});
+		n1.add_dependency({&n0, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+		n3.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
 		REQUIRE(n3.get_pseudo_critical_path_length() == 2);
 	}
 

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -242,7 +242,7 @@ namespace detail {
 	TEST_CASE("task_manager invokes callback upon task creation", "[task_manager]") {
 		task_manager tm{1, nullptr, nullptr};
 		size_t call_counter = 0;
-		tm.register_task_callback([&call_counter](task_id, task_type) { call_counter++; });
+		tm.register_task_callback([&call_counter](task_id) { call_counter++; });
 		cl::sycl::range<2> gs = {1, 1};
 		cl::sycl::id<2> go = {};
 		tm.create_task([=](handler& cgh) { cgh.parallel_for<class kernel>(gs, go, [](auto) {}); });

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -630,7 +630,7 @@ namespace detail {
 		auto buf_b = mbf.create_buffer(range<1>(1));
 		const auto tid_b = test_utils::add_compute_task<class UKN(task_b)>(tm, [&](handler& cgh) { buf_b.get_access<access_mode::discard_write>(cgh, all{}); });
 
-		const auto tid_epoch = tm.end_epoch();
+		const auto tid_epoch = tm.end_epoch(epoch_action::none);
 
 		const auto tid_c = test_utils::add_compute_task<class UKN(task_c)>(tm, [&](handler& cgh) { buf_a.get_access<access_mode::read>(cgh, all{}); });
 		const auto tid_d = test_utils::add_compute_task<class UKN(task_d)>(tm, [&](handler& cgh) { buf_b.get_access<access_mode::discard_write>(cgh, all{}); });
@@ -662,7 +662,7 @@ namespace detail {
 		auto buf = mbf.create_buffer(range<1>(1));
 		for(int i = 0; i < 3; ++i) {
 			test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); });
-			tm.end_epoch();
+			tm.end_epoch(epoch_action::none);
 		}
 
 		CHECK(task_manager_testspy::get_num_horizons(tm) == 0);

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -267,7 +267,7 @@ namespace detail {
 		CHECK_FALSE(has_any_dependency(tm, tid_collective_implicit_1, tid_collective_explicit_2));
 
 		CHECK_FALSE(has_any_dependency(tm, tid_collective_implicit_2, tid_master));
-		CHECK(has_dependency(tm, tid_collective_implicit_2, tid_collective_implicit_1, dependency_kind::ORDER_DEP));
+		CHECK(has_dependency(tm, tid_collective_implicit_2, tid_collective_implicit_1, dependency_kind::TRUE_DEP));
 		CHECK_FALSE(has_any_dependency(tm, tid_collective_implicit_2, tid_collective_explicit_1));
 		CHECK_FALSE(has_any_dependency(tm, tid_collective_implicit_2, tid_collective_explicit_2));
 
@@ -279,7 +279,7 @@ namespace detail {
 		CHECK_FALSE(has_any_dependency(tm, tid_collective_explicit_2, tid_master));
 		CHECK_FALSE(has_any_dependency(tm, tid_collective_explicit_2, tid_collective_implicit_1));
 		CHECK_FALSE(has_any_dependency(tm, tid_collective_explicit_2, tid_collective_implicit_2));
-		CHECK(has_dependency(tm, tid_collective_explicit_2, tid_collective_explicit_1, dependency_kind::ORDER_DEP));
+		CHECK(has_dependency(tm, tid_collective_explicit_2, tid_collective_explicit_1, dependency_kind::TRUE_DEP));
 	}
 
 	void check_path_length_and_front(task_manager& tm, int path_length, std::unordered_set<task_id> exec_front) {
@@ -522,7 +522,7 @@ namespace detail {
 		REQUIRE(master_node_dep != second_collective_deps.end());
 		CHECK(master_node_dep->kind == dependency_kind::TRUE_DEP);
 		REQUIRE(horizon_dep != second_collective_deps.end());
-		CHECK(horizon_dep->kind == dependency_kind::ORDER_DEP);
+		CHECK(horizon_dep->kind == dependency_kind::TRUE_DEP);
 
 		test_utils::maybe_print_graph(tm);
 	}

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -329,17 +329,17 @@ namespace detail {
 
 		test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf_a.get_access<access_mode::discard_write>(cgh, fixed<1>({0, 128})); });
 
-		auto current_horizon = task_manager_testspy::get_current_horizon(tm);
-		CHECK(!current_horizon.has_value());
+		auto current_horizion = task_manager_testspy::get_current_horizion(tm);
+		CHECK(!current_horizion.has_value());
 
 		const auto tid_c = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf_a.get_access<access_mode::read>(cgh, fixed<1>({0, 128})); });
 
-		current_horizon = task_manager_testspy::get_current_horizon(tm);
-		REQUIRE(current_horizon.has_value());
-		CHECK(*current_horizon == tid_c + 1);
+		current_horizion = task_manager_testspy::get_current_horizion(tm);
+		REQUIRE(current_horizion.has_value());
+		CHECK(*current_horizion == tid_c + 1);
 		CHECK(task_manager_testspy::get_num_horizons(tm) == 1);
 
-		auto horizon_dependencies = tm.get_task(*current_horizon)->get_dependencies();
+		auto horizon_dependencies = tm.get_task(*current_horizion)->get_dependencies();
 
 		CHECK(std::distance(horizon_dependencies.begin(), horizon_dependencies.end()) == 1);
 		CHECK(horizon_dependencies.begin()->node->get_id() == tid_c);
@@ -347,7 +347,7 @@ namespace detail {
 		std::set<task_id> expected_dependency_ids;
 
 		// current horizon is always part of the active task front
-		expected_dependency_ids.insert(*current_horizon);
+		expected_dependency_ids.insert(*current_horizion);
 		expected_dependency_ids.insert(test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {}));
 		expected_dependency_ids.insert(test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {}));
 		expected_dependency_ids.insert(test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {}));
@@ -359,12 +359,12 @@ namespace detail {
 		});
 		expected_dependency_ids.insert(tid_d);
 
-		current_horizon = task_manager_testspy::get_current_horizon(tm);
-		REQUIRE(current_horizon.has_value());
-		CHECK(*current_horizon == tid_d + 1);
+		current_horizion = task_manager_testspy::get_current_horizion(tm);
+		REQUIRE(current_horizion.has_value());
+		CHECK(*current_horizion == tid_d + 1);
 		CHECK(task_manager_testspy::get_num_horizons(tm) == 2);
 
-		horizon_dependencies = tm.get_task(*current_horizon)->get_dependencies();
+		horizon_dependencies = tm.get_task(*current_horizion)->get_dependencies();
 		CHECK(std::distance(horizon_dependencies.begin(), horizon_dependencies.end()) == 5);
 
 		std::set<task_id> actual_dependecy_ids;
@@ -398,7 +398,7 @@ namespace detail {
 			buf_a.get_access<access_mode::read_write>(cgh, fixed<1>({32, 64}));
 		});
 
-		auto horizon = task_manager_testspy::get_current_horizon(tm);
+		auto horizon = task_manager_testspy::get_current_horizion(tm);
 		CHECK(task_manager_testspy::get_num_horizons(tm) == 1);
 		CHECK(horizon.has_value());
 
@@ -467,9 +467,9 @@ namespace detail {
 			// and another one that triggers the actual deferred deletion.
 			for(int i = 0; i < 8; ++i) {
 				const auto tid = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); });
-				const auto current_horizon = task_manager_testspy::get_current_horizon(tm);
-				if(current_horizon && *current_horizon > last_executed_horizon) {
-					last_executed_horizon = *current_horizon;
+				const auto current_horizion = task_manager_testspy::get_current_horizion(tm);
+				if(current_horizion && *current_horizion > last_executed_horizon) {
+					last_executed_horizon = *current_horizion;
 					tm.notify_horizon_reached(last_executed_horizon);
 				}
 			}
@@ -485,10 +485,10 @@ namespace detail {
 		const auto* new_last_writer = deps.begin()->node;
 		CHECK(new_last_writer->get_type() == task_type::HORIZON);
 
-		const auto current_horizon = task_manager_testspy::get_current_horizon(tm);
-		REQUIRE(current_horizon);
+		const auto current_horizion = task_manager_testspy::get_current_horizion(tm);
+		REQUIRE(current_horizion);
 		INFO("previous horizon is being used");
-		CHECK(new_last_writer->get_id() < *current_horizon);
+		CHECK(new_last_writer->get_id() < *current_horizion);
 
 		test_utils::maybe_print_graph(tm);
 	}

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -620,5 +620,55 @@ namespace detail {
 
 		test_utils::maybe_print_graph(tm);
 	}
+	TEST_CASE("epochs create appropriate dependencies to predecessors and successors", "[task_manager][task-graph][epoch]") {
+		task_manager tm{1, nullptr, nullptr};
+		test_utils::mock_buffer_factory mbf(&tm);
+
+		auto buf_a = mbf.create_buffer(range<1>(1));
+		const auto tid_a = test_utils::add_compute_task<class UKN(task_a)>(tm, [&](handler& cgh) { buf_a.get_access<access_mode::discard_write>(cgh, all{}); });
+
+		auto buf_b = mbf.create_buffer(range<1>(1));
+		const auto tid_b = test_utils::add_compute_task<class UKN(task_b)>(tm, [&](handler& cgh) { buf_b.get_access<access_mode::discard_write>(cgh, all{}); });
+
+		const auto tid_epoch = tm.end_epoch();
+
+		const auto tid_c = test_utils::add_compute_task<class UKN(task_c)>(tm, [&](handler& cgh) { buf_a.get_access<access_mode::read>(cgh, all{}); });
+		const auto tid_d = test_utils::add_compute_task<class UKN(task_d)>(tm, [&](handler& cgh) { buf_b.get_access<access_mode::discard_write>(cgh, all{}); });
+		const auto tid_e = test_utils::add_compute_task<class UKN(task_e)>(tm, [&](handler& cgh) {});
+		const auto tid_f = test_utils::add_compute_task<class UKN(task_f)>(tm, [&](handler& cgh) { buf_b.get_access<access_mode::read>(cgh, all{}); });
+		const auto tid_g = test_utils::add_compute_task<class UKN(task_g)>(tm, [&](handler& cgh) { buf_b.get_access<access_mode::discard_write>(cgh, all{}); });
+
+		CHECK(has_dependency(tm, tid_epoch, tid_a));
+		CHECK(has_dependency(tm, tid_epoch, tid_b));
+		CHECK(has_dependency(tm, tid_c, tid_epoch));
+		CHECK(!has_any_dependency(tm, tid_c, tid_a));
+		CHECK(has_dependency(tm, tid_d, tid_epoch));
+		CHECK(!has_any_dependency(tm, tid_d, tid_b));
+		CHECK(has_dependency(tm, tid_e, tid_epoch));
+		CHECK(has_dependency(tm, tid_f, tid_d));
+		CHECK(!has_any_dependency(tm, tid_f, tid_epoch));
+		CHECK(has_dependency(tm, tid_g, tid_f, dependency_kind::ANTI_DEP));
+		CHECK(has_dependency(tm, tid_g, tid_epoch)); // needs a TRUE_DEP on barrier since it only has ANTI_DEPs otherwise
+
+		test_utils::maybe_print_graph(tm);
+	}
+
+
+	TEST_CASE("inserting epochs resets the need for horizons", "[task_manager][task-graph][task-horizon][epoch]") {
+		task_manager tm{1, nullptr, nullptr};
+		tm.set_horizon_step(2);
+
+		test_utils::mock_buffer_factory mbf(&tm);
+		auto buf = mbf.create_buffer(range<1>(1));
+		for(int i = 0; i < 3; ++i) {
+			test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); });
+			tm.end_epoch();
+		}
+
+		CHECK(task_manager_testspy::get_num_horizons(tm) == 0);
+
+		test_utils::maybe_print_graph(tm);
+	}
+
 } // namespace detail
 } // namespace celerity

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -307,7 +307,7 @@ namespace test_utils {
 	template <typename KernelName = class test_task, typename CGF, int KernelDims = 2>
 	detail::task_id add_compute_task(
 	    detail::task_manager& tm, CGF cgf, cl::sycl::range<KernelDims> global_size = {1, 1}, cl::sycl::id<KernelDims> global_offset = {}) {
-		return tm.create_task([&, gs = global_size, go = global_offset](handler& cgh) {
+		return tm.submit_command_group([&, gs = global_size, go = global_offset](handler& cgh) {
 			cgf(cgh);
 			cgh.parallel_for<KernelName>(gs, go, [](cl::sycl::id<KernelDims>) {});
 		});
@@ -315,7 +315,7 @@ namespace test_utils {
 
 	template <typename KernelName = class test_task, typename CGF, int KernelDims = 2>
 	detail::task_id add_nd_range_compute_task(detail::task_manager& tm, CGF cgf, celerity::nd_range<KernelDims> execution_range = {{1, 1}, {1, 1}}) {
-		return tm.create_task([&, er = execution_range](handler& cgh) {
+		return tm.submit_command_group([&, er = execution_range](handler& cgh) {
 			cgf(cgh);
 			cgh.parallel_for<KernelName>(er, [](nd_item<KernelDims>) {});
 		});
@@ -323,7 +323,7 @@ namespace test_utils {
 
 	template <typename Spec, typename CGF>
 	detail::task_id add_host_task(detail::task_manager& tm, Spec spec, CGF cgf) {
-		return tm.create_task([&](handler& cgh) {
+		return tm.submit_command_group([&](handler& cgh) {
 			cgf(cgh);
 			cgh.host_task(spec, [](auto...) {});
 		});

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -41,7 +41,7 @@ namespace celerity {
 namespace detail {
 
 	struct task_manager_testspy {
-		static std::optional<task_id> get_current_horizion(task_manager& tm) { return tm.current_horizon; }
+		static std::optional<task_id> get_current_horizon(task_manager& tm) { return tm.current_horizon; }
 
 		static int get_num_horizons(task_manager& tm) {
 			int horizon_counter = 0;
@@ -252,7 +252,7 @@ namespace test_utils {
 		detail::graph_serializer& get_graph_serializer() { return *gsrlzr; }
 
 		detail::task_id build_task_horizons() {
-			const auto most_recently_generated_task_horizon = detail::task_manager_testspy::get_current_horizion(get_task_manager());
+			const auto most_recently_generated_task_horizon = detail::task_manager_testspy::get_current_horizon(get_task_manager());
 			if(most_recently_generated_task_horizon != most_recently_built_task_horizon) {
 				most_recently_built_task_horizon = most_recently_generated_task_horizon;
 				if(most_recently_built_task_horizon) {

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -175,7 +175,7 @@ namespace test_utils {
 
 				const detail::command_id cid = pkg.cid;
 				commands[cid] = {nid, pkg, dependencies};
-				if(pkg.tid) { by_task[*pkg.tid].insert(cid); }
+				if(const auto tid = pkg.get_tid()) { by_task[*tid].insert(cid); }
 				by_node[nid].insert(cid);
 			};
 		}
@@ -205,7 +205,7 @@ namespace test_utils {
 			if(cmd != std::nullopt) {
 				std::set<detail::command_id> new_result;
 				std::copy_if(result.cbegin(), result.cend(), std::inserter(new_result, new_result.begin()),
-				    [this, cmd](detail::command_id cid) { return commands.at(cid).pkg.cmd == cmd; });
+				    [this, cmd](detail::command_id cid) { return commands.at(cid).pkg.get_command_type() == cmd; });
 				result = std::move(new_result);
 			}
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -177,6 +177,7 @@ namespace test_utils {
 				commands[cid] = {nid, pkg, dependencies};
 				if(pkg.cmd == detail::command_type::EXECUTION) { by_task[std::get<detail::execution_data>(pkg.data).tid].insert(cid); }
 				if(pkg.cmd == detail::command_type::HORIZON) { by_task[std::get<detail::horizon_data>(pkg.data).tid].insert(cid); }
+				if(pkg.cmd == detail::command_type::EPOCH) { by_task[std::get<detail::epoch_data>(pkg.data).tid].insert(cid); }
 				by_node[nid].insert(cid);
 			};
 		}
@@ -184,7 +185,9 @@ namespace test_utils {
 		std::set<detail::command_id> get_commands(
 		    std::optional<detail::task_id> tid, std::optional<detail::node_id> nid, std::optional<detail::command_type> cmd) const {
 			// Sanity check: Not all commands have an associated task id
-			assert(tid == std::nullopt || (cmd == std::nullopt || cmd == detail::command_type::EXECUTION || cmd == detail::command_type::HORIZON));
+			assert(tid == std::nullopt
+			       || (cmd == std::nullopt || cmd == detail::command_type::EXECUTION || cmd == detail::command_type::HORIZON
+			           || cmd == detail::command_type::EPOCH));
 
 			std::set<detail::command_id> result;
 			std::transform(commands.cbegin(), commands.cend(), std::inserter(result, result.begin()), [](auto p) { return p.first; });

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -405,9 +405,9 @@ namespace test_utils {
 		}
 	}
 
-	inline void maybe_print_graph(celerity::detail::command_graph& cdag) {
+	inline void maybe_print_graph(celerity::detail::command_graph& cdag, const celerity::detail::task_manager& tm) {
 		if(print_graphs) {
-			const auto graph_str = cdag.print_graph(std::numeric_limits<size_t>::max());
+			const auto graph_str = cdag.print_graph(std::numeric_limits<size_t>::max(), tm);
 			assert(graph_str.has_value());
 			CELERITY_INFO("Command graph:\n\n{}\n", *graph_str);
 		}
@@ -416,7 +416,7 @@ namespace test_utils {
 	inline void maybe_print_graphs(celerity::test_utils::cdag_test_context& ctx) {
 		if(print_graphs) {
 			maybe_print_graph(ctx.get_task_manager());
-			maybe_print_graph(ctx.get_command_graph());
+			maybe_print_graph(ctx.get_command_graph(), ctx.get_task_manager());
 		}
 	}
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -41,7 +41,7 @@ namespace celerity {
 namespace detail {
 
 	struct task_manager_testspy {
-		static std::optional<task_id> get_current_horizon(task_manager& tm) { return tm.current_horizon; }
+		static std::optional<task_id> get_current_horizion(task_manager& tm) { return tm.current_horizon; }
 
 		static int get_num_horizons(task_manager& tm) {
 			int horizon_counter = 0;
@@ -252,7 +252,7 @@ namespace test_utils {
 		detail::graph_serializer& get_graph_serializer() { return *gsrlzr; }
 
 		detail::task_id build_task_horizons() {
-			const auto most_recently_generated_task_horizon = detail::task_manager_testspy::get_current_horizon(get_task_manager());
+			const auto most_recently_generated_task_horizon = detail::task_manager_testspy::get_current_horizion(get_task_manager());
 			if(most_recently_generated_task_horizon != most_recently_built_task_horizon) {
 				most_recently_built_task_horizon = most_recently_generated_task_horizon;
 				if(most_recently_built_task_horizon) {


### PR DESCRIPTION
So far, `queue::slow_full_sync()` and the shutdown of worker `executor`s are implemented by sending SYNC and SHUTDOWN commands through `broadcast_control_command()` and then busy-waiting on the main thread. Since we already introduced synchronization logic to task and command graphs before as part of _horizons_, we now have the opportunity to integrate SYNC and SHUTDOWN into the graphs as well and reduce specialized code paths. This will also be a stepping stone towards using explicit synchronization to exchange data in celerity buffers with the main thread.

This PR represents synchronization points in the graph with _epochs_, which themselves are a generalization of INIT/NOP tasks and commands. Each graph node (except the first epoch) has exactly one preceding epoch, and no node can ever depend on a node before its epoch. In that sense they are similar to horizons, except that they fully serialize execution and dependency tracking:

![TaskGraph](https://user-images.githubusercontent.com/5698527/152795484-d2e17d8e-f4d4-45bf-9977-ad6f07d27d6a.png)

To ensure correct temporal ordering, a new epoch node receives a true-dependency on the entire execution front (orange edges); and all nodes without other true-dependencies (pure producers, tasks `a` `b` `d` `e`) receive a dependency on their epoch (pink edges). A new epoch will immediately become the last-writer and host-buffer initializer for all successor tasks. Like any other node, epochs can be subsumed by horizons, after which the subsuming horizon becomes the epoch for all following nodes. 

Inserting a new epoch task with `task_manager::finish_epoch()` will create one epoch command per node, with dependencies on the current execution front. Each `epoch_command` will issue one `epoch_job`, which awaits the completion of said dependencies, optionally issues an `MPI_Barrier` and then notifies the task manager via `notify_epoch_completed()`. Other threads can await this notification to block the main thread in `queue::slow_full_sync()` and `~runtime()`.

The nodes preceding a task epoch are pruned once the first task is created after `notify_epoch_completed()`. In the command graph generator, nodes can be deleted as soon as they lie behind the last epoch, as they can't be depended on by any successor task. In that regard, epochs act like immediately-applied horizons.

This PR also recognizes that the task manager can prune all nodes preceding a horizon `A` as soon as it has been notified that horizon `B` with `A → B` has been reached. This notification signifies that all commands of tasks preceding `A` have finished executing, so even though they might still be referenced from already-executed commands in the command graph, the task data never has to be accessed again.

To aid debugging, Celerity will now also track the origin of a dependency in addition to its kind. This is currently visualized in generated dot graphs.

The old synchronization infrastructure (`broadcast_control_command()`, `sync_id`, ...) has been removed. 