### PR TITLE
Named threads for better debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,8 +197,11 @@ set(SOURCES
 
 if(WIN32)
   set(SOURCES ${SOURCES} src/platform_specific/affinity.win.cc)
- elseif(UNIX AND NOT APPLE)
+  set(SOURCES ${SOURCES} src/platform_specific/named_threads.win.cc)
+elseif(UNIX AND NOT APPLE)
   set(SOURCES ${SOURCES} src/platform_specific/affinity.unix.cc)
+elseif(UNIX)
+  set(SOURCES ${SOURCES} src/platform_specific/named_threads.unix.cc)
 endif()
 
 add_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,9 +198,10 @@ set(SOURCES
 if(WIN32)
   set(SOURCES ${SOURCES} src/platform_specific/affinity.win.cc)
   set(SOURCES ${SOURCES} src/platform_specific/named_threads.win.cc)
-elseif(UNIX AND NOT APPLE)
-  set(SOURCES ${SOURCES} src/platform_specific/affinity.unix.cc)
 elseif(UNIX)
+  if(NOT APPLE)
+    set(SOURCES ${SOURCES} src/platform_specific/affinity.unix.cc)
+  endif()
   set(SOURCES ${SOURCES} src/platform_specific/named_threads.unix.cc)
 endif()
 

--- a/include/executor.h
+++ b/include/executor.h
@@ -39,6 +39,8 @@ namespace detail {
 	};
 
 	class executor {
+		friend struct executor_testspy;
+
 	  public:
 		// TODO: Try to decouple this more.
 		executor(

--- a/include/host_queue.h
+++ b/include/host_queue.h
@@ -10,6 +10,7 @@
 #include <mpi.h>
 
 #include "config.h"
+#include "named_threads.h"
 #include "types.h"
 
 namespace celerity {
@@ -159,7 +160,12 @@ namespace detail {
 			MPI_Comm comm;
 			ctpl::thread_pool thread;
 
-			comm_thread(MPI_Comm comm, size_t n_threads) : comm(comm), thread(n_threads) {}
+			comm_thread(MPI_Comm comm, size_t n_threads) : comm(comm), thread(n_threads) {
+				for(size_t i = 0; i < n_threads; ++i) {
+					auto& worker = thread.get_thread(i);
+					set_thread_name(worker, "worker" + std::to_string(i));
+				}
+			}
 		};
 
 		std::unordered_map<collective_group_id, comm_thread> threads;

--- a/include/host_queue.h
+++ b/include/host_queue.h
@@ -163,7 +163,7 @@ namespace detail {
 			comm_thread(MPI_Comm comm, size_t n_threads) : comm(comm), thread(n_threads) {
 				for(size_t i = 0; i < n_threads; ++i) {
 					auto& worker = thread.get_thread(i);
-					set_thread_name(worker, "worker" + std::to_string(i));
+					set_thread_name(worker.native_handle(), "worker" + std::to_string(i));
 				}
 			}
 		};

--- a/include/named_threads.h
+++ b/include/named_threads.h
@@ -5,12 +5,10 @@
 
 namespace celerity::detail {
 
-void set_thread_name(std::thread& thread, const std::string& name);
+std::thread::native_handle_type get_current_thread_handle();
 
-void set_current_thread_name(const std::string& name);
+void set_thread_name(const std::thread::native_handle_type thread_handle, const std::string& name);
 
-std::string get_thread_name(std::thread& thread);
-
-std::string get_current_thread_name();
+std::string get_thread_name(const std::thread::native_handle_type thread_handle);
 
 } // namespace celerity::detail

--- a/include/named_threads.h
+++ b/include/named_threads.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <thread>
+
+namespace celerity::detail {
+
+void set_thread_name(std::thread& thread, const std::string& name);
+
+void set_current_thread_name(const std::string& name);
+
+std::string get_thread_name(std::thread& thread);
+
+std::string get_current_thread_name();
+
+} // namespace celerity::detail

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -37,6 +37,8 @@ namespace detail {
 	};
 
 	class runtime {
+		friend struct runtime_testspy;
+
 	  public:
 		/**
 		 * @param user_device This optional device can be provided by the user, overriding any other device selection strategy.

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -21,6 +21,8 @@ namespace detail {
 	};
 
 	class scheduler {
+		friend struct scheduler_testspy;
+
 	  public:
 		scheduler(graph_generator& ggen, graph_serializer& gsrlzr, size_t num_nodes);
 

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -33,7 +33,7 @@ namespace detail {
 
 	void executor::startup() {
 		exec_thrd = std::thread(&executor::run, this);
-		set_thread_name(exec_thrd.native_handle(), "executor");
+		set_thread_name(exec_thrd.native_handle(), "cy-executor");
 	}
 
 	void executor::shutdown() {

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -33,7 +33,7 @@ namespace detail {
 
 	void executor::startup() {
 		exec_thrd = std::thread(&executor::run, this);
-		set_thread_name(exec_thrd, "executor");
+		set_thread_name(exec_thrd.native_handle(), "executor");
 	}
 
 	void executor::shutdown() {

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -5,6 +5,7 @@
 #include "distr_queue.h"
 #include "log.h"
 #include "mpi_support.h"
+#include "named_threads.h"
 
 // TODO: Get rid of this. (This could potentialy even cause deadlocks on large clusters)
 constexpr size_t MAX_CONCURRENT_JOBS = 20;
@@ -30,7 +31,10 @@ namespace detail {
 		metrics.initial_idle.resume();
 	}
 
-	void executor::startup() { exec_thrd = std::thread(&executor::run, this); }
+	void executor::startup() {
+		exec_thrd = std::thread(&executor::run, this);
+		set_thread_name(exec_thrd, "executor");
+	}
 
 	void executor::shutdown() {
 		if(exec_thrd.joinable()) { exec_thrd.join(); }

--- a/src/platform_specific/named_threads.unix.cc
+++ b/src/platform_specific/named_threads.unix.cc
@@ -12,34 +12,22 @@ static_assert(std::is_same_v<std::thread::native_handle_type, pthread_t>, "Unexp
 
 constexpr auto PTHREAD_MAX_THREAD_NAME_LEN = 16;
 
-static inline void set_thread_name_unix(const pthread_t thread_handle, const std::string& name) {
+std::thread::native_handle_type get_current_thread_handle() {
+	return pthread_self();
+}
+
+void set_thread_name(const std::thread::native_handle_type thread_handle, const std::string& name) {
 	auto truncated_name = name;
 	truncated_name.resize(PTHREAD_MAX_THREAD_NAME_LEN - 1); // -1 because of null terminator
 	[[maybe_unused]] const auto res = pthread_setname_np(thread_handle, truncated_name.c_str());
 	assert(res == 0 && "Failed to set thread name");
 }
 
-static inline std::string get_thread_name_unix(const pthread_t thread_handle) {
+std::string get_thread_name(const std::thread::native_handle_type thread_handle) {
 	auto name = std::vector<char>(PTHREAD_MAX_THREAD_NAME_LEN, '\0');
 	[[maybe_unused]] const auto res = pthread_getname_np(thread_handle, name.data(), name.size());
 	assert(res == 0 && "Failed to get thread name");
 	return name.data(); // Strip null terminator
-}
-
-void set_thread_name(std::thread& thread, const std::string& name) {
-	set_thread_name_unix(thread.native_handle(), name);
-}
-
-void set_current_thread_name(const std::string& name) {
-	set_thread_name_unix(pthread_self(), name);
-}
-
-std::string get_thread_name(std::thread& thread) {
-	return get_thread_name_unix(thread.native_handle());
-}
-
-std::string get_current_thread_name() {
-	return get_thread_name_unix(pthread_self());
 }
 
 } // namespace celerity::detail

--- a/src/platform_specific/named_threads.unix.cc
+++ b/src/platform_specific/named_threads.unix.cc
@@ -2,7 +2,6 @@
 
 #include <cassert>
 #include <type_traits>
-#include <vector>
 
 #include <pthread.h>
 
@@ -24,10 +23,10 @@ void set_thread_name(const std::thread::native_handle_type thread_handle, const 
 }
 
 std::string get_thread_name(const std::thread::native_handle_type thread_handle) {
-	auto name = std::vector<char>(PTHREAD_MAX_THREAD_NAME_LEN, '\0');
-	[[maybe_unused]] const auto res = pthread_getname_np(thread_handle, name.data(), name.size());
+	char name[PTHREAD_MAX_THREAD_NAME_LEN] = {};
+	[[maybe_unused]] const auto res = pthread_getname_np(thread_handle, name, PTHREAD_MAX_THREAD_NAME_LEN);
 	assert(res == 0 && "Failed to get thread name");
-	return name.data(); // Strip null terminator
+	return name; // Automatically strips null terminator
 }
 
 } // namespace celerity::detail

--- a/src/platform_specific/named_threads.unix.cc
+++ b/src/platform_specific/named_threads.unix.cc
@@ -1,13 +1,44 @@
 #include "named_threads.h"
 
+#include <cassert>
+#include <type_traits>
+
+#include <pthread.h>
+
 namespace celerity::detail {
 
-void set_thread_name(std::thread& thread, const std::string& name) {}
+static_assert(std::is_same_v<std::thread::native_handle_type, pthread_t>, "Unexpected native thread handle type");
 
-void set_current_thread_name(const std::string& name) {}
+constexpr auto PTHREAD_MAX_THREAD_NAME_LEN = 16;
 
-std::string get_thread_name(std::thread& thread) {}
+static inline void set_thread_name_unix(const pthread_t thread_handle, const std::string& name) {
+	auto truncated_name = name;
+	truncated_name.resize(PTHREAD_MAX_THREAD_NAME_LEN - 1); // -1 because of null terminator
+	const auto res = pthread_setname_np(thread_handle, truncated_name.c_str());
+	assert(res == 0 && "Failed to set thread name");
+}
 
-std::string get_current_thread_name() {}
+static inline std::string get_thread_name_unix(const pthread_t thread_handle) {
+	auto name = std::string(PTHREAD_MAX_THREAD_NAME_LEN, '\0');
+	const auto res = pthread_getname_np(thread_handle, name.data(), name.size());
+	assert(res == 0 && "Failed to get thread name");
+	return name.c_str(); // Strip null terminator
+}
+
+void set_thread_name(std::thread& thread, const std::string& name) {
+	set_thread_name_unix(thread.native_handle(), name);
+}
+
+void set_current_thread_name(const std::string& name) {
+	set_thread_name_unix(pthread_self(), name);
+}
+
+std::string get_thread_name(std::thread& thread) {
+	return get_thread_name_unix(thread.native_handle());
+}
+
+std::string get_current_thread_name() {
+	return get_thread_name_unix(pthread_self());
+}
 
 } // namespace celerity::detail

--- a/src/platform_specific/named_threads.unix.cc
+++ b/src/platform_specific/named_threads.unix.cc
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <type_traits>
+#include <vector>
 
 #include <pthread.h>
 
@@ -19,10 +20,10 @@ static inline void set_thread_name_unix(const pthread_t thread_handle, const std
 }
 
 static inline std::string get_thread_name_unix(const pthread_t thread_handle) {
-	auto name = std::string(PTHREAD_MAX_THREAD_NAME_LEN, '\0');
+	auto name = std::vector<char>(PTHREAD_MAX_THREAD_NAME_LEN, '\0');
 	[[maybe_unused]] const auto res = pthread_getname_np(thread_handle, name.data(), name.size());
 	assert(res == 0 && "Failed to get thread name");
-	return name.c_str(); // Strip null terminator
+	return name.data(); // Strip null terminator
 }
 
 void set_thread_name(std::thread& thread, const std::string& name) {

--- a/src/platform_specific/named_threads.unix.cc
+++ b/src/platform_specific/named_threads.unix.cc
@@ -14,13 +14,13 @@ constexpr auto PTHREAD_MAX_THREAD_NAME_LEN = 16;
 static inline void set_thread_name_unix(const pthread_t thread_handle, const std::string& name) {
 	auto truncated_name = name;
 	truncated_name.resize(PTHREAD_MAX_THREAD_NAME_LEN - 1); // -1 because of null terminator
-	const auto res = pthread_setname_np(thread_handle, truncated_name.c_str());
+	[[maybe_unused]] const auto res = pthread_setname_np(thread_handle, truncated_name.c_str());
 	assert(res == 0 && "Failed to set thread name");
 }
 
 static inline std::string get_thread_name_unix(const pthread_t thread_handle) {
 	auto name = std::string(PTHREAD_MAX_THREAD_NAME_LEN, '\0');
-	const auto res = pthread_getname_np(thread_handle, name.data(), name.size());
+	[[maybe_unused]] const auto res = pthread_getname_np(thread_handle, name.data(), name.size());
 	assert(res == 0 && "Failed to get thread name");
 	return name.c_str(); // Strip null terminator
 }

--- a/src/platform_specific/named_threads.unix.cc
+++ b/src/platform_specific/named_threads.unix.cc
@@ -1,0 +1,13 @@
+#include "named_threads.h"
+
+namespace celerity::detail {
+
+void set_thread_name(std::thread& thread, const std::string& name) {}
+
+void set_current_thread_name(const std::string& name) {}
+
+std::string get_thread_name(std::thread& thread) {}
+
+std::string get_current_thread_name() {}
+
+} // namespace celerity::detail

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -32,13 +32,17 @@ static inline DstT convert_string(const SrcT& str) {
 	return dst;
 }
 
-static inline void set_thread_name_windows(const HANDLE thread_handle, const std::string& name) {
+std::thread::native_handle_type get_current_thread_handle() {
+	return GetCurrentThread();
+}
+
+void set_thread_name(const std::thread::native_handle_type thread_handle, const std::string& name) {
 	const auto wname = convert_string<std::string, std::wstring>(name);
 	[[maybe_unused]] const auto res = SetThreadDescription(thread_handle, wname.c_str());
 	assert(SUCCEEDED(res) && "Failed to set thread name");
 }
 
-static inline std::string get_thread_name_windows(const HANDLE thread_handle) {
+std::string get_thread_name(const std::thread::native_handle_type thread_handle) {
 	PWSTR wname = nullptr;
 	const auto res = GetThreadDescription(thread_handle, &wname);
 	assert(SUCCEEDED(res) && "Failed to get thread name");
@@ -48,22 +52,6 @@ static inline std::string get_thread_name_windows(const HANDLE thread_handle) {
 		LocalFree(wname);
 	}
 	return name;
-}
-
-void set_thread_name(std::thread& thread, const std::string& name) {
-	set_thread_name_windows(thread.native_handle(), name);
-}
-
-void set_current_thread_name(const std::string& name) {
-	set_thread_name_windows(GetCurrentThread(), name);
-}
-
-std::string get_thread_name(std::thread& thread) {
-	return get_thread_name_windows(thread.native_handle());
-}
-
-std::string get_current_thread_name() {
-	return get_thread_name_windows(GetCurrentThread());
 }
 
 } // namespace celerity::detail

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -1,6 +1,7 @@
 #include "named_threads.h"
 
 #include <cassert>
+#include <cwchar>
 #include <type_traits>
 
 #include <windows.h>
@@ -9,22 +10,44 @@ namespace celerity::detail {
 
 static_assert(std::is_same_v<std::thread::native_handle_type, HANDLE>, "Unexpected native thread handle type");
 
+template <typename SrcT, typename DstT>
+static inline DstT convert_string(const SrcT& str) {
+	static_assert(
+	    (std::is_same_v<SrcT, std::string> && std::is_same_v<DstT, std::wstring>) || (std::is_same_v<SrcT, std::wstring> && std::is_same_v<DstT, std::string>),
+	    "Unsupported string type");
+
+	constexpr auto converter = [](typename DstT::value_type* dst, const typename SrcT::value_type** src, const std::size_t len, std::mbstate_t* ps) {
+		if constexpr(std::is_same_v<SrcT, std::string>) {
+			return std::mbsrtowcs(dst, src, len, ps);
+		} else {
+			return std::wcsrtombs(dst, src, len, ps);
+		}
+	};
+
+	const auto* src = str.c_str();
+	auto mbstate = std::mbstate_t{};
+	const auto len = converter(nullptr, &src, 0, &mbstate);
+	auto dst = DstT(len, L'\0'); // Automatically includes space for the null terminator
+	converter(dst.data(), &src, dst.size(), &mbstate);
+	return dst;
+}
+
 static inline void set_thread_name_windows(const HANDLE thread_handle, const std::string& name) {
-	const auto wname = std::wstring(name.begin(), name.end());
+	const auto wname = convert_string<std::string, std::wstring>(name);
 	[[maybe_unused]] const auto res = SetThreadDescription(thread_handle, wname.c_str());
 	assert(SUCCEEDED(res) && "Failed to set thread name");
 }
 
 static inline std::string get_thread_name_windows(const HANDLE thread_handle) {
-	PWSTR name = nullptr;
-	const auto res = GetThreadDescription(thread_handle, &name);
+	PWSTR wname = nullptr;
+	const auto res = GetThreadDescription(thread_handle, &wname);
 	assert(SUCCEEDED(res) && "Failed to get thread name");
-	std::string name_str;
+	std::string name;
 	if(SUCCEEDED(res)) {
-		name_str = std::string(name, name + wcslen(name));
-		LocalFree(name);
+		name = convert_string<std::wstring, std::string>(wname);
+		LocalFree(wname);
 	}
-	return name_str;
+	return name;
 }
 
 void set_thread_name(std::thread& thread, const std::string& name) {

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -45,7 +45,7 @@ std::string get_thread_name(const std::thread::native_handle_type thread_handle)
 	std::string name;
 	if(SUCCEEDED(res)) {
 		name = convert_string(wname);
-		LocalFree(wname);
+		LocalFree(wname); // Will leak if convert_string throws
 	}
 	return name;
 }

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -1,0 +1,43 @@
+#include "named_threads.h"
+
+#include <cassert>
+
+#include <windows.h>
+
+namespace celerity::detail {
+
+static inline void set_thread_name_windows(const HANDLE thread_handle, const std::string& name) {
+	const auto wname = std::wstring(name.begin(), name.end());
+	[[maybe_unused]] const auto res = SetThreadDescription(thread_handle, wname.c_str());
+	assert(SUCCEEDED(res) && "Failed to set thread name");
+}
+
+static inline std::string get_thread_name_windows(const HANDLE thread_handle) {
+	PWSTR name = nullptr;
+	const auto res = GetThreadDescription(thread_handle, &name);
+	assert(SUCCEEDED(res) && "Failed to get thread name");
+	std::string name_str;
+	if(SUCCEEDED(res)) {
+		name_str = std::string(name, name + wcslen(name));
+		LocalFree(name);
+	}
+	return name_str;
+}
+
+void set_thread_name(std::thread& thread, const std::string& name) {
+	set_thread_name_windows(thread.native_handle(), name);
+}
+
+void set_current_thread_name(const std::string& name) {
+	set_thread_name_windows(GetCurrentThread(), name);
+}
+
+std::string get_thread_name(std::thread& thread) {
+	return get_thread_name_windows(thread.native_handle());
+}
+
+std::string get_current_thread_name() {
+	return get_thread_name_windows(GetCurrentThread());
+}
+
+} // namespace celerity::detail

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -1,6 +1,7 @@
 #include "named_threads.h"
 
 #include <cassert>
+#include <type_traits>
 
 #include <windows.h>
 

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -6,6 +6,8 @@
 
 namespace celerity::detail {
 
+static_assert(std::is_same_v<std::thread::native_handle_type, HANDLE>, "Unexpected native thread handle type");
+
 static inline void set_thread_name_windows(const HANDLE thread_handle, const std::string& name) {
 	const auto wname = std::wstring(name.begin(), name.end());
 	[[maybe_unused]] const auto res = SetThreadDescription(thread_handle, wname.c_str());

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -22,6 +22,7 @@
 #include "host_object.h"
 #include "log.h"
 #include "mpi_support.h"
+#include "named_threads.h"
 #include "scheduler.h"
 #include "task_manager.h"
 #include "user_bench.h"
@@ -170,6 +171,7 @@ namespace detail {
 		is_active = true;
 		if(is_master_node()) { schdlr->startup(); }
 		exec->startup();
+		set_current_thread_name("main");
 	}
 
 	void runtime::shutdown() noexcept {

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -171,7 +171,7 @@ namespace detail {
 		is_active = true;
 		if(is_master_node()) { schdlr->startup(); }
 		exec->startup();
-		set_current_thread_name("main");
+		set_thread_name(get_current_thread_handle(), "main");
 	}
 
 	void runtime::shutdown() noexcept {

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -171,7 +171,7 @@ namespace detail {
 		is_active = true;
 		if(is_master_node()) { schdlr->startup(); }
 		exec->startup();
-		set_thread_name(get_current_thread_handle(), "main");
+		set_thread_name(get_current_thread_handle(), "cy-main");
 	}
 
 	void runtime::shutdown() noexcept {

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -2,6 +2,7 @@
 
 #include "graph_generator.h"
 #include "graph_serializer.h"
+#include "named_threads.h"
 #include "transformers/naive_split.h"
 
 namespace celerity {
@@ -9,7 +10,10 @@ namespace detail {
 
 	scheduler::scheduler(graph_generator& ggen, graph_serializer& gsrlzr, size_t num_nodes) : ggen(ggen), gsrlzr(gsrlzr), num_nodes(num_nodes) {}
 
-	void scheduler::startup() { worker_thread = std::thread(&scheduler::schedule, this); }
+	void scheduler::startup() {
+		worker_thread = std::thread(&scheduler::schedule, this);
+		set_thread_name(worker_thread, "scheduler");
+	}
 
 	void scheduler::shutdown() {
 		notify(scheduler_event_type::SHUTDOWN, 0);

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -12,7 +12,7 @@ namespace detail {
 
 	void scheduler::startup() {
 		worker_thread = std::thread(&scheduler::schedule, this);
-		set_thread_name(worker_thread.native_handle(), "scheduler");
+		set_thread_name(worker_thread.native_handle(), "cy-scheduler");
 	}
 
 	void scheduler::shutdown() {

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -12,7 +12,7 @@ namespace detail {
 
 	void scheduler::startup() {
 		worker_thread = std::thread(&scheduler::schedule, this);
-		set_thread_name(worker_thread, "scheduler");
+		set_thread_name(worker_thread.native_handle(), "scheduler");
 	}
 
 	void scheduler::shutdown() {

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -992,20 +992,20 @@ namespace detail {
 		auto& exec = runtime_testspy::get_exec(rt);
 
 		if(rt.is_master_node()) {
-			const auto scheduler_thread_name = get_thread_name(scheduler_testspy::get_worker_thread(schdlr));
+			const auto scheduler_thread_name = get_thread_name(scheduler_testspy::get_worker_thread(schdlr).native_handle());
 			CHECK(scheduler_thread_name == "scheduler");
 		}
 
-		const auto executor_thread_name = get_thread_name(executor_testspy::get_exec_thrd(exec));
+		const auto executor_thread_name = get_thread_name(executor_testspy::get_exec_thrd(exec).native_handle());
 		CHECK(executor_thread_name == "executor");
 
-		const auto main_thread_name = get_current_thread_name();
+		const auto main_thread_name = get_thread_name(get_current_thread_handle());
 		CHECK(main_thread_name == "main");
 
 		q.submit([](handler& cgh) {
 			cgh.host_task(experimental::collective, [&](experimental::collective_partition) {
 				const auto base_name = std::string("worker");
-				const auto worker_thread_name = get_current_thread_name();
+				const auto worker_thread_name = get_thread_name(get_current_thread_handle());
 				CHECK(worker_thread_name.compare(0, base_name.size(), base_name) == 0); // Check thread name starts with "worker"
 			});
 		});

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -985,7 +985,7 @@ namespace detail {
 	}
 
 	TEST_CASE("thread names are set", "[threads]") {
-		[[maybe_unused]] distr_queue _; // Implicitly initializes the runtime
+		distr_queue q;
 
 		auto& rt = runtime::get_instance();
 		auto& schdlr = runtime_testspy::get_schdlr(rt);
@@ -1001,6 +1001,14 @@ namespace detail {
 
 		const auto main_thread_name = get_current_thread_name();
 		CHECK(main_thread_name == "main");
+
+		q.submit([](handler& cgh) {
+			cgh.host_task(experimental::collective, [&](experimental::collective_partition) {
+				const auto base_name = std::string("worker");
+				const auto worker_thread_name = get_current_thread_name();
+				CHECK(worker_thread_name.compare(0, base_name.size(), base_name) == 0); // Check thread name starts with "worker"
+			});
+		});
 	}
 
 } // namespace detail

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -1006,7 +1006,7 @@ namespace detail {
 			cgh.host_task(experimental::collective, [&](experimental::collective_partition) {
 				const auto base_name = std::string("worker");
 				const auto worker_thread_name = get_thread_name(get_current_thread_handle());
-				CHECK(worker_thread_name.compare(0, base_name.size(), base_name) == 0); // Check thread name starts with "worker"
+				CHECK_THAT(worker_thread_name, Catch::Matchers::StartsWith(base_name));
 			});
 		});
 	}

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -18,6 +18,8 @@
 #include <celerity.h>
 
 #include "affinity.h"
+#include "executor.h"
+#include "named_threads.h"
 #include "ranges.h"
 #include "region_map.h"
 
@@ -40,6 +42,20 @@ namespace detail {
 			auto& buf = bm.buffers.at(bid).device_buf;
 			return {dynamic_cast<device_buffer_storage<DataT, Dims>*>(buf.storage.get())->get_device_buffer(), id_cast<Dims>(buf.offset)};
 		}
+	};
+
+	struct runtime_testspy {
+		static scheduler& get_schdlr(runtime& rt) { return *rt.schdlr; }
+
+		static executor& get_exec(runtime& rt) { return *rt.exec; }
+	};
+
+	struct scheduler_testspy {
+		static std::thread& get_worker_thread(scheduler& schdlr) { return schdlr.worker_thread; }
+	};
+
+	struct executor_testspy {
+		static std::thread& get_exec_thrd(executor& exec) { return exec.exec_thrd; }
 	};
 
 	TEST_CASE("only a single distr_queue can be created", "[distr_queue][lifetime][dx]") {
@@ -966,6 +982,25 @@ namespace detail {
 		q.slow_full_sync();
 
 		CHECK(exterior == std::vector{1, 2});
+	}
+
+	TEST_CASE("thread names are set", "[threads]") {
+		[[maybe_unused]] distr_queue _; // Implicitly initializes the runtime
+
+		auto& rt = runtime::get_instance();
+		auto& schdlr = runtime_testspy::get_schdlr(rt);
+		auto& exec = runtime_testspy::get_exec(rt);
+
+		if(rt.is_master_node()) {
+			const auto scheduler_thread_name = get_thread_name(scheduler_testspy::get_worker_thread(schdlr));
+			CHECK(scheduler_thread_name == "scheduler");
+		}
+
+		const auto executor_thread_name = get_thread_name(executor_testspy::get_exec_thrd(exec));
+		CHECK(executor_thread_name == "executor");
+
+		const auto main_thread_name = get_current_thread_name();
+		CHECK(main_thread_name == "main");
 	}
 
 } // namespace detail

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -993,18 +993,18 @@ namespace detail {
 
 		if(rt.is_master_node()) {
 			const auto scheduler_thread_name = get_thread_name(scheduler_testspy::get_worker_thread(schdlr).native_handle());
-			CHECK(scheduler_thread_name == "scheduler");
+			CHECK(scheduler_thread_name == "cy-scheduler");
 		}
 
 		const auto executor_thread_name = get_thread_name(executor_testspy::get_exec_thrd(exec).native_handle());
-		CHECK(executor_thread_name == "executor");
+		CHECK(executor_thread_name == "cy-executor");
 
 		const auto main_thread_name = get_thread_name(get_current_thread_handle());
-		CHECK(main_thread_name == "main");
+		CHECK(main_thread_name == "cy-main");
 
 		q.submit([](handler& cgh) {
 			cgh.host_task(experimental::collective, [&](experimental::collective_partition) {
-				const auto base_name = std::string("worker");
+				const auto base_name = std::string("cy-worker-");
 				const auto worker_thread_name = get_thread_name(get_current_thread_handle());
 				CHECK_THAT(worker_thread_name, Catch::Matchers::StartsWith(base_name));
 			});


### PR DESCRIPTION
This PR is based on #96, so that one should be merged first.  

This PR assigns names to all threads used by celerity for better and easier debugging. Because the `pthread` API limits thread names to only 15 characters, the names were kept relatively short. Especially the host task worker threads are only named `workerN` (where `N` is the thread number inside the thread pool), even though they could also include the MPI communicator name, as celerity uses a thread pool per communicator. This means that there will be worker threads belonging to different communicators, but sharing the same name.