### PR TITLE
Fix cpu affinity runtime test permanently setting affinity of 1

### DIFF
--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -2321,8 +2321,6 @@ namespace detail {
 	}
 
 
-#ifdef _WIN32
-
 	class restore_process_affinity_fixture {
 		restore_process_affinity_fixture(const restore_process_affinity_fixture&) = delete;
 		restore_process_affinity_fixture(restore_process_affinity_fixture&&) = delete;
@@ -2330,9 +2328,10 @@ namespace detail {
 		restore_process_affinity_fixture& operator=(restore_process_affinity_fixture&&) = delete;
 
 	  public:
+#ifdef _WIN32
 		restore_process_affinity_fixture() {
 			[[maybe_unused]] DWORD_PTR system_mask;
-			auto ret = GetProcessAffinityMask(GetCurrentProcess(), &process_mask, &system_mask);
+			const auto ret = GetProcessAffinityMask(GetCurrentProcess(), &process_mask, &system_mask);
 			REQUIRE(ret != FALSE);
 		}
 
@@ -2343,17 +2342,7 @@ namespace detail {
 
 	  private:
 		DWORD_PTR process_mask;
-	};
-
 #else
-
-	class restore_process_affinity_fixture {
-		restore_process_affinity_fixture(const restore_process_affinity_fixture&) = delete;
-		restore_process_affinity_fixture(restore_process_affinity_fixture&&) = delete;
-		restore_process_affinity_fixture& operator=(const restore_process_affinity_fixture&) = delete;
-		restore_process_affinity_fixture& operator=(restore_process_affinity_fixture&&) = delete;
-
-	  public:
 		restore_process_affinity_fixture() {
 			const auto ret = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &process_mask);
 			REQUIRE(ret == 0);
@@ -2366,9 +2355,8 @@ namespace detail {
 
 	  private:
 		cpu_set_t process_mask;
-	};
-
 #endif
+	};
 
 	TEST_CASE_METHOD(restore_process_affinity_fixture, "affinity check", "[affinity]") {
 #ifdef _WIN32

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -5,14 +5,6 @@
 #include <memory>
 #include <random>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <Windows.h>
-#else
-#include <pthread.h>
-#endif
-
 #include <catch2/catch.hpp>
 
 #include <celerity.h>
@@ -2321,18 +2313,20 @@ namespace detail {
 	}
 
 
-	TEST_CASE("affinity check", "[affinity]") {
+	TEST_CASE_METHOD(test_utils::affinity_fixture, "affinity check", "[affinity]") {
 #ifdef _WIN32
 		SECTION("in Windows") {
 			DWORD_PTR cpu_mask = 1;
-			SetProcessAffinityMask(GetCurrentProcess(), cpu_mask);
+			const auto ret = SetProcessAffinityMask(GetCurrentProcess(), cpu_mask);
+			REQUIRE(ret != FALSE);
 		}
 #else
 		SECTION("in Posix") {
 			cpu_set_t cpu_mask;
 			CPU_ZERO(&cpu_mask);
 			CPU_SET(0, &cpu_mask);
-			pthread_setaffinity_np(pthread_self(), sizeof(cpu_mask), &cpu_mask);
+			const auto ret = pthread_setaffinity_np(pthread_self(), sizeof(cpu_mask), &cpu_mask);
+			REQUIRE(ret == 0);
 		}
 #endif
 		const auto cores = affinity_cores_available();

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -475,19 +475,18 @@ namespace test_utils {
 
 	class affinity_fixture {
 	  public:
-		affinity_fixture() : process_handle(GetCurrentProcess()) {
+		affinity_fixture() {
 			[[maybe_unused]] DWORD_PTR system_mask;
-			auto ret = GetProcessAffinityMask(process_handle, &process_mask, &system_mask);
+			auto ret = GetProcessAffinityMask(GetCurrentProcess(), &process_mask, &system_mask);
 			REQUIRE(ret != FALSE);
 		}
 
 		~affinity_fixture() {
-			const auto ret = SetProcessAffinityMask(process_handle, process_mask);
+			const auto ret = SetProcessAffinityMask(GetCurrentProcess(), process_mask);
 			REQUIRE(ret != FALSE);
 		}
 
 	  private:
-		const HANDLE process_handle;
 		DWORD_PTR process_mask;
 	};
 
@@ -495,18 +494,17 @@ namespace test_utils {
 
 	class affinity_fixture {
 	  public:
-		affinity_fixture() : process_handle(pthread_self()) {
-			const auto ret = pthread_getaffinity_np(process_handle, sizeof(cpu_set_t), &process_mask);
+		affinity_fixture() {
+			const auto ret = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &process_mask);
 			REQUIRE(ret == 0);
 		}
 
 		~affinity_fixture() {
-			const auto ret = pthread_setaffinity_np(process_handle, sizeof(process_mask), &process_mask);
+			const auto ret = pthread_setaffinity_np(pthread_self(), sizeof(process_mask), &process_mask);
 			REQUIRE(ret == 0);
 		}
 
 	  private:
-		const pthread_t process_handle;
 		cpu_set_t process_mask;
 	};
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -3,14 +3,6 @@
 #include <map>
 #include <ostream>
 
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-#include <Windows.h>
-#else
-#include <pthread.h>
-#endif
-
 #include <catch2/catch.hpp>
 
 #include <celerity.h>
@@ -470,45 +462,6 @@ namespace test_utils {
 		bool initialized = false;
 		std::unique_ptr<detail::buffer_manager> bm;
 	};
-
-#ifdef _WIN32
-
-	class affinity_fixture {
-	  public:
-		affinity_fixture() {
-			[[maybe_unused]] DWORD_PTR system_mask;
-			auto ret = GetProcessAffinityMask(GetCurrentProcess(), &process_mask, &system_mask);
-			REQUIRE(ret != FALSE);
-		}
-
-		~affinity_fixture() {
-			const auto ret = SetProcessAffinityMask(GetCurrentProcess(), process_mask);
-			REQUIRE(ret != FALSE);
-		}
-
-	  private:
-		DWORD_PTR process_mask;
-	};
-
-#else
-
-	class affinity_fixture {
-	  public:
-		affinity_fixture() {
-			const auto ret = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &process_mask);
-			REQUIRE(ret == 0);
-		}
-
-		~affinity_fixture() {
-			const auto ret = pthread_setaffinity_np(pthread_self(), sizeof(process_mask), &process_mask);
-			REQUIRE(ret == 0);
-		}
-
-	  private:
-		cpu_set_t process_mask;
-	};
-
-#endif
 
 } // namespace test_utils
 } // namespace celerity


### PR DESCRIPTION
This PR is based on #96, so that one should be merged first.  

The cpu affinity runtime test currently sets the cpu affinity of the process to 1, but never restores the original affinity, leading to warnings in subsequent tests about not enough assigned cpu cores. This PR fixes this by introducing a test fixture that uses RAII to store the original affinity on test startup, and restore it after the test has been completed.