### PR TITLE
Add all_tests unit test executable, linking all unit test object files

### DIFF
--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -12,8 +12,5 @@ if [[ $# -ne 0 ]]; then
 fi
 
 # Running "make test" is slow because CTest will spawn one process per test case, adding significant start-up costs.
-# We just call all test executables manually to get around this.
-find test -maxdepth 1 -executable -type f | while read test; do
-    echo -e "\n\n ---- Running ${test##*/} ----\n\n" >&2
-    bash /root/capture-backtrace.sh "$test"
-done
+# We just call the all_tests executable manually to get around this.
+bash /root/capture-backtrace.sh test/all_tests

--- a/cmake/FindComputeCpp.cmake
+++ b/cmake/FindComputeCpp.cmake
@@ -2,6 +2,7 @@
 # This file is sourced from the ComputeCpp SDK and has been patched to allow find_package(ComputeCpp) to gracefully
 # report failure in case OpenCL is not found (find_package(OpenCL) is not REQUIRED any more) and avoid printing
 # warnings if the QUIET option is specified (if NOT ComputeCpp_FIND_QUIETLY).
+# also added spaces at start of forceIncludeFlags strings
 
 #.rst:
 # FindComputeCpp
@@ -365,9 +366,9 @@ function(__build_ir)
     # Add both source and the sycl files to the VS solution.
     target_sources(${SDK_BUILD_IR_TARGET} PUBLIC ${SDK_BUILD_IR_SOURCE} ${outputSyclFile})
 
-    set(forceIncludeFlags "/FI${includedFile} /TP")
+    set(forceIncludeFlags " /FI${includedFile} /TP")
   else()
-    set(forceIncludeFlags "-include ${includedFile} -x c++")
+    set(forceIncludeFlags " -include ${includedFile} -x c++")
   endif()
 
   set_property(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,12 +4,27 @@ endif()
 
 include("${PROJECT_SOURCE_DIR}/vendor/Catch2/extras/ParseAndAddCatchTests.cmake")
 
+# Function for setting all relevant test parameters
+function(set_test_target_parameters TARGET SOURCE)
+  target_link_libraries(${TARGET} PUBLIC Catch2::Catch2)
+  set_property(TARGET ${TARGET} PROPERTY CXX_STANDARD 17)
+  set_property(TARGET ${TARGET} PROPERTY FOLDER "tests")
+  set_property(TARGET ${TARGET} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+  if(MSVC)
+    target_compile_options(${TARGET} PRIVATE /D_CRT_SECURE_NO_WARNINGS /MP /W3 /bigobj)
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wextra -Wno-unused-parameter -Wno-unused-variable)
+  endif()
+
+  add_celerity_to_target(TARGET ${TARGET} SOURCES ${SOURCE})
+endfunction()
+
 # Add includes to library so they show up in IDEs
 file(GLOB_RECURSE TEST_INCLUDES *.h)
 
 set(TEST_TARGETS
   accessor_tests
-  benchmarks
   buffer_manager_tests
   graph_generation_tests
   graph_gen_granularity_tests
@@ -25,40 +40,36 @@ set(TEST_TARGETS
 )
 
 add_library(unit_test_suite unit_test_suite.cc unit_test_suite_celerity.cc)
+set_test_target_parameters(unit_test_suite unit_test_suite_celerity.cc)
 
-target_link_libraries(
-  unit_test_suite
-  PUBLIC
-  Catch2::Catch2
-)
-
-set_property(TARGET unit_test_suite PROPERTY CXX_STANDARD 17)
-
-add_celerity_to_target(TARGET unit_test_suite SOURCES unit_test_suite_celerity.cc)
-
+set(TEST_OBJ_LIST "")
 foreach(TEST_TARGET ${TEST_TARGETS})
-
+  # Build test obj file
   set(TEST_SOURCE ${TEST_TARGET}.cc)
+  set(TEST_OBJ ${TEST_TARGET}_OBJ)
+  list(APPEND TEST_OBJ_LIST $<TARGET_OBJECTS:${TEST_OBJ}>)
 
-  # add test executable
-  add_executable(${TEST_TARGET} ${TEST_SOURCE} ${TEST_INCLUDES})
+  add_library(${TEST_OBJ} OBJECT ${TEST_SOURCE} ${TEST_INCLUDES})
+  set_test_target_parameters(${TEST_OBJ} ${TEST_SOURCE})
+
+  # Add test executable
+  add_executable(${TEST_TARGET} $<TARGET_OBJECTS:${TEST_OBJ}>)
   target_link_libraries(${TEST_TARGET} PRIVATE unit_test_suite)
-
-  set_property(TARGET ${TEST_TARGET} PROPERTY CXX_STANDARD 17)
-  set_property(TARGET ${TEST_TARGET} PROPERTY FOLDER "tests")
-
-  add_celerity_to_target(TARGET ${TEST_TARGET} SOURCES ${TEST_SOURCE})
-
-  if(MSVC)
-    target_compile_options(${TEST_TARGET} PRIVATE /D_CRT_SECURE_NO_WARNINGS /MP /W3 /bigobj)
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
-    target_compile_options(${TEST_TARGET} PRIVATE -Wall -Wextra -Wextra -Wno-unused-parameter -Wno-unused-variable)
-  endif()
-
+  set_test_target_parameters(${TEST_TARGET} "")
+  
   # We use the (undocumented) per-file function as we otherwise run into
   # problems with ComputeCpp's generated integration headers.
   ParseAndAddCatchTests_ParseFile(${TEST_SOURCE} ${TEST_TARGET})
-
 endforeach()
+
+# Add all_tests executable
+add_executable(all_tests ${TEST_OBJ_LIST})
+target_link_libraries(all_tests PRIVATE unit_test_suite)
+set_test_target_parameters(all_tests "")
+
+# Unit benchmark executable
+add_executable(benchmarks benchmarks.cc)
+target_link_libraries(benchmarks PRIVATE unit_test_suite)
+set_test_target_parameters(benchmarks benchmarks.cc)
 
 add_subdirectory(system)


### PR DESCRIPTION
Build system and CI only change, builds all tests as CMake "Object libraries" and links them together as required.