### PR TITLE
Disable core count warning on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ set(SOURCES
 
 if(WIN32)
   set(SOURCES ${SOURCES} src/platform_specific/affinity.win.cc)
- elseif(UNIX)
+ elseif(UNIX AND NOT APPLE)
   set(SOURCES ${SOURCES} src/platform_specific/affinity.unix.cc)
 endif()
 

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -98,13 +98,13 @@ namespace detail {
 		spdlog::set_pattern(fmt::format("[%Y-%m-%d %H:%M:%S.%e] [{:0{}}] [%^%l%$] %v", world_rank, int(ceil(log10(world_size)))));
 
 		cfg = std::make_unique<config>(argc, argv);
-
+#ifndef __APPLE__
 		if(const uint32_t cores = affinity_cores_available(); cores < min_cores_needed) {
 			CELERITY_WARN("Celerity has detected that only {} logical cores are available to this process. It is recommended to assign at least {} "
 			              "logical cores. Performance may be negatively impacted.",
 			    cores, min_cores_needed);
 		}
-
+#endif
 		user_bench = std::make_unique<experimental::bench::detail::user_benchmarker>(*cfg, static_cast<node_id>(world_rank));
 
 		h_queue = std::make_unique<host_queue>();

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -871,6 +871,7 @@ namespace detail {
 		}
 	}
 
+#ifndef __APPLE__
 	class restore_process_affinity_fixture {
 		restore_process_affinity_fixture(const restore_process_affinity_fixture&) = delete;
 		restore_process_affinity_fixture(restore_process_affinity_fixture&&) = delete;
@@ -927,6 +928,7 @@ namespace detail {
 		const auto cores = affinity_cores_available();
 		REQUIRE(cores == 1);
 	}
+#endif
 
 	TEST_CASE("side_effect API works as expected on a single node", "[side-effect]") {
 		distr_queue q;


### PR DESCRIPTION
Due to some incompatibilities mentioned in #85 we decided to exclude this check and test in OSX systems, since for now they are not supported.

This PR depends on #97 