### PR TITLE
Improve CI test system coverage

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -27,6 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # make sure to keep this in sync with docs/platform-support.md
         include:
           - sycl: "computecpp"
             sycl-version: "2.6.0"

--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -28,65 +28,84 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - sycl-version: "computecpp:2.6.0"
+          - sycl: "computecpp"
+            sycl-version: "2.6.0"
+            ubuntu-version: "20.04"
             platform: "intel"
             build-type: "Debug"
-          - sycl-version: "computecpp:2.7.0"
+          - sycl: "computecpp"
+            sycl-version: "2.7.0"
+            ubuntu-version: "20.04"
             platform: "intel"
             build-type: "Debug"
-          - sycl-version: "computecpp:2.8.0"
+          - sycl: "computecpp"
+            sycl-version: "2.8.0"
+            ubuntu-version: "20.04"
             platform: "intel"
             build-type: "Debug"
-          - sycl-version: "computecpp:2.9.0"
+          - sycl: "computecpp"
+            sycl-version: "2.9.0"
+            ubuntu-version: "22.04"
             platform: "intel"
             build-type: "Debug"
-          - sycl-version: "computecpp:2.9.0"
+          - sycl: "computecpp"
+            sycl-version: "2.9.0"
+            ubuntu-version: "22.04"
             platform: "intel"
             build-type: "Release"
-          - sycl-version: "computecpp:2.9.0-experimental"
+          - sycl: "computecpp"
+            sycl-version: "2.9.0-experimental"
+            ubuntu-version: "22.04"
             platform: "intel"
             build-type: "Debug"
-          - sycl-version: "computecpp:2.9.0-experimental"
+          - sycl: "computecpp"
+            sycl-version: "2.9.0-experimental"
+            ubuntu-version: "22.04"
             platform: "intel"
             build-type: "Release"
-          - sycl-version: "hipsycl:HEAD"
+          - sycl: "dpcpp"
+            sycl-version: "7735139b"
+            ubuntu-version: "20.04"
+            platform: "intel"
+            build-type: "Debug"
+          - sycl: "dpcpp"
+            sycl-version: "HEAD"
+            ubuntu-version: "22.04"
+            platform: "intel"
+            build-type: "Debug"
+          - sycl: "dpcpp"
+            sycl-version: "HEAD"
+            ubuntu-version: "22.04"
+            platform: "intel"
+            build-type: "Release"
+          - sycl: "hipsycl"
+            sycl-version: "7b00e2ef"
+            ubuntu-version: "20.04"
             platform: "nvidia"
             build-type: "Debug"
-          - sycl-version: "hipsycl:HEAD"
+          - sycl: "hipsycl"
+            sycl-version: "HEAD"
+            ubuntu-version: "22.04"
+            platform: "nvidia"
+            build-type: "Debug"
+          - sycl: "hipsycl"
+            sycl-version: "HEAD"
+            ubuntu-version: "22.04"
             platform: "nvidia"
             build-type: "Release"
-          - sycl-version: "hipsycl:7b00e2ef"
-            platform: "nvidia"
-            build-type: "Debug"
-          - sycl-version: "dpcpp:HEAD"
-            platform: "intel"
-            build-type: "Debug"
-          - sycl-version: "dpcpp:HEAD"
-            platform: "intel"
-            build-type: "Release"
-          - sycl-version: "dpcpp:7735139b"
-            platform: "intel"
-            build-type: "Debug"
 
     env:
-      build-name: ${{ matrix.platform }}-${{ matrix.sycl-version }}-${{ matrix.build-type }}
+      build-name: ${{ matrix.platform }}-ubuntu${{ matrix.ubuntu-version }}-${{ matrix.sycl }}-${{ matrix.sycl-version }}-${{ matrix.build-type }}
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       build-dir: /root/build
       examples-build-dir: /root/build-examples
     container:
-      image: build/celerity/${{ matrix.sycl-version }}
+      image: celerity-build/${{ matrix.sycl }}:ubuntu${{ matrix.ubuntu-version }}-${{ matrix.sycl-version }}
       volumes:
         - ccache:/ccache
     steps:
       - name: Print exact SYCL revision used for this CI run
         run: cat /VERSION
-      # The build name may not contain colons (this is not allowed for artifacts)
-      # Since GitHub does not provide a built-in string replacement function, we use a bashism
-      - name: Sanitize build name
-        shell: bash
-        run: echo "build-name=${unsanitized/:/-}" >> $GITHUB_ENV
-        env:
-          unsanitized: ${{ env.build-name }}
       - uses: actions/checkout@v2
         with:
           submodules: true

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ installed first.
 - [CMake](https://www.cmake.org) (3.13 or newer)
 - A C++17 compiler
 
+See the [platform support guide](docs/platform-support.md) on which library and OS versions are supported and
+automatically tested.
+
 Building can be as simple as calling `cmake && make`, depending on your setup
 you might however also have to provide some library paths etc.
 See our [installation guide](docs/installation.md) for more information.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,3 +20,4 @@
 
 1. [Overview](overview.md)
 2. [Core Principles](core-principles.md)
+3. [Platform Support](platform-support.md)

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,3 +1,9 @@
+---
+id: platform-support
+title: Officially Supported Platforms
+sidebar_label: Platform Support
+---
+
 # Officially Supported Platforms
 
 The most recent version of Celerity aims to support the following environments:
@@ -16,20 +22,15 @@ The most recent version of Celerity aims to support the following environments:
 ## Continuously Tested Configurations
 
 We automatically verify Celerity's build process and test suites against a select number of system configurations.
+
 Those are:
 
-| SYCL       | SYCL version                                                                        | OS           | Build type |
-|------------|-------------------------------------------------------------------------------------|--------------|------------|
-| ComputeCpp | 2.6.0                                                                               | Ubuntu 20.04 | Debug      |
-| "          | 2.7.0                                                                               | "            | "          |
-| "          | 2.8.0                                                                               | "            | "          |
-| "          | 2.9.0                                                                               | Ubuntu 22.04 | "          |
-| "          | 2.9.0 (Experimental Compiler)                                                       | "            | "          |
-| "          | 2.9.0                                                                               | "            | Release    |
-| "          | 2.9.0 (Experimental Compiler)                                                       | "            | "          |
-| DPC++      | [`7735139b`](https://github.com/intel/llvm/commit/7735139b)                         | Ubuntu 20.04 | Debug      |
-| "          | [`HEAD`](https://github.com/intel/llvm/)                                            | Ubuntu 22.04 | "          |
-| "          | "                                                                                   | "            | Release    |
-| hipSYCL    | [`7b00e2ef`](https://github.com/illuhad/hipSYCL/commit/7b00e2ef) (with CUDA 11.0.3) | Ubuntu 20.04 | Debug      |
-| "          | [`HEAD`](https://github.com/illuhad/hipSYCL) (with CUDA 11.7.0)                     | Ubuntu 22.04 | "          |
-| "          | "                                                                                   | "            | Release    |
+| SYCL       | SYCL version                                                                   | OS           | Build type     |
+|------------|--------------------------------------------------------------------------------|--------------|----------------|
+| ComputeCpp | 2.6.0, 2.7.0, 2.8.0 (stable)                                                   | Ubuntu 20.04 | Debug          |
+| ComputeCpp | 2.9.0 (stable)                                                                 | Ubuntu 22.04 | Debug, Release |
+| ComputeCpp | 2.9.0 (experimental compiler)                                                  | Ubuntu 22.04 | Debug, Release |
+| DPC++      | [`7735139b`](https://github.com/intel/llvm/commit/7735139b)                    | Ubuntu 20.04 | Debug          |
+| DPC++      | [`HEAD`](https://github.com/intel/llvm/)                                       | Ubuntu 22.04 | Debug, Release |
+| hipSYCL    | [`7b00e2ef`](https://github.com/illuhad/hipSYCL/commit/7b00e2ef) (CUDA 11.0.3) | Ubuntu 20.04 | Debug          |
+| hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (CUDA 11.7.0)                     | Ubuntu 22.04 | Debug, Release |

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,0 +1,35 @@
+# Officially Supported Platforms
+
+The most recent version of Celerity aims to support the following environments:
+
+* hipSYCL ≥ revision [`7b00e2ef`](https://github.com/illuhad/hipSYCL/commit/7b00e2ef), with
+  * Clang ≥ 10.0
+  * CUDA ≥ 11.0
+  * on NVIDIA hardware with compute capability ≥ 7.0
+  * or on CPUs via OpenMP
+* ComputeCpp ≥ version 2.6.0
+  * on Intel hardware
+  * with [stable](https://developer.codeplay.com/products/computecpp/ce/download) and [experimental](https://developer.codeplay.com/products/computecpp/ce/download?experimental=true) compilers
+* DPC++ ≥ revision [`7735139b`](https://github.com/intel/llvm/commit/7735139b)
+  * on Intel hardware
+
+## Continuously Tested Configurations
+
+We automatically verify Celerity's build process and test suites against a select number of system configurations.
+Those are:
+
+| SYCL       | SYCL version                                                                        | OS           | Build type |
+|------------|-------------------------------------------------------------------------------------|--------------|------------|
+| ComputeCpp | 2.6.0                                                                               | Ubuntu 20.04 | Debug      |
+| "          | 2.7.0                                                                               | "            | "          |
+| "          | 2.8.0                                                                               | "            | "          |
+| "          | 2.9.0                                                                               | Ubuntu 22.04 | "          |
+| "          | 2.9.0 (Experimental Compiler)                                                       | "            | "          |
+| "          | 2.9.0                                                                               | "            | Release    |
+| "          | 2.9.0 (Experimental Compiler)                                                       | "            | "          |
+| DPC++      | [`7735139b`](https://github.com/intel/llvm/commit/7735139b)                         | Ubuntu 20.04 | Debug      |
+| "          | [`HEAD`](https://github.com/intel/llvm/)                                            | Ubuntu 22.04 | "          |
+| "          | "                                                                                   | "            | Release    |
+| hipSYCL    | [`7b00e2ef`](https://github.com/illuhad/hipSYCL/commit/7b00e2ef) (with CUDA 11.0.3) | Ubuntu 20.04 | Debug      |
+| "          | [`HEAD`](https://github.com/illuhad/hipSYCL) (with CUDA 11.7.0)                     | Ubuntu 22.04 | "          |
+| "          | "                                                                                   | "            | Release    |

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,7 +14,8 @@
     ],
     "Celerity In-Depth": [
       "overview",
-      "core-principles"
+      "core-principles",
+      "platform-support"
     ]
   }
 }


### PR DESCRIPTION
This PR updates the CI configuration to build the most recent version of each SYCL implementation against Ubuntu 22.04, while keeping Ubuntu 20.04 for older SYCL versions. For our pinned hipSYCL version (built with Ubuntu 20.04), the CUDA version is downgraded to 11.0.3, while for hipSYCL HEAD (built with Ubuntu 22.04) CUDA is upgraded to 11.7.

This also adds platform support documentation listing the systems Celerity intends to support together with a table of the precise configurations tested in CI.

**Question:** Do we want to list Windows / MSVC as a supported platform? If so, for which SYCL implementation?