### PR TITLE
Introduce less restrictive side effect orders

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -226,20 +226,21 @@ namespace detail {
 		using payload_type = command_id;
 
 		command_pkg pkg;
-		size_t num_dependencies = 0; // This information is duplicated from unique_frame_ptr::get_payload_count() so that we can still use a
-		                             // `const command_frame &` without its owning pointer
-		payload_type dependencies[];
+		size_t num_dependencies = 0;
+		size_t num_conflicts = 0;
+		payload_type refs[];
 
 		// variable-sized structure
 		command_frame() = default;
 		command_frame(const command_frame&) = delete;
 		command_frame& operator=(const command_frame&) = delete;
 
-		iterable_range<const command_id*> iter_dependencies() const { return {dependencies, dependencies + num_dependencies}; }
+		iterable_range<const command_id*> iter_dependencies() const { return {refs, refs + num_dependencies}; }
+		iterable_range<const command_id*> iter_conflicts() const { return {refs + num_dependencies, refs + num_dependencies + num_conflicts}; }
 	};
 
 	// unique_frame_ptr assumes that the flexible payload member begins at exactly sizeof(Frame) bytes
-	static_assert(offsetof(command_frame, dependencies) == sizeof(command_frame));
+	static_assert(offsetof(command_frame, refs) == sizeof(command_frame));
 
 } // namespace detail
 } // namespace celerity

--- a/include/conflict_graph.h
+++ b/include/conflict_graph.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cassert>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "types.h"
+
+
+namespace celerity::detail {
+
+class conflict_graph {
+  public:
+	using command_set = std::unordered_set<command_id>;
+
+	void add_command(const command_id cid) { commands.emplace(cid); }
+
+	void add_conflict(const command_id a, const command_id b) {
+		assert(a != b);
+		assert(commands.find(a) != commands.end());
+		assert(commands.find(b) != commands.end());
+		conflicts.emplace(a, b);
+		conflicts.emplace(b, a);
+	}
+
+	bool has_any_conflict(const command_id cid) const {
+		const auto [first, last] = conflicts.equal_range(cid);
+		return first != last;
+	}
+
+	bool has_conflict(const command_id a, const command_id b) const {
+		const auto [first, last] = conflicts.equal_range(a);
+		return std::find(first, last, conflict_pair{a, b}) != last;
+	}
+
+	template <typename Predicate>
+	bool has_conflict_if(const command_id cid, Predicate&& predicate) const {
+		const auto [first, last] = conflicts.equal_range(cid);
+		return std::find_if(first, last, [=](const conflict_pair& cf) { return predicate(cf.second); }) != last;
+	}
+
+	void erase_command(const command_id cid) {
+		conflicts.erase(cid);
+		for(auto it = conflicts.begin(); it != conflicts.end();) {
+			if(it->first == cid || it->second == cid) {
+				it = conflicts.erase(it);
+			} else {
+				++it;
+			}
+		}
+	}
+
+	const command_set& get_commands() const { return commands; }
+
+	command_set largest_conflict_free_subset(command_set pending_commands, const command_set& active_commands = {}) const {
+		class backtracker {
+		  public:
+			backtracker(command_set commands, const command_set& active_commands, const conflict_graph& cg)
+			    : cg(cg), active_commands(active_commands), commands(std::move(commands)) {
+				candidate.reserve(this->commands.size());
+				best_candidate.reserve(this->commands.size());
+			}
+
+			command_set backtrack() && {
+				backtrack(commands.begin());
+				return std::move(best_candidate);
+			}
+
+		  private:
+			const conflict_graph& cg;
+			const command_set& active_commands;
+			command_set commands;
+			command_set best_candidate, candidate;
+
+			void backtrack(command_set::iterator it) noexcept { // NOLINT(misc-no-recursion)
+				while(it != commands.end()) {
+					const auto cid = *it++;
+					const auto has_conflict = cg.has_conflict_if(cid, [this](const command_id other_cid) {
+						return active_commands.find(other_cid) != active_commands.end() || candidate.find(other_cid) != candidate.end();
+					});
+					if(!has_conflict) {
+						candidate.insert(cid);
+						backtrack(it);
+						if(candidate.size() > best_candidate.size()) {
+							best_candidate.clear();
+							best_candidate.insert(candidate.begin(), candidate.end()); // don't re-allocate
+						}
+						candidate.erase(cid);
+					}
+				}
+			}
+		};
+
+		assert(std::none_of(pending_commands.begin(), pending_commands.end(), [&](const command_id cid) {
+			return active_commands.find(cid) != active_commands.end();
+		}) && "active and pending command sets intersect");
+		assert(std::none_of(active_commands.begin(), active_commands.end(), [&](const command_id active_cid) {
+			return has_conflict_if(active_cid, [&](const command_id other_cid) { return active_commands.find(other_cid) != active_commands.end(); });
+		}) && "there are conflicts within the set of active commands");
+
+		return backtracker{pending_commands, active_commands, *this}.backtrack();
+	}
+
+  private:
+	using conflict_map = std::unordered_multimap<command_id, command_id>;
+	using conflict_pair = conflict_map::value_type;
+
+	command_set commands;
+	conflict_map conflicts;
+};
+
+} // namespace celerity::detail

--- a/include/conflict_graph.h
+++ b/include/conflict_graph.h
@@ -3,7 +3,6 @@
 #include <cassert>
 #include <unordered_map>
 #include <unordered_set>
-#include <vector>
 
 #include "types.h"
 
@@ -14,19 +13,10 @@ class conflict_graph {
   public:
 	using command_set = std::unordered_set<command_id>;
 
-	void add_command(const command_id cid) { commands.emplace(cid); }
-
 	void add_conflict(const command_id a, const command_id b) {
 		assert(a != b);
-		assert(commands.find(a) != commands.end());
-		assert(commands.find(b) != commands.end());
 		conflicts.emplace(a, b);
 		conflicts.emplace(b, a);
-	}
-
-	bool has_any_conflict(const command_id cid) const {
-		const auto [first, last] = conflicts.equal_range(cid);
-		return first != last;
 	}
 
 	bool has_conflict(const command_id a, const command_id b) const {
@@ -34,52 +24,91 @@ class conflict_graph {
 		return std::find(first, last, conflict_pair{a, b}) != last;
 	}
 
-	template <typename Predicate>
-	bool has_conflict_if(const command_id cid, Predicate&& predicate) const {
+	template <typename... CommandSets>
+	bool has_conflict_with_any_of(const command_id cid, const CommandSets&... sets) const {
+		static_assert(sizeof...(sets) >= 1);
+		static_assert((std::is_same_v<CommandSets, command_set> && ...));
 		const auto [first, last] = conflicts.equal_range(cid);
-		return std::find_if(first, last, [=](const conflict_pair& cf) { return predicate(cf.second); }) != last;
+		return std::find_if(first, last, [&](const conflict_pair& cf) { return ((sets.find(cf.second) != sets.end()) || ...); }) != last;
 	}
 
-	void erase_command(const command_id cid) {
-		conflicts.erase(cid);
-		for(auto it = conflicts.begin(); it != conflicts.end();) {
-			if(it->first == cid || it->second == cid) {
-				it = conflicts.erase(it);
-			} else {
-				++it;
+	void forget_command(const command_id cid) {
+		if(conflicts.erase(cid)) {
+			for(auto it = conflicts.begin(); it != conflicts.end();) {
+				if(it->first == cid || it->second == cid) {
+					it = conflicts.erase(it);
+				} else {
+					++it;
+				}
 			}
 		}
 	}
 
-	const command_set& get_commands() const { return commands; }
-
 	command_set largest_conflict_free_subset(command_set pending_commands, const command_set& active_commands = {}) const {
+		// This method will not allocate unless there are conflicts.
+
+		assert(std::none_of(pending_commands.begin(), pending_commands.end(), [&](const command_id cid) {
+			return active_commands.find(cid) != active_commands.end();
+		}) && "active and pending command sets intersect");
+		assert(std::none_of(active_commands.begin(), active_commands.end(), [&](const command_id active_cid) {
+			return has_conflict_with_any_of(active_cid, active_commands);
+		}) && "there are conflicts within the set of active commands");
+
+		// Separating conflicting and non-conflicting sets ahead of time reduces the number of candidates for backtracking
+		command_set potentially_conflicting_commands;
+		for(auto it = pending_commands.begin(); it != pending_commands.end();) {
+			if(has_conflict_with_any_of(*it, active_commands, pending_commands, potentially_conflicting_commands)) {
+				if(potentially_conflicting_commands.empty()) { potentially_conflicting_commands.reserve(pending_commands.size()); }
+				potentially_conflicting_commands.insert(*it);
+				it = pending_commands.erase(it);
+			} else {
+				++it;
+			}
+		}
+		command_set known_conflict_free_commands = std::move(pending_commands);
+
+		// We can give optimal solutions for the common case without backtracking:
+		// 	- no conflicting commands => accept all pending
+		//	- exactly one conflicting command: conflict is known to be with active_commands (otherwise we would see two conflicts), exclude it
+		if(potentially_conflicting_commands.size() <= 1) {
+			assert(std::all_of(potentially_conflicting_commands.begin(), potentially_conflicting_commands.end(),
+			    [&](const command_id cid) { return has_conflict_with_any_of(cid, active_commands); }));
+			return known_conflict_free_commands;
+		}
+
+		// Finding the largest conflict-free subset (i.e. the maximum independent set) is NP-hard, but we assume few conflicts in practice. In order to avoid
+		// exponential runtimes for degenerate command graphs, we cap the number of backtracking steps and accept suboptimal (but correct) schedules.
+		constexpr static size_t backtracking_max_abandoned_candidates = 100;
+
 		class backtracker {
 		  public:
-			backtracker(command_set commands, const command_set& active_commands, const conflict_graph& cg)
-			    : cg(cg), active_commands(active_commands), commands(std::move(commands)) {
-				candidate.reserve(this->commands.size());
-				best_candidate.reserve(this->commands.size());
+			backtracker(command_set known_conflict_free_pending_commands, command_set potentially_conflicting_pending_commands,
+			    const command_set& active_commands, const conflict_graph& cg)
+			    : cg(cg), active_commands(active_commands) {
+				const auto n_pending_commands = known_conflict_free_pending_commands.size() + potentially_conflicting_pending_commands.size();
+				pending_commands = std::move(potentially_conflicting_pending_commands);
+				best_candidate = std::move(known_conflict_free_pending_commands);
+				best_candidate.reserve(n_pending_commands);
+				candidate.reserve(n_pending_commands);
+				candidate.insert(best_candidate.begin(), best_candidate.end());
 			}
 
 			command_set backtrack() && {
-				backtrack(commands.begin());
+				backtrack(pending_commands.begin());
 				return std::move(best_candidate);
 			}
 
 		  private:
 			const conflict_graph& cg;
 			const command_set& active_commands;
-			command_set commands;
+			command_set pending_commands;
 			command_set best_candidate, candidate;
+			size_t abandoned_candidates = 0;
 
 			void backtrack(command_set::iterator it) noexcept { // NOLINT(misc-no-recursion)
-				while(it != commands.end()) {
+				while(it != pending_commands.end() && abandoned_candidates < backtracking_max_abandoned_candidates) {
 					const auto cid = *it++;
-					const auto has_conflict = cg.has_conflict_if(cid, [this](const command_id other_cid) {
-						return active_commands.find(other_cid) != active_commands.end() || candidate.find(other_cid) != candidate.end();
-					});
-					if(!has_conflict) {
+					if(!cg.has_conflict_with_any_of(cid, active_commands, candidate)) {
 						candidate.insert(cid);
 						backtrack(it);
 						if(candidate.size() > best_candidate.size()) {
@@ -87,26 +116,20 @@ class conflict_graph {
 							best_candidate.insert(candidate.begin(), candidate.end()); // don't re-allocate
 						}
 						candidate.erase(cid);
+					} else {
+						++abandoned_candidates;
 					}
 				}
 			}
 		};
 
-		assert(std::none_of(pending_commands.begin(), pending_commands.end(), [&](const command_id cid) {
-			return active_commands.find(cid) != active_commands.end();
-		}) && "active and pending command sets intersect");
-		assert(std::none_of(active_commands.begin(), active_commands.end(), [&](const command_id active_cid) {
-			return has_conflict_if(active_cid, [&](const command_id other_cid) { return active_commands.find(other_cid) != active_commands.end(); });
-		}) && "there are conflicts within the set of active commands");
-
-		return backtracker{pending_commands, active_commands, *this}.backtrack();
+		return backtracker{std::move(known_conflict_free_commands), std::move(potentially_conflicting_commands), active_commands, *this}.backtrack();
 	}
 
   private:
 	using conflict_map = std::unordered_multimap<command_id, command_id>;
 	using conflict_pair = conflict_map::value_type;
 
-	command_set commands;
 	conflict_map conflicts;
 };
 

--- a/include/executor.h
+++ b/include/executor.h
@@ -92,6 +92,8 @@ namespace detail {
 					m_jobs[pkg.cid].unsatisfied_dependencies++;
 				}
 			}
+
+			// TODO something with conflicts
 		}
 
 		void run();

--- a/include/graph_serializer.h
+++ b/include/graph_serializer.h
@@ -38,7 +38,7 @@ namespace detail {
 
 
 		void flush_dependency(abstract_command* dep) const;
-		void serialize_and_flush(abstract_command* cmd, const std::vector<command_id>& dependencies) const;
+		void serialize_and_flush(abstract_command* cmd) const;
 	};
 
 } // namespace detail

--- a/include/host_object.h
+++ b/include/host_object.h
@@ -11,6 +11,8 @@
 
 namespace celerity::experimental {
 
+enum class side_effect_order;
+
 template <typename T>
 class host_object;
 

--- a/include/intrusive_graph.h
+++ b/include/intrusive_graph.h
@@ -18,6 +18,7 @@ namespace detail {
 
 	enum class dependency_origin {
 		dataflow,                       // buffer access dependencies generate task and command dependencies
+		side_effect_order,              // sequential-order side effects or side-effects behind epochs generate true dependencies
 		collective_group_serialization, // all nodes must execute kernels within the same collective group in the same order
 		execution_front,                // horizons and epochs are temporally ordered after all preceding tasks or commands on the same node
 		last_epoch,                     // nodes without other true-dependencies require an edge to the last epoch for temporal ordering

--- a/include/intrusive_graph.h
+++ b/include/intrusive_graph.h
@@ -157,6 +157,7 @@ namespace detail {
 		int get_pseudo_critical_path_length() const { return m_pseudo_critical_path_length; }
 
 		void add_conflict(conflict cf) {
+			assert(cf.node != this);
 			if(!has_conflict(cf.node) && !has_dependency(cf.node, dependency_kind::true_dep) && !has_dependent(cf.node, dependency_kind::true_dep)) {
 				assert(!cf.node->has_conflict(static_cast<T*>(this)));
 				m_conflicts.push_back(cf);

--- a/include/side_effect.h
+++ b/include/side_effect.h
@@ -10,6 +10,8 @@
 
 namespace celerity::experimental {
 
+enum class side_effect_order { relaxed, exclusive, sequential };
+
 /**
  * Provides access to a `host_object` through capture in a `host_task`. Inside the host task kernel, the internal state of the host object can be accessed
  * through the `*` or `->` operators. This behavior is similar to accessors on buffers.

--- a/include/side_effect.h
+++ b/include/side_effect.h
@@ -2,6 +2,8 @@
 
 #include <type_traits>
 
+#include <spdlog/fmt/fmt.h>
+
 #include "handler.h"
 #include "host_object.h"
 
@@ -43,3 +45,21 @@ template <typename T>
 side_effect(const host_object<T>&, handler&) -> side_effect<T>;
 
 } // namespace celerity::experimental
+
+
+template <>
+struct fmt::formatter<celerity::experimental::side_effect_order> {
+	using side_effect_order = celerity::experimental::side_effect_order;
+
+	constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+	template <typename FormatContext>
+	auto format(const side_effect_order seo, FormatContext& ctx) {
+		switch(seo) {
+		case side_effect_order::relaxed: fmt::format_to(ctx.out(), "relaxed"); break;
+		case side_effect_order::exclusive: fmt::format_to(ctx.out(), "exclusive"); break;
+		case side_effect_order::sequential: fmt::format_to(ctx.out(), "sequential"); break;
+		}
+		return ctx.out();
+	}
+};

--- a/include/side_effect.h
+++ b/include/side_effect.h
@@ -8,9 +8,22 @@
 #include "host_object.h"
 
 
+namespace celerity::detail {
+
+template <experimental::side_effect_order Order>
+struct side_effect_order_tag {
+	inline static constexpr experimental::side_effect_order order = Order;
+};
+
+} // namespace celerity::detail
+
 namespace celerity::experimental {
 
 enum class side_effect_order { relaxed, exclusive, sequential };
+
+inline constexpr detail::side_effect_order_tag<side_effect_order::relaxed> relaxed_order;
+inline constexpr detail::side_effect_order_tag<side_effect_order::exclusive> exclusive_order;
+inline constexpr detail::side_effect_order_tag<side_effect_order::sequential> sequential_order;
 
 /**
  * Provides access to a `host_object` through capture in a `host_task`. Inside the host task kernel, the internal state of the host object can be accessed
@@ -22,7 +35,7 @@ class side_effect {
 	using object_type = typename host_object<T>::object_type;
 	constexpr static inline side_effect_order order = Order;
 
-	explicit side_effect(const host_object<T>& object, handler& cgh) : m_object{object} {
+	explicit side_effect(const host_object<T>& object, handler& cgh, detail::side_effect_order_tag<Order> = {}) : m_object{object} {
 		if(detail::is_prepass_handler(cgh)) {
 			auto& prepass_cgh = static_cast<detail::prepass_handler&>(cgh);
 			prepass_cgh.add_requirement(object.get_id(), order);
@@ -45,6 +58,9 @@ class side_effect {
 
 template <typename T>
 side_effect(const host_object<T>&, handler&) -> side_effect<T>;
+
+template <typename T, side_effect_order Order>
+side_effect(const host_object<T>&, handler&, detail::side_effect_order_tag<Order>) -> side_effect<T, Order>;
 
 } // namespace celerity::experimental
 

--- a/include/task.h
+++ b/include/task.h
@@ -14,6 +14,12 @@ namespace celerity {
 
 class handler;
 
+namespace experimental {
+
+	enum class side_effect_order;
+
+}
+
 namespace detail {
 
 	enum class task_type {

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -170,6 +170,11 @@ namespace detail {
 		size_t get_current_task_count() const { return m_task_buffer.get_current_task_count(); }
 
 	  private:
+		struct collective_group_state {
+			bool had_tasks_before_current_epoch = false;
+			std::unordered_set<task_id> active_conflict_set;
+		};
+
 		const size_t m_num_collective_nodes;
 		host_queue* m_queue;
 
@@ -186,7 +191,7 @@ namespace detail {
 		// NOTE: This represents the state after the latest performed pre-pass.
 		buffer_writers_map m_buffers_last_writers;
 
-		std::unordered_map<collective_group_id, task_id> m_last_collective_tasks;
+		std::unordered_map<collective_group_id, collective_group_state> m_collective_groups;
 
 		// Stores which host object was last affected by which task.
 		std::unordered_map<host_object_id, task_id> m_host_object_last_effects;

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -175,6 +175,11 @@ namespace detail {
 			std::unordered_set<task_id> active_conflict_set;
 		};
 
+		struct host_object_state {
+			std::optional<task_id> last_serializing_effect_or_epoch;
+			std::unordered_map<task_id, experimental::side_effect_order> active_concurrent_set;
+		};
+
 		const size_t m_num_collective_nodes;
 		host_queue* m_queue;
 
@@ -193,8 +198,7 @@ namespace detail {
 
 		std::unordered_map<collective_group_id, collective_group_state> m_collective_groups;
 
-		// Stores which host object was last affected by which task.
-		std::unordered_map<host_object_id, task_id> m_host_object_last_effects;
+		std::unordered_map<host_object_id, host_object_state> m_host_objects;
 
 		// For simplicity we use a single mutex to control access to all task-related (i.e. the task graph, ...) data structures.
 		mutable std::mutex m_task_mutex;

--- a/include/types.h
+++ b/include/types.h
@@ -55,11 +55,3 @@ MAKE_PHANTOM_TYPE(command_id, size_t)
 MAKE_PHANTOM_TYPE(collective_group_id, size_t)
 MAKE_PHANTOM_TYPE(reduction_id, size_t)
 MAKE_PHANTOM_TYPE(host_object_id, size_t)
-
-
-// declared in this header for include-dependency reasons
-namespace celerity::experimental {
-
-enum class side_effect_order { relaxed, exclusive, sequential };
-
-}

--- a/include/types.h
+++ b/include/types.h
@@ -60,6 +60,6 @@ MAKE_PHANTOM_TYPE(host_object_id, size_t)
 // declared in this header for include-dependency reasons
 namespace celerity::experimental {
 
-enum class side_effect_order { sequential };
+enum class side_effect_order { relaxed, exclusive, sequential };
 
 }

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -117,7 +117,7 @@ namespace detail {
 				MPI_Get_count(&status, MPI_BYTE, &frame_bytes);
 				unique_frame_ptr<command_frame> frame(from_size_bytes, static_cast<size_t>(frame_bytes));
 				MPI_Mrecv(frame.get_pointer(), frame_bytes, MPI_BYTE, &msg, &status);
-				assert(frame->num_dependencies == frame.get_payload_count());
+				assert(frame->num_dependencies + frame->num_conflicts == frame.get_payload_count());
 				command_queue.push(std::move(frame));
 
 				if(!m_first_command_received) {

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -100,7 +100,7 @@ namespace detail {
 					done = true;
 				}
 
-				conflict_graph.erase_command(cid);
+				conflict_graph.forget_command(cid);
 				it = m_jobs.erase(it);
 			}
 
@@ -135,10 +135,7 @@ namespace detail {
 				assert(frame->num_dependencies + frame->num_conflicts == frame.get_payload_count());
 
 				const auto cid = frame->pkg.cid;
-				conflict_graph.add_command(cid);
 				for(const auto conflict_cid : frame->iter_conflicts()) {
-					// TODO how to decide when to add/remove a command to/from the CG? Like for dependencies, we should not track conflicts to old commands
-					conflict_graph.add_command(conflict_cid);
 					conflict_graph.add_conflict(cid, conflict_cid);
 				}
 

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -608,12 +608,13 @@ namespace detail {
 				const auto [hoid, order] = side_effect;
 				auto& ho = nd.host_objects[hoid];
 				if(ho.last_serializing_effect_or_epoch && (order != experimental::side_effect_order::sequential || ho.active_concurrent_set.empty())) {
-					m_cdag.add_dependency(cmd, m_cdag.get(*ho.last_serializing_effect_or_epoch), dependency_kind::true_dep, dependency_origin::dataflow);
+					m_cdag.add_dependency(
+					    cmd, m_cdag.get(*ho.last_serializing_effect_or_epoch), dependency_kind::true_dep, dependency_origin::side_effect_order);
 				}
 				if(order == experimental::side_effect_order::sequential) {
 					for(const auto [earlier_cid, weaker_order] : ho.active_concurrent_set) {
 						assert(weaker_order < experimental::side_effect_order::sequential);
-						m_cdag.add_dependency(cmd, m_cdag.get(earlier_cid), dependency_kind::true_dep, dependency_origin::dataflow);
+						m_cdag.add_dependency(cmd, m_cdag.get(earlier_cid), dependency_kind::true_dep, dependency_origin::side_effect_order);
 					}
 					ho.active_concurrent_set.clear();
 					ho.last_serializing_effect_or_epoch = cmd->get_cid();

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -17,6 +17,7 @@ namespace detail {
 	const char* dependency_style(const Dependency& dep) {
 		if(dep.kind == dependency_kind::anti_dep) return "color=limegreen";
 		switch(dep.origin) {
+		case dependency_origin::side_effect_order: return "color=teal";
 		case dependency_origin::collective_group_serialization: return "color=blue";
 		case dependency_origin::execution_front: return "color=orange";
 		case dependency_origin::last_epoch: return "color=orchid";
@@ -24,12 +25,17 @@ namespace detail {
 		}
 	}
 
-	template <typename Conflict>
-	const char* conflict_style(const Conflict& cf) {
-		switch(cf.origin) {
-		case conflict_origin::collective_group: return "dir=none,color=blue";
-		default: return "dir=none";
+	const char* conflict_origin_color(conflict_origin origin) {
+		switch(origin) {
+		case conflict_origin::collective_group: return "blue";
+		case conflict_origin::side_effect_order: return "teal";
+		default: return "";
 		}
+	}
+
+	template <typename Conflict>
+	std::string conflict_style(const Conflict& cf) {
+		return std::string{"dir=both,arrowhead=empty,arrowtail=empty,color="} + conflict_origin_color(cf.origin);
 	}
 
 	std::string get_task_label(const task* tsk) {

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -24,6 +24,14 @@ namespace detail {
 		}
 	}
 
+	template <typename Conflict>
+	const char* conflict_style(const Conflict& cf) {
+		switch(cf.origin) {
+		case conflict_origin::collective_group: return "dir=none,color=blue";
+		default: return "dir=none";
+		}
+	}
+
 	std::string get_task_label(const task* tsk) {
 		switch(tsk->get_type()) {
 		case task_type::epoch: return fmt::format("Task {} (epoch)", tsk->get_id());
@@ -53,6 +61,11 @@ namespace detail {
 
 			for(auto d : tsk->get_dependencies()) {
 				ss << fmt::format("{} -> {} [{}];", d.node->get_id(), tsk->get_id(), dependency_style(d));
+			}
+			for(auto c : tsk->get_conflicts()) {
+				if(c.node->get_id() < tsk->get_id()) { // Conflicts exist in both directions, do not print twice
+					ss << fmt::format("{} -> {} [{}];", c.node->get_id(), tsk->get_id(), conflict_style(c));
+				}
 			}
 		}
 
@@ -125,6 +138,11 @@ namespace detail {
 
 			for(auto d : cmd->get_dependencies()) {
 				main_ss << fmt::format("{} -> {} [{}];", d.node->get_cid(), cmd->get_cid(), dependency_style(d));
+			}
+			for(auto c : cmd->get_conflicts()) {
+				if(c.node->get_cid() < cmd->get_cid()) { // Conflicts exist in both directions, do not print twice
+					main_ss << fmt::format("{} -> {} [{}];", c.node->get_cid(), cmd->get_cid(), conflict_style(c));
+				}
 			}
 
 			// Add a dashed line to the corresponding push

--- a/src/task.cc
+++ b/src/task.cc
@@ -1,4 +1,5 @@
 #include "task.h"
+#include "side_effect.h"
 
 #include <algorithm>
 

--- a/src/task.cc
+++ b/src/task.cc
@@ -60,8 +60,14 @@ namespace detail {
 	}
 
 	void side_effect_map::add_side_effect(const host_object_id hoid, const experimental::side_effect_order order) {
-		// TODO for multiple side effects on the same hoid, find the weakest order satisfying all of them
-		emplace(hoid, order);
+		if(auto it = unordered_map::find(hoid); it != end()) {
+			using seo = experimental::side_effect_order;
+			// stronger orders subsume weaker ones and have higher integral enum value, so we can use std::max
+			static_assert(seo::exclusive > seo::relaxed && seo::sequential > seo::exclusive);
+			it->second = std::max(it->second, order);
+		} else {
+			emplace(hoid, order);
+		}
 	}
 } // namespace detail
 } // namespace celerity

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -2,6 +2,7 @@
 
 #include "access_modes.h"
 #include "print_graph.h"
+#include "side_effect.h"
 
 namespace celerity {
 namespace detail {

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -159,12 +159,13 @@ namespace detail {
 			const auto [hoid, order] = side_effect;
 			auto& ho = m_host_objects[hoid];
 			if(ho.last_serializing_effect_or_epoch && (order != experimental::side_effect_order::sequential || ho.active_concurrent_set.empty())) {
-				add_dependency(tsk, *m_task_buffer.get_task(*ho.last_serializing_effect_or_epoch), dependency_kind::true_dep, dependency_origin::dataflow);
+				add_dependency(
+				    tsk, *m_task_buffer.get_task(*ho.last_serializing_effect_or_epoch), dependency_kind::true_dep, dependency_origin::side_effect_order);
 			}
 			if(order == experimental::side_effect_order::sequential) {
 				for(const auto [earlier_tid, weaker_order] : ho.active_concurrent_set) {
 					assert(weaker_order < experimental::side_effect_order::sequential);
-					add_dependency(tsk, *m_task_buffer.get_task(earlier_tid), dependency_kind::true_dep, dependency_origin::dataflow);
+					add_dependency(tsk, *m_task_buffer.get_task(earlier_tid), dependency_kind::true_dep, dependency_origin::side_effect_order);
 				}
 				ho.active_concurrent_set.clear();
 				ho.last_serializing_effect_or_epoch = tsk.get_id();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ set(TEST_TARGETS
   task_graph_tests
   task_ring_buffer_tests
   device_selection_tests
+  executor_tests
 )
 
 add_library(test_main test_main.cc)
@@ -58,7 +59,7 @@ foreach(TEST_TARGET ${TEST_TARGETS})
   add_executable(${TEST_TARGET} $<TARGET_OBJECTS:${TEST_OBJ}>)
   target_link_libraries(${TEST_TARGET} PRIVATE test_main)
   set_test_target_parameters(${TEST_TARGET} "")
-  
+
   # We use the (undocumented) per-file function as we otherwise run into
   # problems with ComputeCpp's generated integration headers.
   ParseAndAddCatchTests_ParseFile(${TEST_SOURCE} ${TEST_TARGET})

--- a/test/executor_tests.cc
+++ b/test/executor_tests.cc
@@ -1,0 +1,74 @@
+#include "conflict_graph.h"
+
+#include "test_utils.h"
+
+namespace celerity::detail {
+
+TEST_CASE("maximum independent set", "[conflict-graph]") {
+	conflict_graph cg;
+	for(command_id cid = 0; cid <= 11; ++cid) {
+		cg.add_command(cid);
+	}
+
+	// fork
+	cg.add_conflict(0, 1);
+	cg.add_conflict(0, 2);
+	cg.add_conflict(0, 3);
+
+	// triangle
+	cg.add_conflict(5, 6);
+	cg.add_conflict(6, 7);
+	cg.add_conflict(5, 7);
+
+	// quadrilateral
+	cg.add_conflict(8, 9);
+	cg.add_conflict(8, 10);
+	cg.add_conflict(9, 11);
+	cg.add_conflict(10, 11);
+
+	const auto cfs = cg.largest_conflict_free_subset(cg.get_commands());
+	CHECK(cfs.size() == 7);
+
+	CHECK(cfs.count(0) == 0);
+	for(command_id cid = 1; cid <= 4; ++cid) {
+		CHECK(cfs.count(cid) == 1);
+	}
+
+	CHECK(cfs.count(5) + cfs.count(6) + cfs.count(7) == 1);
+
+	const auto quad_8_11 = cfs.count(8) + cfs.count(11) == 2;
+	const auto quad_9_10 = cfs.count(9) + cfs.count(10) == 2;
+	CHECK(quad_8_11 != quad_9_10);
+}
+
+TEST_CASE("maximum independent set 2", "[conflict-graph]") {
+	conflict_graph cg;
+	cg.add_command(2);
+	cg.add_command(0);
+	cg.add_conflict(0, 2);
+	const auto cfs = cg.largest_conflict_free_subset({2});
+	CHECK(cfs == conflict_graph::command_set{2});
+}
+
+TEST_CASE("conflict graph", "[conflict-graph]") {
+	conflict_graph cg;
+	for(command_id cid = 0; cid < 5; ++cid) {
+		cg.add_command(cid);
+	}
+
+	CHECK(!cg.has_any_conflict(0));
+	CHECK(!cg.has_any_conflict(1));
+	cg.add_conflict(0, 1);
+	CHECK(cg.has_conflict(0, 1));
+	CHECK(cg.has_conflict(1, 0));
+	CHECK(cg.has_any_conflict(0));
+	CHECK(cg.has_any_conflict(1));
+
+	cg.add_conflict(2, 3);
+	CHECK(cg.has_conflict(2, 3));
+	CHECK(cg.has_conflict(3, 2));
+	CHECK(cg.has_any_conflict(2));
+	CHECK(cg.has_any_conflict(3));
+}
+
+} // namespace celerity::detail

--- a/test/executor_tests.cc
+++ b/test/executor_tests.cc
@@ -5,10 +5,12 @@
 namespace celerity::detail {
 
 TEST_CASE("maximum independent set", "[conflict-graph]") {
-	conflict_graph cg;
+	conflict_graph::command_set commands;
 	for(command_id cid = 0; cid <= 11; ++cid) {
-		cg.add_command(cid);
+		commands.insert(cid);
 	}
+
+	conflict_graph cg;
 
 	// fork
 	cg.add_conflict(0, 1);
@@ -26,7 +28,7 @@ TEST_CASE("maximum independent set", "[conflict-graph]") {
 	cg.add_conflict(9, 11);
 	cg.add_conflict(10, 11);
 
-	const auto cfs = cg.largest_conflict_free_subset(cg.get_commands());
+	const auto cfs = cg.largest_conflict_free_subset(commands);
 	CHECK(cfs.size() == 7);
 
 	CHECK(cfs.count(0) == 0);
@@ -43,8 +45,6 @@ TEST_CASE("maximum independent set", "[conflict-graph]") {
 
 TEST_CASE("maximum independent set 2", "[conflict-graph]") {
 	conflict_graph cg;
-	cg.add_command(2);
-	cg.add_command(0);
 	cg.add_conflict(0, 2);
 	const auto cfs = cg.largest_conflict_free_subset({2});
 	CHECK(cfs == conflict_graph::command_set{2});
@@ -52,23 +52,20 @@ TEST_CASE("maximum independent set 2", "[conflict-graph]") {
 
 TEST_CASE("conflict graph", "[conflict-graph]") {
 	conflict_graph cg;
-	for(command_id cid = 0; cid < 5; ++cid) {
-		cg.add_command(cid);
-	}
 
-	CHECK(!cg.has_any_conflict(0));
-	CHECK(!cg.has_any_conflict(1));
+	CHECK(!cg.has_conflict_with_any_of(0, conflict_graph::command_set{}));
+	CHECK(!cg.has_conflict_with_any_of(1, conflict_graph::command_set{}));
 	cg.add_conflict(0, 1);
 	CHECK(cg.has_conflict(0, 1));
 	CHECK(cg.has_conflict(1, 0));
-	CHECK(cg.has_any_conflict(0));
-	CHECK(cg.has_any_conflict(1));
+	CHECK(cg.has_conflict_with_any_of(0, conflict_graph::command_set{0, 1}));
+	CHECK(cg.has_conflict_with_any_of(1, conflict_graph::command_set{0, 1}));
 
 	cg.add_conflict(2, 3);
 	CHECK(cg.has_conflict(2, 3));
 	CHECK(cg.has_conflict(3, 2));
-	CHECK(cg.has_any_conflict(2));
-	CHECK(cg.has_any_conflict(3));
+	CHECK(cg.has_conflict_with_any_of(2, conflict_graph::command_set{0, 1, 2, 3}));
+	CHECK(cg.has_conflict_with_any_of(3, conflict_graph::command_set{0, 1, 2, 3}));
 }
 
 } // namespace celerity::detail


### PR DESCRIPTION
Side-effects introduced in #68 currently always serialize execution between host tasks affecting the same host object. Since the precise interactions within the host task are entirely user-defined, this can be overly restrictive. For example, incrementing an atomic counter from multiple host tasks does not need to introduce any scheduling constraints, but the user should still be able to rely on Celerity guaranteeing the correct lifetime of the accessed host object.

Choosing between different scheduling guarantees for side effects is reminiscent of access modes on buffer access. However, the read/write dichotomy itself is not a good fit for this new use case: First of all, whether two "writing" side effects can be scheduled concurrently or not depends on the level of synchronization employed by the object itself, which is outside of Celerity's control. Also, for buffers, the access modes request implicit data movement from the runtime, which does not apply to host objects either.

This PR proposes three distinct side effect orders:

-  `side_effect_order::sequential`: The task cannot be re-ordered or executed concurrently with any other task affecting the same host object (the current behavior, and also the default)
- `side_effect_order::exclusive`: The task may be re-ordered, but not executed concurrently with any other task affecting the same host object. Example usage: Inserting into a (unsynchronized) `host_object<std::unordered_set<T>>`.
- `side_effect_order::relaxed`: The task may be executed concurrently with and freely re-ordered against other tasks affecting the same host object. Example usage: Incrementing an atomic counter.

Note that between a pair of tasks affecting the same host object, the more restrictive side effect order decides the level of freedom with respect to re-ordering and concurrency: `relaxed` effects can be executed concurrently only with other `relaxed` effects, but re-ordered against `relaxed` and `exclusive`. A `sequential` effect will always serialize execution around the host object.

To implement re-ordering constraints, task and command graphs gain undirected edges (called conflicts) in addition to directed edges (called dependencies). These indicate that one node must be sequenced before the other, but the order is arbitrary. This is also backported to collective host tasks (which require an arbitrary, but fixed execution order on all nodes), giving the graph generator more freedom in scheduling.

![task graph with conflict edges](https://user-images.githubusercontent.com/5698527/156317244-066483e7-5020-482e-9089-2a235ecc646a.png)

These conflict edges are communicated to the executor of each node, which opportunistically schedules non-conflicting sets of commands concurrently. The assumption here is that executors will have a significant backlog most of the time, allowing them to make informed scheduling decisions at that level.