### PR TITLE
Add overload for runtime::init/distr_queue ctor that accepts a device selector

### DIFF
--- a/include/celerity.h
+++ b/include/celerity.h
@@ -1,6 +1,7 @@
 #ifndef RUNTIME_INCLUDE_ENTRY_CELERITY
 #define RUNTIME_INCLUDE_ENTRY_CELERITY
 
+#include "device_queue.h"
 #include "runtime.h"
 
 #include "accessor.h"
@@ -15,14 +16,24 @@ namespace runtime {
 	/**
 	 * @brief Initializes the Celerity runtime.
 	 */
-	inline void init(int* argc, char** argv[]) { detail::runtime::init(argc, argv, nullptr); }
+	inline void init(int* argc, char** argv[]) { detail::runtime::init(argc, argv, detail::auto_select_device{}); }
 
 	/**
 	 * @brief Initializes the Celerity runtime and instructs it to use a particular device.
 	 *
 	 * @param device The device to be used on the current node. This can vary between nodes.
 	 */
-	inline void init(int* argc, char** argv[], cl::sycl::device& device) { detail::runtime::init(argc, argv, &device); }
+	[[deprecated("Use the overload with device selector instead, this will be removed in future release")]] inline void init(
+	    int* argc, char** argv[], sycl::device& device) {
+		detail::runtime::init(argc, argv, device);
+	}
+
+	/**
+	 * @brief Initializes the Celerity runtime and instructs it to use a particular device.
+	 *
+	 * @param device_selector The device selector to be used on the current node. This can vary between nodes.
+	 */
+	inline void init(int* argc, char** argv[], const detail::device_selector& device_selector) { detail::runtime::init(argc, argv, device_selector); }
 } // namespace runtime
 } // namespace celerity
 

--- a/include/config.h
+++ b/include/config.h
@@ -48,6 +48,7 @@ namespace detail {
 		std::optional<device_config> device_cfg;
 		std::optional<bool> enable_device_profiling;
 		size_t graph_print_max_verts = 200;
+		friend struct config_testspy;
 	};
 
 } // namespace detail

--- a/include/config.h
+++ b/include/config.h
@@ -19,6 +19,8 @@ namespace detail {
 	};
 
 	class config {
+		friend struct config_testspy;
+
 	  public:
 		/**
 		 * Initializes the @p config by parsing environment variables and passed arguments.
@@ -48,7 +50,6 @@ namespace detail {
 		std::optional<device_config> device_cfg;
 		std::optional<bool> enable_device_profiling;
 		size_t graph_print_max_verts = 200;
-		friend struct config_testspy;
 	};
 
 } // namespace detail

--- a/include/config.h
+++ b/include/config.h
@@ -10,7 +10,6 @@ namespace detail {
 	struct host_config {
 		size_t node_count;
 		size_t local_rank;
-		size_t local_num_cpus;
 	};
 
 	struct device_config {

--- a/include/device_queue.h
+++ b/include/device_queue.h
@@ -59,9 +59,79 @@ namespace detail {
 		std::unique_ptr<cl::sycl::queue> sycl_queue;
 		bool device_profiling_enabled = false;
 
-		cl::sycl::device pick_device(const config& cfg, cl::sycl::device* user_device) const;
 		void handle_async_exceptions(cl::sycl::exception_list el) const;
 	};
+
+	template <typename DeviceT, typename PlatformT>
+	DeviceT pick_device(const config& cfg, DeviceT* user_device, const std::vector<PlatformT>& platforms) {
+		DeviceT device;
+		std::string how_selected = "automatically selected";
+		if(user_device != nullptr) {
+			device = *user_device;
+			how_selected = "specified by user";
+		} else {
+			const auto device_cfg = cfg.get_device_config();
+			if(device_cfg != std::nullopt) {
+				how_selected = fmt::format("set by CELERITY_DEVICES: platform {}, device {}", device_cfg->platform_id, device_cfg->device_id);
+				CELERITY_DEBUG("{} platforms available", platforms.size());
+				if(device_cfg->platform_id >= platforms.size()) {
+					throw std::runtime_error(fmt::format("Invalid platform id {}: Only {} platforms available", device_cfg->platform_id, platforms.size()));
+				}
+				const auto devices = platforms[device_cfg->platform_id].get_devices();
+				if(device_cfg->device_id >= devices.size()) {
+					throw std::runtime_error(fmt::format(
+					    "Invalid device id {}: Only {} devices available on platform {}", device_cfg->device_id, devices.size(), device_cfg->platform_id));
+				}
+				device = devices[device_cfg->device_id];
+			} else {
+				const auto host_cfg = cfg.get_host_config();
+
+				const auto try_find_device_per_node = [&host_cfg, &device, &how_selected, &platforms](cl::sycl::info::device_type type) {
+					// Try to find a platform that can provide a unique device for each node.
+					for(size_t i = 0; i < platforms.size(); ++i) {
+						auto&& platform = platforms[i];
+						const auto devices = platform.get_devices(type);
+						if(devices.size() >= host_cfg.node_count) {
+							how_selected = fmt::format("automatically selected platform {}, device {}", i, host_cfg.local_rank);
+							device = devices[host_cfg.local_rank];
+							return true;
+						}
+					}
+					return false;
+				};
+
+				const auto try_find_one_device = [&device, &platforms](cl::sycl::info::device_type type) {
+					for(auto& p : platforms) {
+						for(auto& d : p.get_devices(type)) {
+							device = d;
+							return true;
+						}
+					}
+					return false;
+				};
+
+				// Try to find a unique GPU per node.
+				if(!try_find_device_per_node(cl::sycl::info::device_type::gpu)) {
+					// Try to find a unique device (of any type) per node.
+					if(try_find_device_per_node(cl::sycl::info::device_type::all)) {
+						CELERITY_WARN("No suitable platform found that can provide {} GPU devices, and CELERITY_DEVICES not set", host_cfg.node_count);
+					} else {
+						CELERITY_WARN("No suitable platform found that can provide {} devices, and CELERITY_DEVICES not set", host_cfg.node_count);
+						// Just use the first available device. Prefer GPUs, but settle for anything.
+						if(!try_find_one_device(cl::sycl::info::device_type::gpu) && !try_find_one_device(cl::sycl::info::device_type::all)) {
+							throw std::runtime_error("Automatic device selection failed: No device available");
+						}
+					}
+				}
+			}
+		}
+
+		const auto platform_name = device.get_platform().template get_info<cl::sycl::info::platform::name>();
+		const auto device_name = device.template get_info<cl::sycl::info::device::name>();
+		CELERITY_INFO("Using platform '{}', device '{}' ({})", platform_name, device_name, how_selected);
+
+		return device;
+	}
 
 } // namespace detail
 } // namespace celerity

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -41,9 +41,10 @@ namespace detail {
 
 	  public:
 		/**
-		 * @param user_device This optional device can be provided by the user, overriding any other device selection strategy.
+		 * @param user_device_or_selector This optional device (overriding any other device selection strategy) or device selector can be provided by the user.
 		 */
-		static void init(int* argc, char** argv[], cl::sycl::device* user_device = nullptr);
+		static void init(int* argc, char** argv[], device_or_selector user_device_or_selector = auto_select_device{});
+
 		static bool is_initialized() { return instance != nullptr; }
 		static runtime& get_instance();
 
@@ -117,7 +118,7 @@ namespace detail {
 		};
 		std::deque<flush_handle> active_flushes;
 
-		runtime(int* argc, char** argv[], cl::sycl::device* user_device = nullptr);
+		runtime(int* argc, char** argv[], device_or_selector user_device_or_selector);
 		runtime(const runtime&) = delete;
 		runtime(runtime&&) = delete;
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -180,17 +180,6 @@ namespace detail {
 			const auto result = get_env("CELERITY_FORCE_WG");
 			if(result.first) { CELERITY_WARN("Support for CELERITY_FORCE_WG has been removed with Celerity 0.3.0."); }
 		}
-
-		// -------------------------------- CELERITY_HOST_CPUS --------------------------------
-
-		{
-			host_cfg.local_num_cpus = std::thread::hardware_concurrency();
-			const auto result = get_env("CELERITY_HOST_CPUS");
-			if(result.first) {
-				const auto parsed = parse_uint(result.second.c_str());
-				if(parsed.first) { host_cfg.local_num_cpus = parsed.second; }
-			}
-		}
 	}
 } // namespace detail
 } // namespace celerity

--- a/src/config.cc
+++ b/src/config.cc
@@ -192,6 +192,5 @@ namespace detail {
 			}
 		}
 	}
-
 } // namespace detail
 } // namespace celerity

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -8,7 +8,7 @@
 namespace celerity {
 namespace detail {
 
-	void device_queue::init(const config& cfg, cl::sycl::device* user_device) {
+	void device_queue::init(const config& cfg, const device_or_selector& user_device_or_selector) {
 		assert(sycl_queue == nullptr);
 		const auto profiling_cfg = cfg.get_enable_device_profiling();
 		device_profiling_enabled = profiling_cfg != std::nullopt && *profiling_cfg;
@@ -16,10 +16,11 @@ namespace detail {
 
 		const auto props = device_profiling_enabled ? cl::sycl::property_list{cl::sycl::property::queue::enable_profiling()} : cl::sycl::property_list{};
 		const auto handle_exceptions = cl::sycl::async_handler{[this](cl::sycl::exception_list el) { this->handle_async_exceptions(el); }};
-		auto device = pick_device(cfg, user_device, cl::sycl::platform::get_platforms());
+
+		auto device = std::visit(
+		    [&cfg](const auto& value) { return ::celerity::detail::pick_device(cfg, value, cl::sycl::platform::get_platforms()); }, user_device_or_selector);
 		sycl_queue = std::make_unique<cl::sycl::queue>(device, handle_exceptions, props);
 	}
-
 
 	void device_queue::handle_async_exceptions(cl::sycl::exception_list el) const {
 		for(auto& e : el) {

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -16,80 +16,10 @@ namespace detail {
 
 		const auto props = device_profiling_enabled ? cl::sycl::property_list{cl::sycl::property::queue::enable_profiling()} : cl::sycl::property_list{};
 		const auto handle_exceptions = cl::sycl::async_handler{[this](cl::sycl::exception_list el) { this->handle_async_exceptions(el); }};
-		auto device = pick_device(cfg, user_device);
+		auto device = pick_device(cfg, user_device, cl::sycl::platform::get_platforms());
 		sycl_queue = std::make_unique<cl::sycl::queue>(device, handle_exceptions, props);
 	}
 
-	cl::sycl::device device_queue::pick_device(const config& cfg, cl::sycl::device* user_device) const {
-		cl::sycl::device device;
-		std::string how_selected = "automatically selected";
-		if(user_device != nullptr) {
-			device = *user_device;
-			how_selected = "specified by user";
-		} else {
-			const auto device_cfg = cfg.get_device_config();
-			if(device_cfg != std::nullopt) {
-				how_selected = fmt::format("set by CELERITY_DEVICES: platform {}, device {}", device_cfg->platform_id, device_cfg->device_id);
-				const auto platforms = cl::sycl::platform::get_platforms();
-				CELERITY_DEBUG("{} platforms available", platforms.size());
-				if(device_cfg->platform_id >= platforms.size()) {
-					throw std::runtime_error(fmt::format("Invalid platform id {}: Only {} platforms available", device_cfg->platform_id, platforms.size()));
-				}
-				const auto devices = platforms[device_cfg->platform_id].get_devices();
-				if(device_cfg->device_id >= devices.size()) {
-					throw std::runtime_error(fmt::format(
-					    "Invalid device id {}: Only {} devices available on platform {}", device_cfg->device_id, devices.size(), device_cfg->platform_id));
-				}
-				device = devices[device_cfg->device_id];
-			} else {
-				const auto host_cfg = cfg.get_host_config();
-
-				const auto try_find_device_per_node = [&host_cfg, &device, &how_selected](cl::sycl::info::device_type type) {
-					// Try to find a platform that can provide a unique device for each node.
-					const auto platforms = cl::sycl::platform::get_platforms();
-					for(size_t i = 0; i < platforms.size(); ++i) {
-						auto&& platform = platforms[i];
-						const auto devices = platform.get_devices(type);
-						if(devices.size() >= host_cfg.node_count) {
-							how_selected = fmt::format("automatically selected platform {}, device {}", i, host_cfg.local_rank);
-							device = devices[host_cfg.local_rank];
-							return true;
-						}
-					}
-					return false;
-				};
-
-				const auto try_find_one_device = [&device](cl::sycl::info::device_type type) {
-					const auto devices = cl::sycl::device::get_devices(type);
-					if(!devices.empty()) {
-						device = devices[0];
-						return true;
-					}
-					return false;
-				};
-
-				// Try to find a unique GPU per node.
-				if(!try_find_device_per_node(cl::sycl::info::device_type::gpu)) {
-					// Try to find a unique device (of any type) per node.
-					if(try_find_device_per_node(cl::sycl::info::device_type::all)) {
-						CELERITY_WARN("No suitable platform found that can provide {} GPU devices, and CELERITY_DEVICES not set", host_cfg.node_count);
-					} else {
-						CELERITY_WARN("No suitable platform found that can provide {} devices, and CELERITY_DEVICES not set", host_cfg.node_count);
-						// Just use the first available device. Prefer GPUs, but settle for anything.
-						if(!try_find_one_device(cl::sycl::info::device_type::gpu) && !try_find_one_device(cl::sycl::info::device_type::all)) {
-							throw std::runtime_error("Automatic device selection failed: No device available");
-						}
-					}
-				}
-			}
-		}
-
-		const auto platform_name = device.get_platform().get_info<cl::sycl::info::platform::name>();
-		const auto device_name = device.get_info<cl::sycl::info::device::name>();
-		CELERITY_INFO("Using platform '{}', device '{}' ({})", platform_name, device_name, how_selected);
-
-		return device;
-	}
 
 	void device_queue::handle_async_exceptions(cl::sycl::exception_list el) const {
 		for(auto& e : el) {
@@ -101,7 +31,6 @@ namespace detail {
 			}
 		}
 	}
-
 
 } // namespace detail
 } // namespace celerity

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -48,9 +48,9 @@ namespace detail {
 		mpi_finalized = true;
 	}
 
-	void runtime::init(int* argc, char** argv[], cl::sycl::device* user_device) {
+	void runtime::init(int* argc, char** argv[], device_or_selector user_device_or_selector) {
 		assert(!instance);
-		instance = std::unique_ptr<runtime>(new runtime(argc, argv, user_device));
+		instance = std::unique_ptr<runtime>(new runtime(argc, argv, user_device_or_selector));
 	}
 
 	runtime& runtime::get_instance() {
@@ -91,7 +91,7 @@ namespace detail {
 #endif
 	}
 
-	runtime::runtime(int* argc, char** argv[], cl::sycl::device* user_device) {
+	runtime::runtime(int* argc, char** argv[], device_or_selector user_device_or_selector) {
 		if(test_mode) {
 			assert(test_active && "initializing the runtime from a test without a runtime_fixture");
 		} else {
@@ -145,7 +145,7 @@ namespace detail {
 
 		CELERITY_INFO(
 		    "Celerity runtime version {} running on {}. PID = {}, build type = {}", get_version_string(), get_sycl_version(), get_pid(), get_build_type());
-		d_queue->init(*cfg, user_device);
+		d_queue->init(*cfg, user_device_or_selector);
 	}
 
 	runtime::~runtime() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_TARGETS
   runtime_deprecation_tests
   sycl_tests
   task_graph_tests
+  device_selection_tests
 )
 
 add_library(test_main test_main.cc)

--- a/test/device_selection_tests.cc
+++ b/test/device_selection_tests.cc
@@ -1,0 +1,390 @@
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/generators/catch_generators.hpp"
+#include "catch2/matchers/catch_matchers_string.hpp"
+#include "spdlog/sinks/ostream_sink.h"
+#include "test_utils.h"
+#include <celerity.h>
+
+struct mock_platform;
+struct mock_device {
+	mock_device() : id(0), type(cl::sycl::info::device_type::gpu) {}
+
+	mock_device(size_t id, cl::sycl::info::device_type type = cl::sycl::info::device_type::gpu) : id(id), type(type) {}
+
+	mock_platform get_platform() const;
+
+	template <cl::sycl::info::device Param>
+	std::string get_info() const {
+		return "bar";
+	}
+
+	bool operator==(const mock_device& other) const { return other.id == id; }
+
+	cl::sycl::info::device_type get_type() const { return type; }
+
+	size_t get_id() { return id; }
+
+  private:
+	size_t id;
+	cl::sycl::info::device_type type;
+};
+struct mock_platform {
+	// TODO: These devices should somehow have this platform as their platform (?)
+	mock_platform(size_t id, std::vector<mock_device> devices) : devices(std::move(devices)), id(id) {}
+
+	std::vector<mock_device> get_devices(cl::sycl::info::device_type type = cl::sycl::info::device_type::all) const {
+		if(type != cl::sycl::info::device_type::all) {
+			std::vector<mock_device> devices_with_type;
+			for(auto device : devices) {
+				if(device.get_type() == type) { devices_with_type.emplace_back(device); }
+			}
+			return devices_with_type;
+		} else
+			return devices;
+	}
+
+	template <cl::sycl::info::platform Param>
+	std::string get_info() const {
+		return "foo";
+	}
+
+	size_t get_id() { return id; }
+
+  private:
+	std::vector<mock_device> devices;
+	size_t id;
+};
+
+// TODO: Device should know its associated platform and return it from here
+mock_platform mock_device::get_platform() const {
+	return {15, {}}; // Setting random platform ID for now
+}
+
+
+namespace celerity::detail {
+struct config_testspy {
+	static void set_mock_device_cfg(config& cfg, const device_config& d_cfg) { cfg.device_cfg = d_cfg; }
+	static void set_mock_host_cfg(config& cfg, const host_config& h_cfg) { cfg.host_cfg = h_cfg; }
+};
+} // namespace celerity::detail
+
+TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prefers user specified device pointer", "[device-selection][one]") {
+	celerity::detail::config cfg(nullptr, nullptr);
+
+	mock_device td(42);
+	mock_platform tp(68, {{5}, {7}, {9}});
+
+	auto device = pick_device(cfg, &td, std::vector<mock_platform>{tp});
+	CHECK(device == td);
+}
+
+TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
+    "pick_device automatically selects a gpu device if available and otherwise falls back to the first device available", "[device-selection][gen]") {
+	celerity::detail::config cfg(nullptr, nullptr);
+
+	mock_device* td = nullptr;
+	using device_t = cl::sycl::info::device_type;
+
+	auto dv_type_1 = GENERATE(as<cl::sycl::info::device_type>(), device_t::gpu, device_t::accelerator, device_t::cpu, device_t::custom, device_t::host);
+	CAPTURE(dv_type_1);
+
+	mock_device td_1(0, dv_type_1);
+	mock_platform tp_1(0, {td_1});
+
+	auto dv_type_2 = GENERATE(as<cl::sycl::info::device_type>(), device_t::gpu, device_t::accelerator, device_t::cpu, device_t::custom, device_t::host);
+	CAPTURE(dv_type_2);
+
+	mock_device td_2(0, dv_type_2);
+	mock_platform tp_2(1, {td_2});
+
+	auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_1, tp_2});
+	std::vector<mock_device> devices;
+	if(dv_type_1 == device_t::gpu || (dv_type_1 != device_t::gpu && dv_type_2 != device_t::gpu)) {
+		devices = tp_1.get_devices();
+	} else {
+		devices = tp_2.get_devices();
+	}
+	CHECK(device == devices[0]);
+}
+
+TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device selects device using CELERITY_DEVICES", "[device-selection][device-cfg]") {
+	celerity::detail::config cfg(nullptr, nullptr);
+	mock_device* td = nullptr;
+
+	mock_device td_1(0, cl::sycl::info::device_type::cpu);
+	mock_platform tp_0(0, {td_1});
+
+	mock_device td_2(0, cl::sycl::info::device_type::gpu);
+	mock_device td_3(1, cl::sycl::info::device_type::gpu);
+	mock_platform tp_1(1, {td_2, td_3});
+
+	celerity::detail::device_config d_cfg{tp_1.get_id(), td_3.get_id()};
+	celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
+
+	auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1});
+	std::vector<mock_device> devices = tp_1.get_devices();
+	CHECK(device == devices[1]);
+}
+
+TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
+    "pick_device selects a GPU for each local_rank or falls back to any type of sufficient device for all ranks", "[device-selection][host-cfg]") {
+	celerity::detail::config cfg(nullptr, nullptr);
+	mock_device* td = nullptr;
+
+	SECTION("pick_device unique GPU per node") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_device td_3(1, cl::sycl::info::device_type::gpu);
+		mock_device td_4(2, cl::sycl::info::device_type::gpu);
+		mock_device td_5(3, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2, td_3, td_4, td_5});
+
+		size_t node_count = 4;
+		size_t local_rank = 2;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1});
+		std::vector<mock_device> devices = tp_1.get_devices();
+		CHECK(device == devices[2]);
+	}
+
+	SECTION("pick_device prefers unique GPU over other devices") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_device td_3(1, cl::sycl::info::device_type::gpu);
+		mock_device td_4(2, cl::sycl::info::device_type::gpu);
+		mock_device td_5(3, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2, td_3, td_4, td_5});
+
+		mock_device td_6(0, cl::sycl::info::device_type::accelerator);
+		mock_device td_7(1, cl::sycl::info::device_type::accelerator);
+		mock_device td_8(2, cl::sycl::info::device_type::accelerator);
+		mock_device td_9(3, cl::sycl::info::device_type::accelerator);
+		mock_platform tp_2(1, {td_6, td_7, td_8, td_9});
+
+		size_t node_count = 4;
+		size_t local_rank = 3;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		std::vector<mock_device> devices = tp_1.get_devices();
+		CHECK(device == devices[3]);
+	}
+
+	SECTION("pick_device falls back to other devices with insufficient GPUs") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_device td_3(1, cl::sycl::info::device_type::gpu);
+		mock_device td_4(2, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2, td_3, td_4});
+
+		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
+		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
+		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
+		mock_device td_8(3, cl::sycl::info::device_type::accelerator);
+		mock_platform tp_2(1, {td_5, td_6, td_7, td_8});
+
+		size_t node_count = 4;
+		size_t local_rank = 3;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		std::vector<mock_device> devices = tp_2.get_devices();
+		CHECK(device == devices[3]);
+	}
+
+	SECTION("pick_device prefers the first available GPU with insufficient GPUs and other devices") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2});
+
+		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
+		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
+		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
+		mock_platform tp_2(1, {td_5, td_6, td_7});
+
+		size_t node_count = 4;
+		size_t local_rank = 3;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		std::vector<mock_device> devices = tp_1.get_devices();
+		CHECK(device == devices[0]);
+	}
+
+	SECTION("pick_device prefers the first available device(any) with no GPUs") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
+		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
+		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
+		mock_platform tp_2(1, {td_5, td_6, td_7});
+
+		size_t node_count = 4;
+		size_t local_rank = 3;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_2});
+		std::vector<mock_device> devices = tp_2.get_devices();
+		CHECK(device == devices[0]);
+	}
+}
+
+TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected info/warn messages", "[device-selection][msg]") {
+	std::ostringstream oss;
+	auto logger = spdlog::default_logger();
+	auto ostream_info_sink = std::make_shared<spdlog::sinks::ostream_sink_st>(oss);
+	ostream_info_sink->set_level(spdlog::level::info);
+	logger->sinks().push_back(ostream_info_sink);
+
+	celerity::detail::config cfg(nullptr, nullptr);
+	SECTION("device_pointer is specified by the user") {
+		mock_device td(42);
+		mock_platform tp(68, {{5}, {7}, {9}});
+
+		auto device = pick_device(cfg, &td, std::vector<mock_platform>{tp});
+		CHECK_THAT(oss.str(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (specified by user)"));
+		oss.str("");
+	}
+
+	mock_device* td = nullptr;
+	SECTION("CELERITY_DEVICE is set by the user") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_device td_3(1, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2, td_3});
+
+		celerity::detail::device_config d_cfg{td_3.get_id(), tp_1.get_id()};
+		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1});
+		CHECK_THAT(oss.str(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (set by CELERITY_DEVICES: platform 1, device 1)"));
+		oss.str("");
+	}
+
+
+	SECTION("pick_device selects a gpu/any per node automaticaly") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_device td_3(1, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2, td_3});
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1});
+		CHECK_THAT(oss.str(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (automatically selected platform 1, device 0)"));
+		oss.str("");
+	}
+
+	std::ostringstream _oss;
+	auto ostream_warn_sink = std::make_shared<spdlog::sinks::ostream_sink_st>(_oss);
+	ostream_warn_sink->set_level(spdlog::level::warn);
+	logger->sinks().push_back(ostream_warn_sink);
+	SECTION("pick_device can't find any platform with sufficient GPUs") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_device td_3(1, cl::sycl::info::device_type::gpu);
+		mock_device td_4(2, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2, td_3, td_4});
+
+		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
+		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
+		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
+		mock_device td_8(3, cl::sycl::info::device_type::accelerator);
+		mock_platform tp_2(1, {td_5, td_6, td_7, td_8});
+
+		size_t node_count = 4;
+		size_t local_rank = 3;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK_THAT(_oss.str(), Catch::Matchers::ContainsSubstring("No suitable platform found that can provide 4 GPU devices, and CELERITY_DEVICES not set"));
+		_oss.str("");
+	}
+
+	SECTION("pick_device can't find any platform with any type of sufficient device") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2});
+
+		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
+		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
+		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
+		mock_platform tp_2(1, {td_5, td_6, td_7});
+
+		size_t node_count = 4;
+		size_t local_rank = 3;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK_THAT(_oss.str(), Catch::Matchers::ContainsSubstring("No suitable platform found that can provide 4 devices, and CELERITY_DEVICES not set"));
+		_oss.str("");
+	}
+
+	SECTION("CELERITY_DEVICE is set with invalid platform id") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(0, cl::sycl::info::device_type::gpu);
+		mock_device td_3(1, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(3, {td_2, td_3});
+
+		celerity::detail::device_config d_cfg{tp_1.get_id(), td_3.get_id()};
+		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
+		CHECK_THROWS_WITH(pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1}), "Invalid platform id 3: Only 2 platforms available");
+	}
+
+	SECTION("CELERITY_DEVICE is set with invalid device id") {
+		mock_device td_1(0, cl::sycl::info::device_type::cpu);
+		mock_platform tp_0(0, {td_1});
+
+		mock_device td_2(4, cl::sycl::info::device_type::gpu);
+		mock_device td_3(5, cl::sycl::info::device_type::gpu);
+		mock_platform tp_1(1, {td_2, td_3});
+
+		celerity::detail::device_config d_cfg{tp_1.get_id(), td_3.get_id()};
+		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
+
+		CHECK_THROWS_WITH(pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1}), "Invalid device id 5: Only 2 devices available on platform 1");
+	}
+
+	SECTION("pick_device couldn't find any device") {
+		CHECK_THROWS_WITH(pick_device(cfg, td, std::vector<mock_platform>{}), "Automatic device selection failed: No device available");
+	}
+}

--- a/test/device_selection_tests.cc
+++ b/test/device_selection_tests.cc
@@ -7,33 +7,37 @@
 
 struct mock_platform;
 struct mock_device {
-	mock_device() : id(0), type(cl::sycl::info::device_type::gpu) {}
+	mock_device() : platform(nullptr), id(0), type(sycl::info::device_type::gpu) {}
 
-	mock_device(size_t id, cl::sycl::info::device_type type = cl::sycl::info::device_type::gpu) : id(id), type(type) {}
+	mock_device(size_t id, mock_platform& platform, sycl::info::device_type type = sycl::info::device_type::gpu) : platform(&platform), id(id), type(type) {}
 
-	mock_platform get_platform() const;
+	mock_platform& get_platform() const { return *platform; }
 
-	template <cl::sycl::info::device Param>
-	std::string get_info() const {
-		return "bar";
+	template <sycl::info::device Param>
+	auto get_info() const {
+		if constexpr(Param == sycl::info::device::name) { return name; }
+		if constexpr(Param == sycl::info::device::device_type) { return type; }
 	}
 
 	bool operator==(const mock_device& other) const { return other.id == id; }
 
-	cl::sycl::info::device_type get_type() const { return type; }
+	sycl::info::device_type get_type() const { return type; }
 
 	size_t get_id() { return id; }
 
   private:
+	mock_platform* platform;
+	std::string name = "bar";
 	size_t id;
-	cl::sycl::info::device_type type;
+	sycl::info::device_type type;
 };
 struct mock_platform {
-	// TODO: These devices should somehow have this platform as their platform (?)
-	mock_platform(size_t id, std::vector<mock_device> devices) : devices(std::move(devices)), id(id) {}
+	mock_platform(size_t id) : id(id) {}
 
-	std::vector<mock_device> get_devices(cl::sycl::info::device_type type = cl::sycl::info::device_type::all) const {
-		if(type != cl::sycl::info::device_type::all) {
+	void set_devices(std::vector<mock_device> devices) { this->devices = devices; }
+
+	std::vector<mock_device> get_devices(sycl::info::device_type type = sycl::info::device_type::all) const {
+		if(type != sycl::info::device_type::all) {
 			std::vector<mock_device> devices_with_type;
 			for(auto device : devices) {
 				if(device.get_type() == type) { devices_with_type.emplace_back(device); }
@@ -43,22 +47,22 @@ struct mock_platform {
 			return devices;
 	}
 
-	template <cl::sycl::info::platform Param>
+	template <sycl::info::platform Param>
 	std::string get_info() const {
-		return "foo";
+		return name;
 	}
+
+	void set_info(std::string name) { this->name = name; }
+
+	bool operator!=(const mock_platform& other) const { return other.id != id; }
 
 	size_t get_id() { return id; }
 
   private:
 	std::vector<mock_device> devices;
 	size_t id;
+	std::string name = "foo";
 };
-
-// TODO: Device should know its associated platform and return it from here
-mock_platform mock_device::get_platform() const {
-	return {15, {}}; // Setting random platform ID for now
-}
 
 
 namespace celerity::detail {
@@ -68,78 +72,79 @@ struct config_testspy {
 };
 } // namespace celerity::detail
 
-TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prefers user specified device pointer", "[device-selection][one]") {
+TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prefers user specified device pointer", "[device-selection]") {
 	celerity::detail::config cfg(nullptr, nullptr);
 
-	mock_device td(42);
-	mock_platform tp(68, {{5}, {7}, {9}});
+	mock_platform tp(68);
+	mock_device td(42, tp);
+	tp.set_devices({td});
 
-	auto device = pick_device(cfg, &td, std::vector<mock_platform>{tp});
+	auto device = pick_device(cfg, td, std::vector<mock_platform>{tp});
 	CHECK(device == td);
 }
 
 TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
-    "pick_device automatically selects a gpu device if available and otherwise falls back to the first device available", "[device-selection][gen]") {
+    "pick_device automatically selects a gpu device if available and otherwise falls back to the first device available", "[device-selection]") {
 	celerity::detail::config cfg(nullptr, nullptr);
 
-	mock_device* td = nullptr;
-	using device_t = cl::sycl::info::device_type;
+	using device_t = sycl::info::device_type;
 
-	auto dv_type_1 = GENERATE(as<cl::sycl::info::device_type>(), device_t::gpu, device_t::accelerator, device_t::cpu, device_t::custom, device_t::host);
+	auto dv_type_1 = GENERATE(as<sycl::info::device_type>(), device_t::gpu, device_t::accelerator, device_t::cpu, device_t::custom, device_t::host);
 	CAPTURE(dv_type_1);
 
-	mock_device td_1(0, dv_type_1);
-	mock_platform tp_1(0, {td_1});
+	mock_platform tp_1(0);
+	mock_device td_1(0, tp_1, dv_type_1);
+	tp_1.set_devices({td_1});
 
-	auto dv_type_2 = GENERATE(as<cl::sycl::info::device_type>(), device_t::gpu, device_t::accelerator, device_t::cpu, device_t::custom, device_t::host);
+	auto dv_type_2 = GENERATE(as<sycl::info::device_type>(), device_t::gpu, device_t::accelerator, device_t::cpu, device_t::custom, device_t::host);
 	CAPTURE(dv_type_2);
 
-	mock_device td_2(0, dv_type_2);
-	mock_platform tp_2(1, {td_2});
+	mock_platform tp_2(1);
+	mock_device td_2(1, tp_2, dv_type_2);
+	tp_2.set_devices({td_2});
 
-	auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_1, tp_2});
-	std::vector<mock_device> devices;
+	auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_1, tp_2});
 	if(dv_type_1 == device_t::gpu || (dv_type_1 != device_t::gpu && dv_type_2 != device_t::gpu)) {
-		devices = tp_1.get_devices();
+		CHECK(device == td_1);
 	} else {
-		devices = tp_2.get_devices();
+		CHECK(device == td_2);
 	}
-	CHECK(device == devices[0]);
 }
 
 TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device selects device using CELERITY_DEVICES", "[device-selection][device-cfg]") {
 	celerity::detail::config cfg(nullptr, nullptr);
-	mock_device* td = nullptr;
 
-	mock_device td_1(0, cl::sycl::info::device_type::cpu);
-	mock_platform tp_0(0, {td_1});
+	mock_platform tp_0(0);
+	mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+	tp_0.set_devices({td_1});
 
-	mock_device td_2(0, cl::sycl::info::device_type::gpu);
-	mock_device td_3(1, cl::sycl::info::device_type::gpu);
-	mock_platform tp_1(1, {td_2, td_3});
+	mock_platform tp_1(1);
+	mock_device td_2(0, tp_1, sycl::info::device_type::gpu);
+	mock_device td_3(1, tp_1, sycl::info::device_type::gpu);
+	tp_1.set_devices({td_2, td_3});
 
 	celerity::detail::device_config d_cfg{tp_1.get_id(), td_3.get_id()};
 	celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
 
-	auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1});
-	std::vector<mock_device> devices = tp_1.get_devices();
-	CHECK(device == devices[1]);
+	auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1});
+	CHECK(device == td_3);
 }
 
 TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
     "pick_device selects a GPU for each local_rank or falls back to any type of sufficient device for all ranks", "[device-selection][host-cfg]") {
 	celerity::detail::config cfg(nullptr, nullptr);
-	mock_device* td = nullptr;
 
 	SECTION("pick_device unique GPU per node") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_device td_3(1, cl::sycl::info::device_type::gpu);
-		mock_device td_4(2, cl::sycl::info::device_type::gpu);
-		mock_device td_5(3, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2, td_3, td_4, td_5});
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+		mock_device td_5(4, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4, td_5});
 
 		size_t node_count = 4;
 		size_t local_rank = 2;
@@ -148,26 +153,28 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
 		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1});
-		std::vector<mock_device> devices = tp_1.get_devices();
-		CHECK(device == devices[2]);
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1});
+		CHECK(device == td_4);
 	}
 
 	SECTION("pick_device prefers unique GPU over other devices") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_device td_3(1, cl::sycl::info::device_type::gpu);
-		mock_device td_4(2, cl::sycl::info::device_type::gpu);
-		mock_device td_5(3, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2, td_3, td_4, td_5});
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+		mock_device td_5(4, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4, td_5});
 
-		mock_device td_6(0, cl::sycl::info::device_type::accelerator);
-		mock_device td_7(1, cl::sycl::info::device_type::accelerator);
-		mock_device td_8(2, cl::sycl::info::device_type::accelerator);
-		mock_device td_9(3, cl::sycl::info::device_type::accelerator);
-		mock_platform tp_2(1, {td_6, td_7, td_8, td_9});
+		mock_platform tp_2(1);
+		mock_device td_6(5, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_7(6, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_8(7, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_9(8, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_6, td_7, td_8, td_9});
 
 		size_t node_count = 4;
 		size_t local_rank = 3;
@@ -176,25 +183,27 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
 		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
-		std::vector<mock_device> devices = tp_1.get_devices();
-		CHECK(device == devices[3]);
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK(device == td_5);
 	}
 
 	SECTION("pick_device falls back to other devices with insufficient GPUs") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_device td_3(1, cl::sycl::info::device_type::gpu);
-		mock_device td_4(2, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2, td_3, td_4});
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4});
 
-		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
-		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
-		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
-		mock_device td_8(3, cl::sycl::info::device_type::accelerator);
-		mock_platform tp_2(1, {td_5, td_6, td_7, td_8});
+		mock_platform tp_2(2);
+		mock_device td_5(4, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_6(5, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_7(6, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_8(7, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_5, td_6, td_7, td_8});
 
 		size_t node_count = 4;
 		size_t local_rank = 3;
@@ -203,22 +212,24 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
 		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
-		std::vector<mock_device> devices = tp_2.get_devices();
-		CHECK(device == devices[3]);
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK(device == td_8);
 	}
 
 	SECTION("pick_device prefers the first available GPU with insufficient GPUs and other devices") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2});
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2});
 
-		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
-		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
-		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
-		mock_platform tp_2(1, {td_5, td_6, td_7});
+		mock_platform tp_2(2);
+		mock_device td_3(2, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_4(3, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_5(4, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_3, td_4, td_5});
 
 		size_t node_count = 4;
 		size_t local_rank = 3;
@@ -227,19 +238,20 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
 		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
-		std::vector<mock_device> devices = tp_1.get_devices();
-		CHECK(device == devices[0]);
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK(device == td_2);
 	}
 
 	SECTION("pick_device prefers the first available device(any) with no GPUs") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
-		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
-		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
-		mock_platform tp_2(1, {td_5, td_6, td_7});
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::accelerator);
+		mock_device td_3(2, tp_1, sycl::info::device_type::accelerator);
+		mock_device td_4(3, tp_1, sycl::info::device_type::accelerator);
+		tp_1.set_devices({td_2, td_3, td_4});
 
 		size_t node_count = 4;
 		size_t local_rank = 3;
@@ -248,78 +260,96 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
 		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_2});
-		std::vector<mock_device> devices = tp_2.get_devices();
-		CHECK(device == devices[0]);
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1});
+		CHECK(device == td_1);
 	}
 }
 
-TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected info/warn messages", "[device-selection][msg]") {
-	std::ostringstream oss;
-	auto logger = spdlog::default_logger();
-	auto ostream_info_sink = std::make_shared<spdlog::sinks::ostream_sink_st>(oss);
-	ostream_info_sink->set_level(spdlog::level::info);
-	logger->sinks().push_back(ostream_info_sink);
-
-	celerity::detail::config cfg(nullptr, nullptr);
-	SECTION("device_pointer is specified by the user") {
-		mock_device td(42);
-		mock_platform tp(68, {{5}, {7}, {9}});
-
-		auto device = pick_device(cfg, &td, std::vector<mock_platform>{tp});
-		CHECK_THAT(oss.str(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (specified by user)"));
-		oss.str("");
+class log_capture {
+  public:
+	log_capture(spdlog::level::level_enum level = spdlog::level::trace) {
+		auto logger = spdlog::default_logger();
+		auto ostream_info_sink = std::make_shared<spdlog::sinks::ostream_sink_st>(oss);
+		ostream_info_sink->set_level(level);
+		logger->sinks().push_back(ostream_info_sink);
 	}
 
-	mock_device* td = nullptr;
-	SECTION("CELERITY_DEVICE is set by the user") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+	~log_capture() {
+		auto logger = spdlog::default_logger();
+		// TODO: Assert that no other sink has been pushed in the meantime
+		logger->sinks().pop_back();
+	}
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_device td_3(1, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2, td_3});
+	std::string get_log() { return oss.str(); }
+
+  private:
+	std::ostringstream oss;
+};
+
+TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected info/warn messages", "[device-selection][msg]") {
+	celerity::detail::config cfg(nullptr, nullptr);
+	SECTION("device_pointer is specified by the user") {
+		log_capture lc;
+		mock_platform tp(68);
+		mock_device td(42, tp);
+		tp.set_devices({{5, tp}, {7, tp}, {9, tp}});
+
+		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp});
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (specified by user)"));
+	}
+
+	SECTION("CELERITY_DEVICE is set by the user") {
+		log_capture lc;
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
+
+		mock_platform tp_1(1);
+		mock_device td_2(0, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(1, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3});
 
 		celerity::detail::device_config d_cfg{td_3.get_id(), tp_1.get_id()};
 		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1});
-		CHECK_THAT(oss.str(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (set by CELERITY_DEVICES: platform 1, device 1)"));
-		oss.str("");
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1});
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (set by CELERITY_DEVICES: platform 1, device 1)"));
 	}
 
 
 	SECTION("pick_device selects a gpu/any per node automaticaly") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		log_capture lc;
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_device td_3(1, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2, td_3});
+		mock_platform tp_1(1);
+		mock_device td_2(0, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(1, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3});
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1});
-		CHECK_THAT(oss.str(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (automatically selected platform 1, device 0)"));
-		oss.str("");
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1});
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("Using platform 'foo', device 'bar' (automatically selected platform 1, device 0)"));
 	}
 
-	std::ostringstream _oss;
-	auto ostream_warn_sink = std::make_shared<spdlog::sinks::ostream_sink_st>(_oss);
-	ostream_warn_sink->set_level(spdlog::level::warn);
-	logger->sinks().push_back(ostream_warn_sink);
 	SECTION("pick_device can't find any platform with sufficient GPUs") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		log_capture lc{spdlog::level::warn};
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_device td_3(1, cl::sycl::info::device_type::gpu);
-		mock_device td_4(2, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2, td_3, td_4});
+		mock_platform tp_1(1);
+		mock_device td_2(0, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(1, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(2, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4});
 
-		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
-		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
-		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
-		mock_device td_8(3, cl::sycl::info::device_type::accelerator);
-		mock_platform tp_2(1, {td_5, td_6, td_7, td_8});
+		mock_platform tp_2(1);
+		mock_device td_5(0, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_6(1, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_7(2, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_8(3, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_5, td_6, td_7, td_8});
 
 		size_t node_count = 4;
 		size_t local_rank = 3;
@@ -328,22 +358,25 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected
 		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
-		CHECK_THAT(_oss.str(), Catch::Matchers::ContainsSubstring("No suitable platform found that can provide 4 GPU devices, and CELERITY_DEVICES not set"));
-		_oss.str("");
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("No suitable platform found that can provide 4 GPU devices, and CELERITY_DEVICES not set"));
 	}
 
 	SECTION("pick_device can't find any platform with any type of sufficient device") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		log_capture lc(spdlog::level::warn);
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2});
+		mock_platform tp_1(1);
+		mock_device td_2(0, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2});
 
-		mock_device td_5(0, cl::sycl::info::device_type::accelerator);
-		mock_device td_6(1, cl::sycl::info::device_type::accelerator);
-		mock_device td_7(2, cl::sycl::info::device_type::accelerator);
-		mock_platform tp_2(1, {td_5, td_6, td_7});
+		mock_platform tp_2(2);
+		mock_device td_3(0, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_4(1, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_5(2, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_3, td_4, td_5});
 
 		size_t node_count = 4;
 		size_t local_rank = 3;
@@ -352,39 +385,323 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected
 		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1, tp_2});
-		CHECK_THAT(_oss.str(), Catch::Matchers::ContainsSubstring("No suitable platform found that can provide 4 devices, and CELERITY_DEVICES not set"));
-		_oss.str("");
+		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("No suitable platform found that can provide 4 devices, and CELERITY_DEVICES not set"));
 	}
 
 	SECTION("CELERITY_DEVICE is set with invalid platform id") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(0, cl::sycl::info::device_type::gpu);
-		mock_device td_3(1, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(3, {td_2, td_3});
+		mock_platform tp_1(3);
+		mock_device td_2(0, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(1, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3});
 
 		celerity::detail::device_config d_cfg{tp_1.get_id(), td_3.get_id()};
 		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
-		CHECK_THROWS_WITH(pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1}), "Invalid platform id 3: Only 2 platforms available");
+		CHECK_THROWS_WITH(pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1}),
+		    "Invalid platform id 3: Only 2 platforms available");
 	}
 
 	SECTION("CELERITY_DEVICE is set with invalid device id") {
-		mock_device td_1(0, cl::sycl::info::device_type::cpu);
-		mock_platform tp_0(0, {td_1});
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
 
-		mock_device td_2(4, cl::sycl::info::device_type::gpu);
-		mock_device td_3(5, cl::sycl::info::device_type::gpu);
-		mock_platform tp_1(1, {td_2, td_3});
+		mock_platform tp_1(1);
+		mock_device td_2(4, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(5, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3});
 
 		celerity::detail::device_config d_cfg{tp_1.get_id(), td_3.get_id()};
 		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
 
-		CHECK_THROWS_WITH(pick_device(cfg, td, std::vector<mock_platform>{tp_0, tp_1}), "Invalid device id 5: Only 2 devices available on platform 1");
+		CHECK_THROWS_WITH(pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{tp_0, tp_1}),
+		    "Invalid device id 5: Only 2 devices available on platform 1");
 	}
 
 	SECTION("pick_device couldn't find any device") {
-		CHECK_THROWS_WITH(pick_device(cfg, td, std::vector<mock_platform>{}), "Automatic device selection failed: No device available");
+		CHECK_THROWS_WITH(
+		    pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{}), "Automatic device selection failed: No device available");
 	}
+}
+
+// The following test doesn't work with ComputeCpp backend, since the == operator behaves differently
+#if !defined(WORKAROUND_COMPUTECPP)
+TEST_CASE_METHOD(celerity::test_utils::runtime_fixture,
+    "runtime::init/distr_queue provides an overloaded constructor with device selector, testing sycl::device", "[distr_queue][ctor][sycl]") {
+	std::vector<sycl::device> devices = sycl::device::get_devices();
+	if(devices.size() < 2) {
+		WARN("Platforms must have 2 or more devices!");
+		return;
+	}
+
+	auto device_idx = GENERATE(0, 1);
+	CAPTURE(device_idx);
+	sycl::device device = devices[device_idx];
+	CAPTURE(device);
+
+	auto device_selector = [device](const sycl::device& d) -> int { return d == device ? 2 : 1; };
+
+	celerity::distr_queue q(device_selector);
+
+	auto& dq = celerity::detail::runtime::get_instance().get_device_queue();
+	CHECK(dq.get_sycl_queue().get_device() == device);
+}
+#endif
+
+TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "runtime::init/distr_queue provides an overloaded constructor with device selector, testing mock_device",
+    "[device-selection][ctor][mock-host-cfg]") {
+	celerity::detail::config cfg(nullptr, nullptr);
+
+	SECTION("pick_device prefers a particular device over all") {
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
+		tp_0.set_info("foo_0");
+
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+		mock_device td_5(4, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4, td_5});
+		tp_1.set_info("foo_1");
+
+		mock_platform tp_2(2);
+		mock_device td_6(5, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_7(6, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_8(7, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_9(8, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_6, td_7, td_8, td_9});
+		tp_2.set_info("foo_2");
+
+		auto device_selector = [td_7](const mock_device& d) -> int { return d == td_7 ? 2 : 1; };
+
+		auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK(device == td_7);
+	}
+
+	SECTION("pick_device prefers a group of devices") {
+		log_capture lc;
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
+		tp_0.set_info("foo_0");
+
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::gpu);
+		mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4});
+		tp_1.set_info("foo_1");
+
+		mock_platform tp_2(2);
+		mock_device td_5(4, tp_2, sycl::info::device_type::gpu);
+		mock_device td_6(5, tp_2, sycl::info::device_type::gpu);
+		mock_device td_7(6, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_8(7, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_9(8, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_10(9, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_5, td_6, td_7, td_8, td_9, td_10});
+		tp_2.set_info("foo_2");
+
+		size_t node_count = 4;
+		size_t local_rank = 3;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device_selector = [](const mock_device& d) -> int { return d.get_type() == sycl::info::device_type::accelerator ? 2 : 1; };
+
+		auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("Using platform 'foo_2', device 'bar' (device selector specified: platform 2, device 3)"));
+		CHECK(device == td_10);
+	}
+
+	SECTION("pick_device prefers prioritised device with selector with insufficient devices") {
+		log_capture lc(spdlog::level::warn);
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
+		tp_0.set_info("foo_0");
+
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2});
+		tp_1.set_info("foo_1");
+
+		mock_platform tp_2(2);
+		mock_device td_3(2, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_3});
+		tp_2.set_info("foo_2");
+
+		size_t node_count = 4;
+		size_t local_rank = 3;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+		auto device_selector = [td_3](const mock_device& d) -> int { return d == td_3 ? 2 : 1; };
+
+		auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		CHECK_THAT(
+		    lc.get_log(), Catch::Matchers::ContainsSubstring("No suitable platform found that can provide 4 devices that match the specified device selector"));
+		CHECK(device == td_3);
+	}
+
+	SECTION("pick_device can choose devices across platform with warnings") {
+		log_capture lc(spdlog::level::warn);
+
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
+		tp_0.set_info("foo_0");
+
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::accelerator);
+		mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+		mock_device td_5(4, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4, td_5});
+		tp_1.set_info("foo_1");
+
+		mock_platform tp_2(2);
+		mock_device td_6(5, tp_2, sycl::info::device_type::gpu);
+		mock_device td_7(6, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_8(7, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_9(8, tp_2, sycl::info::device_type::accelerator);
+		tp_2.set_devices({td_6, td_7, td_8, td_9});
+		tp_2.set_info("foo_2");
+
+		size_t node_count = 4;
+		size_t local_rank = 2;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device_selector = [](const mock_device& d) -> int { return d.get_type() == sycl::info::device_type::accelerator ? 2 : 1; };
+
+		auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		INFO("Platform id" << device.get_platform().get_id() << " device id " << device.get_id());
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("Selected devices are of different type and/or do not belong to the same platform"));
+		CHECK(device == td_8);
+	}
+
+	SECTION("pick_device can choose different types of devices with warnings") {
+		log_capture lc(spdlog::level::warn);
+
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
+		tp_0.set_info("foo_0");
+
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::accelerator);
+		mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+		mock_device td_5(4, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4, td_5});
+		tp_1.set_info("foo_1");
+
+		mock_platform tp_2(2);
+		mock_device td_6(5, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_7(6, tp_2, sycl::info::device_type::gpu);
+		mock_device td_8(7, tp_2, sycl::info::device_type::gpu);
+		mock_device td_9(8, tp_2, sycl::info::device_type::gpu);
+		tp_2.set_devices({td_6, td_7, td_8, td_9});
+		tp_2.set_info("foo_2");
+
+		size_t node_count = 4;
+		size_t local_rank = 0;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device_selector = [](const mock_device& d) -> int { return d.get_type() == sycl::info::device_type::accelerator ? 2 : 1; };
+
+		auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		INFO("Platform id" << device.get_platform().get_id() << " device id " << device.get_id());
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("Selected devices are of different type and/or do not belong to the same platform"));
+		CHECK(device == td_2);
+	}
+
+	SECTION("pick_device can choose different types of devices with insufficient devices in platforms with warnings") {
+		log_capture lc(spdlog::level::warn);
+
+		mock_platform tp_0(0);
+		mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+		tp_0.set_devices({td_1});
+		tp_0.set_info("foo_0");
+
+		mock_platform tp_1(1);
+		mock_device td_2(1, tp_1, sycl::info::device_type::accelerator);
+		mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+		mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+		mock_device td_5(4, tp_1, sycl::info::device_type::gpu);
+		tp_1.set_devices({td_2, td_3, td_4, td_5});
+		tp_1.set_info("foo_1");
+
+		mock_platform tp_2(2);
+		mock_device td_6(5, tp_2, sycl::info::device_type::accelerator);
+		mock_device td_7(6, tp_2, sycl::info::device_type::gpu);
+		mock_device td_8(7, tp_2, sycl::info::device_type::gpu);
+		tp_2.set_devices({td_6, td_7, td_8});
+		tp_2.set_info("foo_2");
+
+		size_t node_count = 4;
+		size_t local_rank = 1;
+		size_t local_num_cpus = 1;
+
+		celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+		auto device_selector = [](const mock_device& d) -> int { return d.get_type() == sycl::info::device_type::accelerator ? 2 : 1; };
+
+		auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{tp_0, tp_1, tp_2});
+		INFO("Platform id" << device.get_platform().get_id() << " device id " << device.get_id());
+		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring("Selected devices are of different type and/or do not belong to the same platform"));
+		CHECK(device == td_6);
+	}
+}
+
+TEST_CASE_METHOD(
+    celerity::test_utils::mpi_fixture, "pick_device does not consider devices with a negative selector score", "[device-selection][msg][negative]") {
+	celerity::detail::config cfg(nullptr, nullptr);
+	log_capture lc;
+
+	mock_platform tp_0(0);
+	mock_device td_1(0, tp_0, sycl::info::device_type::cpu);
+	tp_0.set_devices({td_1});
+	tp_0.set_info("foo_0");
+
+	mock_platform tp_1(1);
+	mock_device td_2(1, tp_1, sycl::info::device_type::gpu);
+	mock_device td_3(2, tp_1, sycl::info::device_type::gpu);
+	mock_device td_4(3, tp_1, sycl::info::device_type::gpu);
+	mock_device td_5(4, tp_1, sycl::info::device_type::gpu);
+	tp_1.set_devices({td_2, td_3, td_4});
+	tp_1.set_info("foo_1");
+
+	mock_platform tp_2(2);
+	mock_device td_7(5, tp_2, sycl::info::device_type::gpu);
+	tp_2.set_devices({td_7});
+	tp_2.set_info("foo_2");
+
+	size_t node_count = 4;
+	size_t local_rank = 2;
+	size_t local_num_cpus = 1;
+
+	celerity::detail::host_config h_cfg{node_count, local_rank, local_num_cpus};
+	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+
+	auto device_selector = [](const mock_device& d) -> int { return d.get_type() == sycl::info::device_type::accelerator ? 1 : -1; };
+
+	CHECK_THROWS_WITH(
+	    pick_device(cfg, device_selector, std::vector<mock_platform>{tp_0, tp_1, tp_2}), "Device selection with device selector failed: No device available");
 }

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -69,6 +69,8 @@ namespace detail {
 		REQUIRE(runtime::is_initialized());
 	}
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "an explicit device can be provided to distr_queue", "[distr_queue][lifetime]") {
 		cl::sycl::default_selector selector;
 		cl::sycl::device device{selector};
@@ -84,6 +86,7 @@ namespace detail {
 			REQUIRE_THROWS_WITH(distr_queue{device}, "Passing explicit device not possible, runtime has already been initialized.");
 		}
 	}
+#pragma GCC diagnostic pop
 
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "buffer implicitly initializes the runtime", "[distr_queue][lifetime]") {
 		REQUIRE_FALSE(runtime::is_initialized());
@@ -683,7 +686,7 @@ namespace detail {
 #if CELERITY_FEATURE_SIMPLE_SCALAR_REDUCTIONS
 
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "attempting a reduction on buffers with size != 1 throws", "[task-manager]") {
-		runtime::init(nullptr, nullptr, nullptr);
+		runtime::init(nullptr, nullptr);
 		auto& tm = runtime::get_instance().get_task_manager();
 
 		buffer<float, 1> buf_1{cl::sycl::range<1>{2}};

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -384,7 +384,7 @@ namespace test_utils {
 			if(!dq) {
 				cfg = std::make_unique<detail::config>(nullptr, nullptr);
 				dq = std::make_unique<detail::device_queue>();
-				dq->init(*cfg, nullptr);
+				dq->init(*cfg, detail::auto_select_device{});
 			}
 			return *dq;
 		}
@@ -447,6 +447,20 @@ struct StringMaker<cl::sycl::range<Dims>> {
 		case 3: return fmt::format("{{{}, {}, {}}}", value[0], value[1], value[2]);
 		default: return {};
 		}
+	}
+};
+
+template <>
+struct StringMaker<sycl::device> {
+	static std::string convert(const sycl::device& d) {
+		return fmt::format("sycl::device(vendor_id={}, name=\"{}\")", d.get_info<sycl::info::device::vendor_id>(), d.get_info<sycl::info::device::name>());
+	}
+};
+
+template <>
+struct StringMaker<sycl::platform> {
+	static std::string convert(const sycl::platform& d) {
+		return fmt::format("sycl::platform(vendor=\"{}\", name=\"{}\")", d.get_info<sycl::info::platform::vendor>(), d.get_info<sycl::info::platform::name>());
 	}
 };
 


### PR DESCRIPTION
This feature adds the option to pass a device selector to the `distr_queue`, according to which devices get selected. Previously, a `sycl::device` could be passed (now deprecated). The device or the selector is then passed to the `device_queue.h/pick_device` function, which accepts a variant for either automatic device selection or the device selector or the `sycl::device` itself. 

The `pick_device` function has in total 4 branches in which a device can be selected. The first one is choosing the provided `sycl::device`, the second one is, choosing the device with the `CELERITY_DEVICES` environment variable. If in case none of those two options are taken, we then have another branch that either chooses the device automatically or uses the selector to choose the device.

The logic for automatic device selection:
1. `try_find_device_per_node` function takes in the type of device which should be selected and checks if any platform has enough devices of the same type to assign a unique device to each local node. 
The automatic selection first checks for all the unique devices to be GPUs, if not, it checks for any type of enough devices. 
2.  If there's no platform that can provide enough unique devices, the automatic selection tries to find at least one device, which is preferably a GPU, if not then any type of device with `try_find_one_device`.

The logic for device selection with the selector:
The same two functions as above are called, however, the type of device doesn't matter here. 
1. For `try_find_device_per_node` all the devices are collected and are sorted using the device selector. If enough devices of the same type belong to one platform, they are selected.
2. Similarly, for `try_find_one_device`, all the devices are collected and sorted and the device with the highest score is selected. 
3. A device with a score of `-1` is excluded from the selection. 

In case, no device gets selected according to the selector, the selection does not fall back to any random device.