### PR TITLE
Support empty buffers and buffer requirements with empty ranges

### DIFF
--- a/include/accessor.h
+++ b/include/accessor.h
@@ -71,6 +71,8 @@ namespace detail {
 	template <int Dims>
 	subrange<Dims> get_effective_sycl_accessor_subrange(id<Dims> device_buffer_offset, subrange<Dims> sr) {
 #if WORKAROUND_COMPUTECPP || WORKAROUND_DPCPP
+		// For ComputeCpp and DPC++, we allocate a unit-sized dummy backing buffer. ComputeCpp >= 2.8.0 does not support zero-sized placeholder accessors, so
+		// we simply create a unit-sized (SYCL) accessor instead.
 		if(sr.range.size() == 0) return {{}, unit_range};
 #endif
 		return {sr.offset - device_buffer_offset, sr.range};

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -122,7 +122,6 @@ namespace detail {
 			buffer_id bid;
 			const bool is_host_initialized = host_init_ptr != nullptr;
 			{
-				assert(range.size() > 0);
 				std::unique_lock lock(mutex);
 				bid = buffer_count++;
 				buffer_infos[bid] = buffer_info{range, is_host_initialized};
@@ -252,10 +251,12 @@ namespace detail {
 				    .wait();
 			}
 
-			backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
-			const backing_buffer empty{};
-			const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
-			make_buffer_subrange_coherent(bid, mode, target_buffer, {offset, range}, previous_buffer);
+			if (range.size() != 0) {
+				backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
+				const backing_buffer empty{};
+				const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
+				make_buffer_subrange_coherent(bid, mode, target_buffer, {offset, range}, previous_buffer);
+			}
 
 			if(new_buffer.is_allocated()) { buffers[bid].device_buf = std::move(new_buffer); }
 
@@ -291,10 +292,12 @@ namespace detail {
 				std::memset(host_buf.get_pointer(), test_mode_pattern, host_buf.get_range().size() * sizeof(DataT));
 			}
 
-			backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
-			const backing_buffer empty{};
-			const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
-			make_buffer_subrange_coherent(bid, mode, target_buffer, {offset, range}, previous_buffer);
+			if (range.size() != 0) {
+				backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
+				const backing_buffer empty{};
+				const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
+				make_buffer_subrange_coherent(bid, mode, target_buffer, {offset, range}, previous_buffer);
+			}
 
 			if(new_buffer.is_allocated()) { buffers[bid].host_buf = std::move(new_buffer); }
 

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -411,8 +411,8 @@ namespace detail {
 		static resize_info is_resize_required(const backing_buffer& buffer, cl::sycl::range<3> request_range, cl::sycl::id<3> request_offset) {
 			assert(buffer.is_allocated());
 
+			// Empty-range buffer requirements never count towards the bounding box
 			if(request_range.size() == 0) { return resize_info{}; }
-
 			if(buffer.storage->get_range().size() == 0) { return resize_info{true, request_offset, request_range}; }
 
 			const cl::sycl::range<3> old_abs_range = range_cast<3>(buffer.offset + buffer.storage->get_range());

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -251,7 +251,7 @@ namespace detail {
 				    .wait();
 			}
 
-			if (range.size() != 0) {
+			if(range.size() != 0) {
 				backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
 				const backing_buffer empty{};
 				const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
@@ -292,7 +292,7 @@ namespace detail {
 				std::memset(host_buf.get_pointer(), test_mode_pattern, host_buf.get_range().size() * sizeof(DataT));
 			}
 
-			if (range.size() != 0) {
+			if(range.size() != 0) {
 				backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
 				const backing_buffer empty{};
 				const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
@@ -410,6 +410,11 @@ namespace detail {
 
 		static resize_info is_resize_required(const backing_buffer& buffer, cl::sycl::range<3> request_range, cl::sycl::id<3> request_offset) {
 			assert(buffer.is_allocated());
+
+			if(request_range.size() == 0) { return resize_info{}; }
+
+			if(buffer.storage->get_range().size() == 0) { return resize_info{true, request_offset, request_range}; }
+
 			const cl::sycl::range<3> old_abs_range = range_cast<3>(buffer.offset + buffer.storage->get_range());
 			const cl::sycl::range<3> new_abs_range = range_cast<3>(request_offset + request_range);
 			const bool is_inside_old_range = ((request_offset >= buffer.offset) == cl::sycl::id<3>(true, true, true))

--- a/include/buffer_storage.h
+++ b/include/buffer_storage.h
@@ -246,6 +246,7 @@ namespace detail {
 
 		static celerity::range<Dims> make_device_buf_effective_range(sycl::range<Dims> range) {
 #if WORKAROUND_COMPUTECPP || WORKAROUND_DPCPP
+			// ComputeCpp and DPC++ do not support empty buffers, so we make a unit-sized dummy allocation instead.
 			for(int d = 0; d < Dims; ++d) {
 				range[d] = std::max(size_t{1}, range[d]);
 			}

--- a/include/command_graph.h
+++ b/include/command_graph.h
@@ -115,10 +115,12 @@ namespace detail {
 
 		bool has(command_id cid) const { return commands.count(cid) == 1; }
 
-		template <typename T = abstract_command>
+		abstract_command* get(command_id cid) { return commands.at(cid).get(); }
+
+		template <typename T>
 		T* get(command_id cid) {
-			assert(commands.find(cid) != commands.end());
-			return commands[cid].get();
+			// dynamic_cast with reference to force bad_cast to be thrown if type mismatches
+			return &dynamic_cast<T&>(*commands.at(cid));
 		}
 
 		size_t command_count() const { return commands.size(); }

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -54,10 +54,11 @@ namespace detail {
 #undef MAKE_COMPONENT_WISE_BINARY_FN
 
 	struct {
-		operator cl::sycl::range<1>() const { return {0}; }
-		operator cl::sycl::range<2>() const { return {0, 0}; }
-		operator cl::sycl::range<3>() const { return {0, 0, 0}; }
-	} inline constexpr zero_range;
+		size_t value;
+		constexpr operator cl::sycl::range<1>() const { return {value}; }
+		constexpr operator cl::sycl::range<2>() const { return {value, value}; }
+		constexpr operator cl::sycl::range<3>() const { return {value, value, value}; }
+	} inline constexpr zero_range{0}, unit_range{1};
 
 }; // namespace detail
 

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -55,9 +55,9 @@ namespace detail {
 
 	struct {
 		size_t value;
-		constexpr operator cl::sycl::range<1>() const { return {value}; }
-		constexpr operator cl::sycl::range<2>() const { return {value, value}; }
-		constexpr operator cl::sycl::range<3>() const { return {value, value, value}; }
+		operator cl::sycl::range<1>() const { return {value}; }
+		operator cl::sycl::range<2>() const { return {value, value}; }
+		operator cl::sycl::range<3>() const { return {value, value, value}; }
 	} inline constexpr zero_range{0}, unit_range{1};
 
 }; // namespace detail
@@ -69,8 +69,8 @@ struct chunk {
 	static constexpr int dims = Dims;
 
 	celerity::id<Dims> offset;
-	celerity::range<Dims> range = detail::range_cast<Dims>(celerity::range<3>(0, 0, 0));
-	celerity::range<Dims> global_size = detail::range_cast<Dims>(celerity::range<3>(0, 0, 0));
+	celerity::range<Dims> range = detail::zero_range;
+	celerity::range<Dims> global_size = detail::zero_range;
 
 	chunk() = default;
 

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -119,9 +119,9 @@ namespace detail {
 			if(std::any_of(modes.cbegin(), modes.cend(), detail::access::mode_traits::is_producer) || reduction.has_value()) {
 				auto write_requirements = get_requirements(tsk.get(), bid, {detail::access::producer_modes.cbegin(), detail::access::producer_modes.cend()});
 				if(reduction.has_value()) { write_requirements = GridRegion<3>::merge(write_requirements, GridRegion<3>{{1, 1, 1}}); }
-				assert(!write_requirements.empty() && "Task specified empty buffer range requirement. This indicates potential anti-pattern.");
-				const auto last_writers = buffers_last_writers.at(bid).get_region_values(write_requirements);
+				if(write_requirements.empty()) continue;
 
+				const auto last_writers = buffers_last_writers.at(bid).get_region_values(write_requirements);
 				for(auto& p : last_writers) {
 					if(p.second == std::nullopt) continue;
 					assert(task_map.count(*p.second) == 1);

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -414,8 +414,8 @@ namespace test_utils {
 		accessor<DataT, Dims, Mode, target::device> get_device_accessor(
 		    detail::live_pass_device_handler& cgh, detail::buffer_id bid, const cl::sycl::range<Dims>& range, const cl::sycl::id<Dims>& offset) {
 			auto buf_info = bm->get_device_buffer<DataT, Dims>(bid, Mode, detail::range_cast<3>(range), detail::id_cast<3>(offset));
-			return detail::make_device_accessor<DataT, Dims, Mode>(
-			    cgh.get_eventual_sycl_cgh(), subrange<Dims>(offset, range), buf_info.buffer, buf_info.offset);
+			return detail::make_device_accessor<DataT, Dims, Mode>(cgh.get_eventual_sycl_cgh(), buf_info.buffer,
+			    detail::get_effective_sycl_accessor_subrange(buf_info.offset, subrange<Dims>(offset, range)), offset);
 		}
 
 		template <typename DataT, int Dims, access_mode Mode>


### PR DESCRIPTION
Currently, Celerity does not support buffers or buffer accesses where `get_range().size() == 0`. This edge case can be encountered by using range mappers that produce empty ranges for some chunks. This PR enables creating empty buffers and empty buffer requirements while ensuring that no unnecessary dependencies or data transfers are generated.

The ComputeCpp and DPC++ backends do not support empty buffers or empty-range accessors themselves. As a workaround, we allocate unit-sized backing buffers on the device when necessary and verify that these allocations are not included in the bounding box of subsequent backing buffer resizes:

- `detail::device_buffer_storage::make_device_buf_effective_range()` ensures that `device_buf.get_range().size()` is always `>= 1` 
- `detail::get_effective_sycl_accessor_subrange()` re-maps empty-ranged accesses to unit-ranged accesses starting at the beginning of the backing buffer