### PR TITLE
Experimental windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,8 @@ target_link_libraries(celerity_runtime PUBLIC
   Threads::Threads
   MPI::MPI_CXX
   spdlog::spdlog
+  $<$<AND:$<BOOL:${WIN32}>,$<CONFIG:Debug>>:sycld>
+  $<$<AND:$<BOOL:${WIN32}>,$<CONFIG:Release>>:sycl>
 )
 
 # For debug builds, we set the CELERITY_DETAIL_ENABLE_DEBUG preprocessor flag,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,8 @@ target_include_directories(celerity_runtime PUBLIC
   $<INSTALL_INTERFACE:include/celerity/vendor>
 )
 
+# With DPC++ on windows the correct release (sycl) / debug (sycld) library needs to be linked,
+# because they are not ABI compatible.
 if(WIN32 AND CELERITY_SYCL_IMPL STREQUAL "DPC++")
   set(SYCL_LIB
     $<$<CONFIG:Debug>:sycld>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if(CELERITY_SYCL_IMPL STREQUAL "ComputeCpp")
   endif()
 endif()
 
-if(MSVC)
+if(WIN32)
   list(APPEND CELERITY_CXX_FLAGS -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
@@ -280,7 +280,7 @@ add_sycl_to_target(
 )
 
 if(MSVC)
-  target_compile_options(celerity_runtime PRIVATE /MP /W3 /D_CRT_SECURE_NO_WARNINGS)
+  target_compile_options(celerity_runtime PRIVATE /MP /W3)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
   target_compile_options(celerity_runtime PRIVATE -Wall -Wextra -Wno-unused-parameter -Werror=return-type -Werror=init-self)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,12 +216,18 @@ target_include_directories(celerity_runtime PUBLIC
   $<INSTALL_INTERFACE:include/celerity/vendor>
 )
 
+if(WIN32 AND CELERITY_SYCL_IMPL STREQUAL "DPC++")
+  set(SYCL_LIB
+    $<$<CONFIG:Debug>:sycld>
+    $<$<CONFIG:Release>:sycl>
+  )
+endif()
+
 target_link_libraries(celerity_runtime PUBLIC
   Threads::Threads
   MPI::MPI_CXX
   spdlog::spdlog
-  $<$<AND:$<BOOL:${WIN32}>,$<CONFIG:Debug>>:sycld>
-  $<$<AND:$<BOOL:${WIN32}>,$<CONFIG:Release>>:sycl>
+  ${SYCL_LIB}
 )
 
 # For debug builds, we set the CELERITY_DETAIL_ENABLE_DEBUG preprocessor flag,

--- a/include/handler.h
+++ b/include/handler.h
@@ -38,7 +38,6 @@ namespace detail {
 	template <typename Name>
 	std::string kernel_debug_name() {
 		std::string name = typeid(Name*).name();
-		// TODO: On Windows, returned names are still a bit messy. Consider improving this.
 #if !defined(_MSC_VER)
 		const std::unique_ptr<char, void (*)(void*)> demangled(abi::__cxa_demangle(name.c_str(), nullptr, nullptr, nullptr), std::free);
 		const std::string demangled_s(demangled.get());

--- a/include/handler.h
+++ b/include/handler.h
@@ -47,6 +47,10 @@ namespace detail {
 		} else {
 			name = demangled_s;
 		}
+#elif defined(_MSC_VER)
+		if(size_t lastc, id_end; (lastc = name.rfind(":")) != std::string::npos && (id_end = name.find(" ", lastc)) != std::string::npos) {
+			name = name.substr(lastc + 1, id_end - lastc);
+		}
 #endif
 		return name.substr(0, name.length() - 1);
 	}

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -6,6 +6,8 @@
 #include <random>
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <Windows.h>
 #else
 #include <pthread.h>

--- a/test/sycl_tests.cc
+++ b/test/sycl_tests.cc
@@ -152,7 +152,9 @@ TEST_CASE_METHOD(test_utils::device_queue_fixture, "SYCL can access empty buffer
 
 // If this test fails, celerity can't reliably support reductions on the user's combination of backend and hardware
 TEST_CASE_METHOD(test_utils::device_queue_fixture, "SYCL has working simple scalar reductions", "[sycl][reductions]") {
-	constexpr size_t N = 1024;
+	const size_t N = GENERATE(64, 512, 1024, 4096);
+	CAPTURE(N);
+
 	sycl::buffer<int> buf{1};
 
 	get_device_queue().get_sycl_queue().submit([&](sycl::handler& cgh) {
@@ -161,7 +163,7 @@ TEST_CASE_METHOD(test_utils::device_queue_fixture, "SYCL has working simple scal
 	});
 
 	sycl::host_accessor acc{buf};
-	CHECK(acc[0] == N);
+	CHECK(static_cast<size_t>(acc[0]) == N);
 }
 
 #endif

--- a/test/sycl_tests.cc
+++ b/test/sycl_tests.cc
@@ -150,6 +150,7 @@ TEST_CASE_METHOD(test_utils::device_queue_fixture, "SYCL can access empty buffer
 
 #if CELERITY_FEATURE_SIMPLE_SCALAR_REDUCTIONS
 
+// If this test fails, celerity can't reliably support reductions on the user's combination of backend and hardware
 TEST_CASE_METHOD(test_utils::device_queue_fixture, "SYCL has working simple scalar reductions", "[sycl][reductions]") {
 	constexpr size_t N = 1024;
 	sycl::buffer<int> buf{1};


### PR DESCRIPTION
This PR adds experimental windows support. Currently only DPC++ as the compiler, and running with an OpenCL backend on an Intel CPU has been tested and confirmed working. Using DPC++ with a CUDA backend has also been investigated, but does not work reliably in all configurations.  

Additionally, this PR includes a simple SYCL reductions test with 1024 elements, because using an Intel i7 4790k with DPC++ on windows results in an `CL_OUT_OF_RESOURCES` exception, when running even trivial reductions with more than 1023 elements. It is currently unclear whether this only happens on windows, and further testing with the same hardware on linux will be done.