### PR TITLE
Efficiently handle tasks with empty execution ranges

### DIFF
--- a/include/accessor.h
+++ b/include/accessor.h
@@ -71,6 +71,8 @@ namespace detail {
 	template <int Dims>
 	subrange<Dims> get_effective_sycl_accessor_subrange(id<Dims> device_buffer_offset, subrange<Dims> sr) {
 #if WORKAROUND_COMPUTECPP || WORKAROUND_DPCPP
+		// For ComputeCpp and DPC++, we allocate a unit-sized dummy backing buffer. ComputeCpp >= 2.8.0 does not support zero-sized placeholder accessors, so
+		// we simply create a unit-sized (SYCL) accessor instead.
 		if(sr.range.size() == 0) return {{}, unit_range};
 #endif
 		return {sr.offset - device_buffer_offset, sr.range};

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -122,7 +122,6 @@ namespace detail {
 			buffer_id bid;
 			const bool is_host_initialized = host_init_ptr != nullptr;
 			{
-				assert(range.size() > 0);
 				std::unique_lock lock(mutex);
 				bid = buffer_count++;
 				buffer_infos[bid] = buffer_info{range, is_host_initialized};
@@ -252,10 +251,12 @@ namespace detail {
 				    .wait();
 			}
 
-			backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
-			const backing_buffer empty{};
-			const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
-			make_buffer_subrange_coherent(bid, mode, target_buffer, {offset, range}, previous_buffer);
+			if (range.size() != 0) {
+				backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
+				const backing_buffer empty{};
+				const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
+				make_buffer_subrange_coherent(bid, mode, target_buffer, {offset, range}, previous_buffer);
+			}
 
 			if(new_buffer.is_allocated()) { buffers[bid].device_buf = std::move(new_buffer); }
 
@@ -291,10 +292,12 @@ namespace detail {
 				std::memset(host_buf.get_pointer(), test_mode_pattern, host_buf.get_range().size() * sizeof(DataT));
 			}
 
-			backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
-			const backing_buffer empty{};
-			const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
-			make_buffer_subrange_coherent(bid, mode, target_buffer, {offset, range}, previous_buffer);
+			if (range.size() != 0) {
+				backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
+				const backing_buffer empty{};
+				const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
+				make_buffer_subrange_coherent(bid, mode, target_buffer, {offset, range}, previous_buffer);
+			}
 
 			if(new_buffer.is_allocated()) { buffers[bid].host_buf = std::move(new_buffer); }
 

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -411,8 +411,8 @@ namespace detail {
 		static resize_info is_resize_required(const backing_buffer& buffer, cl::sycl::range<3> request_range, cl::sycl::id<3> request_offset) {
 			assert(buffer.is_allocated());
 
+			// Empty-range buffer requirements never count towards the bounding box
 			if(request_range.size() == 0) { return resize_info{}; }
-
 			if(buffer.storage->get_range().size() == 0) { return resize_info{true, request_offset, request_range}; }
 
 			const cl::sycl::range<3> old_abs_range = range_cast<3>(buffer.offset + buffer.storage->get_range());

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -251,7 +251,7 @@ namespace detail {
 				    .wait();
 			}
 
-			if (range.size() != 0) {
+			if(range.size() != 0) {
 				backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
 				const backing_buffer empty{};
 				const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
@@ -292,7 +292,7 @@ namespace detail {
 				std::memset(host_buf.get_pointer(), test_mode_pattern, host_buf.get_range().size() * sizeof(DataT));
 			}
 
-			if (range.size() != 0) {
+			if(range.size() != 0) {
 				backing_buffer& target_buffer = new_buffer.is_allocated() ? new_buffer : old_buffer;
 				const backing_buffer empty{};
 				const backing_buffer& previous_buffer = new_buffer.is_allocated() ? old_buffer : empty;
@@ -410,6 +410,11 @@ namespace detail {
 
 		static resize_info is_resize_required(const backing_buffer& buffer, cl::sycl::range<3> request_range, cl::sycl::id<3> request_offset) {
 			assert(buffer.is_allocated());
+
+			if(request_range.size() == 0) { return resize_info{}; }
+
+			if(buffer.storage->get_range().size() == 0) { return resize_info{true, request_offset, request_range}; }
+
 			const cl::sycl::range<3> old_abs_range = range_cast<3>(buffer.offset + buffer.storage->get_range());
 			const cl::sycl::range<3> new_abs_range = range_cast<3>(request_offset + request_range);
 			const bool is_inside_old_range = ((request_offset >= buffer.offset) == cl::sycl::id<3>(true, true, true))

--- a/include/buffer_storage.h
+++ b/include/buffer_storage.h
@@ -246,6 +246,7 @@ namespace detail {
 
 		static celerity::range<Dims> make_device_buf_effective_range(sycl::range<Dims> range) {
 #if WORKAROUND_COMPUTECPP || WORKAROUND_DPCPP
+			// ComputeCpp and DPC++ do not support empty buffers, so we make a unit-sized dummy allocation instead.
 			for(int d = 0; d < Dims; ++d) {
 				range[d] = std::max(size_t{1}, range[d]);
 			}

--- a/include/command_graph.h
+++ b/include/command_graph.h
@@ -129,7 +129,13 @@ namespace detail {
 			return iterable_range{make_transform_iterator(commands.cbegin(), transform), make_transform_iterator(commands.cend(), transform)};
 		}
 
-		auto& task_commands(task_id tid) { return by_task.at(tid); }
+		const std::vector<task_command*>& task_commands(const task_id tid) const {
+			if(const auto it = by_task.find(tid); it != by_task.end()) {
+				return it->second;
+			} else {
+				return no_task_commands;
+			}
+		}
 
 		void print_graph(logger& graph_logger) const;
 
@@ -155,6 +161,7 @@ namespace detail {
 		// TODO: Consider storing commands in a contiguous memory data structure instead
 		std::unordered_map<command_id, std::unique_ptr<abstract_command>> commands;
 		std::unordered_map<task_id, std::vector<task_command*>> by_task;
+		std::vector<task_command*> no_task_commands; // left empty
 
 		// Set of per-node commands with no dependents
 		std::unordered_map<node_id, std::unordered_set<abstract_command*>> execution_fronts;

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -54,10 +54,11 @@ namespace detail {
 #undef MAKE_COMPONENT_WISE_BINARY_FN
 
 	struct {
-		operator cl::sycl::range<1>() const { return {0}; }
-		operator cl::sycl::range<2>() const { return {0, 0}; }
-		operator cl::sycl::range<3>() const { return {0, 0, 0}; }
-	} inline constexpr zero_range;
+		size_t value;
+		constexpr operator cl::sycl::range<1>() const { return {value}; }
+		constexpr operator cl::sycl::range<2>() const { return {value, value}; }
+		constexpr operator cl::sycl::range<3>() const { return {value, value, value}; }
+	} inline constexpr zero_range{0}, unit_range{1};
 
 }; // namespace detail
 

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -55,9 +55,9 @@ namespace detail {
 
 	struct {
 		size_t value;
-		constexpr operator cl::sycl::range<1>() const { return {value}; }
-		constexpr operator cl::sycl::range<2>() const { return {value, value}; }
-		constexpr operator cl::sycl::range<3>() const { return {value, value, value}; }
+		operator cl::sycl::range<1>() const { return {value}; }
+		operator cl::sycl::range<2>() const { return {value, value}; }
+		operator cl::sycl::range<3>() const { return {value, value, value}; }
 	} inline constexpr zero_range{0}, unit_range{1};
 
 }; // namespace detail
@@ -69,8 +69,8 @@ struct chunk {
 	static constexpr int dims = Dims;
 
 	celerity::id<Dims> offset;
-	celerity::range<Dims> range = detail::range_cast<Dims>(celerity::range<3>(0, 0, 0));
-	celerity::range<Dims> global_size = detail::range_cast<Dims>(celerity::range<3>(0, 0, 0));
+	celerity::range<Dims> range = detail::zero_range;
+	celerity::range<Dims> global_size = detail::zero_range;
 
 	chunk() = default;
 

--- a/include/task.h
+++ b/include/task.h
@@ -131,7 +131,7 @@ namespace detail {
 		}
 
 		static std::unique_ptr<task> make_master_node(task_id tid, std::unique_ptr<command_group_storage_base> cgf, buffer_access_map access_map) {
-			return std::unique_ptr<task>(new task(tid, task_type::MASTER_NODE, {}, 0, {0, 0, 0}, {}, {1, 1, 1}, std::move(cgf), std::move(access_map), {}, {}));
+			return std::unique_ptr<task>(new task(tid, task_type::MASTER_NODE, {}, 0, {1, 1, 1}, {}, {1, 1, 1}, std::move(cgf), std::move(access_map), {}, {}));
 		}
 
 		static std::unique_ptr<task> make_horizon_task(task_id tid) {

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -65,6 +65,11 @@ namespace detail {
 				}
 				last_collective_commands.emplace(cgid, cmd->get_cid());
 			}
+		} else if(tsk->get_global_size().size() == 0
+		          && std::all_of(tsk->get_reductions().begin(), tsk->get_reductions().end(), //
+		              [&](const reduction_id rid) { return reduction_mngr.get_reduction(rid).initialize_from_buffer; })) {
+			// the task has an empty execution range and does not need a reduction initializer -> do not generate any commands
+			return;
 		} else {
 			const auto sr = subrange<3>{tsk->get_global_offset(), tsk->get_global_size()};
 			cdag.create<task_command>(0, tid, sr);

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -119,9 +119,9 @@ namespace detail {
 			if(std::any_of(modes.cbegin(), modes.cend(), detail::access::mode_traits::is_producer) || reduction.has_value()) {
 				auto write_requirements = get_requirements(tsk.get(), bid, {detail::access::producer_modes.cbegin(), detail::access::producer_modes.cend()});
 				if(reduction.has_value()) { write_requirements = GridRegion<3>::merge(write_requirements, GridRegion<3>{{1, 1, 1}}); }
-				assert(!write_requirements.empty() && "Task specified empty buffer range requirement. This indicates potential anti-pattern.");
-				const auto last_writers = buffers_last_writers.at(bid).get_region_values(write_requirements);
+				if(write_requirements.empty()) continue;
 
+				const auto last_writers = buffers_last_writers.at(bid).get_region_values(write_requirements);
 				for(auto& p : last_writers) {
 					if(p.second == std::nullopt) continue;
 					assert(task_map.count(*p.second) == 1);

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -1459,5 +1459,87 @@ namespace detail {
 		maybe_print_graphs(ctx);
 	}
 
+
+	TEST_CASE("buffer accesses with empty ranges do not generate pushes or data-flow dependencies", "[graph_generator][command-graph]") {
+		constexpr size_t num_nodes = 2;
+		test_utils::cdag_test_context ctx(num_nodes);
+		auto& tm = ctx.get_task_manager();
+		auto& ggen = ctx.get_graph_generator();
+
+		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		const range<1> buf_range{16};
+		auto buf = mbf.create_buffer(buf_range);
+
+		const auto write_rm = [&](chunk<1> chnk) {
+			const range<1> rg{chnk.offset[0] < 8 ? 8 - chnk.offset[0] : 0};
+			return subrange<1>{chnk.offset, rg};
+		};
+		const auto write_tid = test_utils::build_and_flush(ctx, num_nodes,
+		    test_utils::add_compute_task<class UKN(write)>(
+		        tm, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, write_rm); }, buf_range));
+
+		const auto read_rm = [&](chunk<1> chnk) {
+			subrange<1> sr;
+			sr.offset[0] = 4;
+			sr.range[0] = chnk.offset[0] + chnk.range[0] > 4 ? chnk.offset[0] + chnk.range[0] - 4 : 0;
+			return sr;
+		};
+		const auto read_tid = test_utils::build_and_flush(ctx, num_nodes,
+		    test_utils::add_compute_task<class UKN(read)>(
+		        tm, [&](handler& cgh) { buf.get_access<access_mode::read>(cgh, read_rm); }, buf_range / 2));
+
+		maybe_print_graphs(ctx);
+
+		CHECK(has_dependency(tm, read_tid, write_tid));
+
+		auto& inspector = ctx.get_inspector();
+		auto& cdag = ctx.get_command_graph();
+
+		const abstract_command* write_cmds[num_nodes];
+		{
+			const auto write_cids = inspector.get_commands(write_tid, std::nullopt, std::nullopt);
+			REQUIRE(write_cids.size() == num_nodes); // naive split
+			for(const auto cid : write_cids) {
+				const auto cmd = cdag.get(cid);
+				write_cmds[cmd->get_nid()] = cmd;
+			}
+		}
+
+		const abstract_command* read_cmds[num_nodes];
+		{
+			const auto read_cids = inspector.get_commands(read_tid, std::nullopt, std::nullopt);
+			REQUIRE(read_cids.size() == num_nodes); // naive split
+			for(const auto cid : read_cids) {
+				const auto cmd = cdag.get(cid);
+				read_cmds[cmd->get_nid()] = cmd;
+			}
+		}
+
+		CHECK(!inspector.has_dependency(read_cmds[0]->get_cid(), write_cmds[0]->get_cid()));
+		CHECK(!inspector.has_dependency(read_cmds[1]->get_cid(), write_cmds[1]->get_cid()));
+
+		const abstract_command* push_cmd;
+		{
+			const auto pushes = inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH);
+			REQUIRE(pushes.size() == 1);
+			push_cmd = cdag.get(*pushes.begin());
+			CHECK(push_cmd->get_nid() == 0);
+			const auto push_dependencies = push_cmd->get_dependencies();
+			REQUIRE(std::distance(push_dependencies.begin(), push_dependencies.end()) == 1);
+			CHECK(push_dependencies.begin()->node == write_cmds[0]);
+		}
+
+		const abstract_command* await_push_cmd;
+		{
+			const auto await_pushes = inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH);
+			REQUIRE(await_pushes.size() == 1);
+			await_push_cmd = cdag.get(*await_pushes.begin());
+			CHECK(await_push_cmd->get_nid() == 1);
+			const auto await_push_dependents = await_push_cmd->get_dependents();
+			REQUIRE(std::distance(await_push_dependents.begin(), await_push_dependents.end()) == 1);
+			CHECK(await_push_dependents.begin()->node == read_cmds[1]);
+		}
+	}
+
 } // namespace detail
 } // namespace celerity

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -414,8 +414,8 @@ namespace test_utils {
 		accessor<DataT, Dims, Mode, target::device> get_device_accessor(
 		    detail::live_pass_device_handler& cgh, detail::buffer_id bid, const cl::sycl::range<Dims>& range, const cl::sycl::id<Dims>& offset) {
 			auto buf_info = bm->get_device_buffer<DataT, Dims>(bid, Mode, detail::range_cast<3>(range), detail::id_cast<3>(offset));
-			return detail::make_device_accessor<DataT, Dims, Mode>(
-			    cgh.get_eventual_sycl_cgh(), subrange<Dims>(offset, range), buf_info.buffer, buf_info.offset);
+			return detail::make_device_accessor<DataT, Dims, Mode>(cgh.get_eventual_sycl_cgh(), buf_info.buffer,
+			    detail::get_effective_sycl_accessor_subrange(buf_info.offset, subrange<Dims>(offset, range)), offset);
 		}
 
 		template <typename DataT, int Dims, access_mode Mode>

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -118,9 +118,11 @@ namespace test_utils {
 			std::transform(commands.cbegin(), commands.cend(), std::inserter(result, result.begin()), [](auto p) { return p.first; });
 
 			if(tid != std::nullopt) {
-				auto& task_set = by_task.at(*tid);
 				std::set<detail::command_id> new_result;
-				std::set_intersection(result.cbegin(), result.cend(), task_set.cbegin(), task_set.cend(), std::inserter(new_result, new_result.begin()));
+				if(const auto task_it = by_task.find(*tid); task_it != by_task.end()) {
+					const auto& task_set = task_it->second;
+					std::set_intersection(result.cbegin(), result.cend(), task_set.cbegin(), task_set.cend(), std::inserter(new_result, new_result.begin()));
+				}
 				result = std::move(new_result);
 			}
 			if(nid != std::nullopt) {


### PR DESCRIPTION
**Note:** This changeset is based on #89, so that PR will have to be merged first. It also requires #84 to be merged for all tests to work correctly.

This PR ensures that compute and host tasks with empty execution ranges only generate necessary dependencies and CDAG nodes.

For consistency, a TDAG node is always generated, but without introducing dataflow dependencies, even when using constant range mappers. It therefore does not count against the pseudo-critical path length in the general case. The one exception is for tasks that include reductions with `property::reduction::initialize_to_identity`, which have to perform a buffer write regardless of the execution range.

CDAG nodes are only generated for tasks that have non-empty execution range or that need a reduction initializer command.