### PR TITLE
Correctly qualify epoch_action type in detail::task

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -143,9 +143,9 @@ namespace detail {
 
 		const std::vector<reduction_id>& get_reductions() const { return reductions; }
 
-		epoch_action get_epoch_action() const { return epoch_action; }
+		detail::epoch_action get_epoch_action() const { return epoch_action; }
 
-		static std::unique_ptr<task> make_epoch(task_id tid, epoch_action action) {
+		static std::unique_ptr<task> make_epoch(task_id tid, detail::epoch_action action) {
 			return std::unique_ptr<task>(new task(tid, task_type::EPOCH, collective_group_id{}, task_geometry{}, nullptr, {}, {}, {}, {}, action));
 		}
 


### PR DESCRIPTION
`detail::task` has a member variable `epoch_action`, which shadows the type of the same name. Clang is fine with this, but GCC is not. This PR adds the necessary namespace qualification to disambiguate the type.

The issue is currently only observable when including `<celerity.h>` in a translation unit that is not built as a SYCL object and can therefore be compiled by the default C++ compiler (which is often GCC). At some point, we might want to check for better cross-compiler compatibility through CI.