### PR TITLE
Add clang-tidy configuration; check during CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,9 @@ CheckOptions:
     value: lower_case
   - key: readability-identifier-naming.LocalVariableCase
     value: lower_case
+  - key: readability-identifier-naming.LocalVariableIgnoredRegexp
+    # Allow single-letter uppercase variable names
+    value: "[A-Z]"
   - key: readability-identifier-naming.ParameterCase
     value: lower_case
   - key: readability-identifier-naming.PrivateMemberCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,19 @@
 #
 InheritParentConfig: false
 # See https://clang.llvm.org/extra/clang-tidy/checks/list.html for a full list of available checks.
-Checks: clang-diagnostic-*,clang-analyzer-*,readability-*,performance-*,cppcoreguidelines-*,mpi-*,-readability-uppercase-literal-suffix
+Checks:
+  -*,
+  readability-identifier-naming,
+  # TODO: Figure out which ones we want to (at least partially) enable
+  # bugprone-*,
+  # clang-analyzer-*,
+  # clang-diagnostic-*,
+  # cppcoreguidelines-*,
+  # mpi-*,
+  # performance-*,
+  # readability-*,
+  # -readability-uppercase-literal-suffix
+
 CheckOptions:
   # Naming conventions
   - key: readability-identifier-naming.ClassCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,6 +31,9 @@ CheckOptions:
     value: "[A-Z]"
   - key: readability-identifier-naming.ParameterCase
     value: lower_case
+  - key: readability-identifier-naming.ParameterIgnoredRegexp
+    # Allow single-letter uppercase function parameters
+    value: "[A-Z]"
   - key: readability-identifier-naming.PrivateMemberCase
     value: lower_case
   - key: readability-identifier-naming.PrivateMemberPrefix

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,45 @@
+---
+#
+# Clang-Tidy configuration for Celerity.
+#
+# There are three usage scenarios:
+# 1. Automatic checks through an IDE (CLion, VsCode, ...)
+# 2. Running manually on select files (not recommended)
+#    `clang-tidy -p path/to/compile_commands.json file1 [file2, ...]`
+# 3. Running on a diff (also done during CI)
+#    `git diff -U0 --no-color | clang-tidy-diff.py -p1 -path path/to/compile_commands.json`
+#
+InheritParentConfig: false
+# See https://clang.llvm.org/extra/clang-tidy/checks/list.html for a full list of available checks.
+Checks: clang-diagnostic-*,clang-analyzer-*,readability-*,performance-*,cppcoreguidelines-*,mpi-*,-readability-uppercase-literal-suffix
+CheckOptions:
+  # Naming conventions
+  - key: readability-identifier-naming.ClassCase
+    value: lower_case
+  - key: readability-identifier-naming.ClassMethodCase
+    value: lower_case
+  - key: readability-identifier-naming.EnumCase
+    value: lower_case
+  - key: readability-identifier-naming.EnumConstantCase
+    value: lower_case
+  - key: readability-identifier-naming.FunctionCase
+    value: lower_case
+  - key: readability-identifier-naming.LocalVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.TemplateParameterCase
+    value: CamelCase
+  # Other coding conventions
+  - key: readability-braces-around-statements.ShortStatementLines
+    # Allow control-flow statements w/o braces when on a single line
+    value: 1
+
+# Treat naming violations as errors
+WarningsAsErrors: "readability-identifier-naming"
+# Use .clang-format configuration for fixes
+FormatStyle: file

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,21 @@
+# Revisions to ignore in git blame.
+#
+# Usage:
+#   `git blame --ignore-revs-file .git-blame-ignore-revs`
+# Or set by default:
+#   `git config --global blame.ignoreRevsFile .git-blame-ignore-revs`
+
+# clang-tidy: Fix readability-identifier-naming.PrivateMemberPrefix
+f445ce7df132c35ae1b77fc6a1c38ff47115f02c
+# clang-tidy: Fix readability-identifier-naming.ParameterCase
+76e0791931bb01cd44feb4d21165d7735eeb6271
+# clang-tidy: Fix readability-identifier-naming.LocalVariableCase
+b2056c59c1401c18851f2b189b2c8746dfd64e1c
+# clang-tidy: Fix readability-identifier-naming.FunctionCase
+64f332eac4baba8167ff2aa6ee708ae941e89bb6
+# clang-tidy: Fix readability-identifier-naming.EnumConstantCase
+33228ff954d39990a21d2357e0f63ef30062c1fe
+# clang-tidy: Fix readability-identifier-naming.EnumCase
+2a397771ecbdd31bf0bc9ce1ab860478127dbf79
+# clang-tidy: Fix readability-identifier-naming.ClassCase
+b2f5f47eee4527d2466d62172ef8e34e2f1953a3

--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -14,11 +14,61 @@ jobs:
       - id: skip-check
         uses: fkirc/skip-duplicate-actions@v3.4.1
         with:
-          concurrent_skipping: 'same_content_newer'
-          skip_after_successful_duplicate: 'true'
+          concurrent_skipping: "same_content_newer"
+          skip_after_successful_duplicate: "true"
           paths_ignore: '["**/*.md", "docs/**", "website/**"]'
           do_not_skip: '["workflow_dispatch", "schedule"]'
-          cancel_others: 'true'
+          cancel_others: "true"
+
+  # Run Clang-Tidy checks
+  #
+  # Note:
+  # - The action we use for this (ZedThree/clang-tidy-review) is a Docker action.
+  #   However, to obtain the required compile_commands.json file, we need our own
+  #   Docker container environment. We therefore run this job within a build container
+  #   and manually call the job's Python script.
+  # - This action currently only supports pull_request triggers (as it creates review
+  #   comments), so we have to run it regardless of skip-duplicate-action's outcome
+  #   (as otherwise pull_request triggers will usually be skipped due to the push
+  #   trigger already running).
+  #
+  # TODO: This should be combined with the report (or "lint") step, really
+  clang-tidy:
+    if: github.event.pull_request
+    runs-on: [self-hosted, nvidia]
+    env:
+      container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
+      build-dir: /root/build
+    container:
+      # We could run this for more than one implementation,
+      # but would likely end up with mostly duplicate diagnostics.
+      image: celerity-build/hipsycl:ubuntu22.04-HEAD
+      volumes:
+        - ccache:/ccache
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      # We only want to configure CMake, so we build the "help" target,
+      # which doesn't actually do anything (other than print all targets).
+      - name: Configure CMake
+        run: bash -o pipefail -c "bash /root/build-celerity.sh ${{ env.container-workspace }} --build-type Debug --target help"
+      - name: Check clang-tidy
+        working-directory: ${{ env.build-dir }}
+        run: |
+          git clone https://github.com/ZedThree/clang-tidy-review.git
+          cd clang-tidy-review
+          git checkout v0.8.4
+          pip install -r ./requirements.txt
+          cd ${{ env.container-workspace }}
+          python3 ${{ env.build-dir }}/clang-tidy-review/review.py \
+            --clang_tidy_binary=clang-tidy \
+            --token=${{ github.token }} \
+            --repo=${{ github.repository }} \
+            --pr=${{ github.event.pull_request.number }} \
+            --build_dir=${{ env.build-dir }} \
+            --config_file=${{ env.container-workspace }}/.clang-tidy \
+            --include="*.h,*.cc,*.[ch]pp"
 
   build-and-test:
     needs: find-duplicate-workflows

--- a/ci/run-clang-tidy.sh
+++ b/ci/run-clang-tidy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -o errexit -o pipefail -o noclobber -o nounset
+
+if [[ $# -gt 0 && $1 == "--help" ]]; then
+    {
+        echo "Run clang-tidy on all Celerity source files"
+        echo "Usage: $0 [<clang-tidy arguments>...]"
+        echo "Set CLANG_TIDY environment variable to override default executable (\`clang-tidy\`)."
+    } >&2
+    exit 1
+fi
+
+if [[ ! -d src ]]; then
+    echo "Error: This script should be run from within the repository root directory." >&2
+    exit 1
+fi
+
+CLANG_TIDY=${CLANG_TIDY:-clang-tidy}
+if [[ ! -x "$CLANG_TIDY" ]]; then
+    echo "Clang tidy executable \`$CLANG_TIDY\` does not exist. Set CLANG_TIDY environment variable to override."
+    exit 1
+fi
+
+RUN_PARALLEL=1
+if [[ ! -x $(command -v parallel) ]]; then
+    echo "\`parallel\` not found. Running sequentially." >&2
+    RUN_PARALLEL=0
+fi
+if grep -q -- "--fix\(-errors\)\?" <<< "$@" ; then
+    echo "\`--fix\` or \`--fix-errors\` is set. Running sequentially." >&2
+    RUN_PARALLEL=0
+fi
+
+INCLUDE_DIR=$(readlink -f include)
+SOURCES=$(find examples src test -name "*.cc")
+
+if [[ $RUN_PARALLEL -eq 1 ]]; then
+    set -x
+    parallel "$CLANG_TIDY" --header-filter="$INCLUDE_DIR" "$@" -- $SOURCES
+else
+    set -x
+    "$CLANG_TIDY" --header-filter="$INCLUDE_DIR" "$@" $SOURCES
+fi

--- a/include/accessor.h
+++ b/include/accessor.h
@@ -344,7 +344,7 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 #endif
 			return {static_cast<cl::sycl::handler* const*>(nullptr), sycl_accessor, id<Dims>{}, detail::zero_range};
 		} else {
-			if(detail::get_handler_execution_target(cgh) != detail::execution_target::DEVICE) {
+			if(detail::get_handler_execution_target(cgh) != detail::execution_target::device) {
 				throw std::runtime_error(
 				    "Calling accessor constructor with device target is only allowed in parallel_for tasks."
 				    "If you want to access this buffer from within a host task, please specialize the call using one of the *_host_task tags");
@@ -409,7 +409,7 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 			prepass_cgh.add_requirement(detail::get_buffer_id(buff), std::make_unique<detail::range_mapper<Dims, Functor>>(rmfn, Mode, buff.get_range()));
 		} else {
 			if constexpr(Target == target::host_task) {
-				if(detail::get_handler_execution_target(cgh) != detail::execution_target::HOST) {
+				if(detail::get_handler_execution_target(cgh) != detail::execution_target::host) {
 					throw std::runtime_error(
 					    "Calling accessor constructor with host_buffer target is only allowed in host tasks."
 					    "If you want to access this buffer from within a parallel_for task, please specialize the call using one of the non host tags");

--- a/include/accessor.h
+++ b/include/accessor.h
@@ -115,54 +115,54 @@ class [[deprecated("host_memory_layout will be removed in favor of buffer_alloca
 		dimension() noexcept = default;
 
 		dimension(size_t global_size, size_t global_offset, size_t local_size, size_t local_offset, size_t extent)
-		    : global_size(global_size), global_offset(global_offset), local_size(local_size), local_offset(local_offset), extent(extent) {
+		    : m_global_size(global_size), m_global_offset(global_offset), m_local_size(local_size), m_local_offset(local_offset), m_extent(extent) {
 			assert(global_offset >= local_offset);
 			assert(global_size >= local_size);
 		}
 
-		size_t get_global_size() const { return global_size; }
+		size_t get_global_size() const { return m_global_size; }
 
-		size_t get_local_size() const { return local_size; }
+		size_t get_local_size() const { return m_local_size; }
 
-		size_t get_global_offset() const { return global_offset; }
+		size_t get_global_offset() const { return m_global_offset; }
 
-		size_t get_local_offset() const { return local_offset; }
+		size_t get_local_offset() const { return m_local_offset; }
 
-		size_t get_extent() const { return extent; }
+		size_t get_extent() const { return m_extent; }
 
 	  private:
-		size_t global_size{};
-		size_t global_offset{};
-		size_t local_size{};
-		size_t local_offset{};
-		size_t extent{};
+		size_t m_global_size{};
+		size_t m_global_offset{};
+		size_t m_local_size{};
+		size_t m_local_offset{};
+		size_t m_extent{};
 	};
 
 	class [[deprecated("host_memory_layout will be removed in favor of buffer_allocation_window in a future version of Celerity")]] dimension_vector {
 	  public:
-		dimension_vector(size_t size) : this_size(size) {}
+		dimension_vector(size_t size) : m_this_size(size) {}
 
-		dimension& operator[](size_t idx) { return values[idx]; }
-		const dimension& operator[](size_t idx) const { return values[idx]; }
+		dimension& operator[](size_t idx) { return m_values[idx]; }
+		const dimension& operator[](size_t idx) const { return m_values[idx]; }
 
-		size_t size() const { return this_size; }
+		size_t size() const { return m_this_size; }
 
 	  private:
 		/**
 		 * Since contiguous dimensions can be merged when generating the memory layout, host_memory_layout is not generic over a fixed dimension count
 		 */
 		constexpr static size_t max_dimensionality = 4;
-		std::array<dimension, max_dimensionality> values;
-		size_t this_size;
+		std::array<dimension, max_dimensionality> m_values;
+		size_t m_this_size;
 	};
 
-	explicit host_memory_layout(const dimension_vector& dimensions) : dimensions(dimensions) {}
+	explicit host_memory_layout(const dimension_vector& dimensions) : m_dimensions(dimensions) {}
 
 	/** The layout maps per dimension, in descending dimensionality */
-	const dimension_vector& get_dimensions() const { return dimensions; }
+	const dimension_vector& get_dimensions() const { return m_dimensions; }
 
   private:
-	dimension_vector dimensions;
+	dimension_vector m_dimensions;
 };
 #pragma GCC diagnostic pop
 
@@ -178,33 +178,33 @@ class [[deprecated("host_memory_layout will be removed in favor of buffer_alloca
 template <typename T, int Dims>
 class buffer_allocation_window {
   public:
-	T* get_allocation() const { return allocation; }
+	T* get_allocation() const { return m_allocation; }
 
-	range<Dims> get_buffer_range() const { return buffer_range; }
+	range<Dims> get_buffer_range() const { return m_buffer_range; }
 
-	range<Dims> get_allocation_range() const { return allocation_range; }
+	range<Dims> get_allocation_range() const { return m_allocation_range; }
 
-	range<Dims> get_window_range() const { return window_range; }
+	range<Dims> get_window_range() const { return m_window_range; }
 
-	id<Dims> get_allocation_offset_in_buffer() const { return allocation_offset_in_buffer; }
+	id<Dims> get_allocation_offset_in_buffer() const { return m_allocation_offset_in_buffer; }
 
-	id<Dims> get_window_offset_in_buffer() const { return window_offset_in_buffer; }
+	id<Dims> get_window_offset_in_buffer() const { return m_window_offset_in_buffer; }
 
-	id<Dims> get_window_offset_in_allocation() const { return window_offset_in_buffer - allocation_offset_in_buffer; }
+	id<Dims> get_window_offset_in_allocation() const { return m_window_offset_in_buffer - m_allocation_offset_in_buffer; }
 
   private:
-	T* allocation;
-	range<Dims> buffer_range;
-	range<Dims> allocation_range;
-	range<Dims> window_range;
-	id<Dims> allocation_offset_in_buffer;
-	id<Dims> window_offset_in_buffer;
+	T* m_allocation;
+	range<Dims> m_buffer_range;
+	range<Dims> m_allocation_range;
+	range<Dims> m_window_range;
+	id<Dims> m_allocation_offset_in_buffer;
+	id<Dims> m_window_offset_in_buffer;
 
   public:
 	buffer_allocation_window(T* allocation, const range<Dims>& buffer_range, const range<Dims>& allocation_range, const range<Dims>& window_range,
 	    const id<Dims>& allocation_offset_in_buffer, const id<Dims>& window_offset_in_buffer)
-	    : allocation(allocation), buffer_range(buffer_range), allocation_range(allocation_range), window_range(window_range),
-	      allocation_offset_in_buffer(allocation_offset_in_buffer), window_offset_in_buffer(window_offset_in_buffer) {}
+	    : m_allocation(allocation), m_buffer_range(buffer_range), m_allocation_range(allocation_range), m_window_range(window_range),
+	      m_allocation_offset_in_buffer(allocation_offset_in_buffer), m_window_offset_in_buffer(window_offset_in_buffer) {}
 
 	template <typename, int, access_mode, target>
 	friend class accessor;
@@ -240,11 +240,11 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 	}
 
 #if !defined(__SYCL_DEVICE_ONLY__)
-	accessor(const accessor& other) : sycl_accessor(other.sycl_accessor) { init_from(other); }
+	accessor(const accessor& other) : m_sycl_accessor(other.m_sycl_accessor) { init_from(other); }
 
 	accessor& operator=(const accessor& other) {
 		if(this != &other) {
-			sycl_accessor = other.sycl_accessor;
+			m_sycl_accessor = other.m_sycl_accessor;
 			init_from(other);
 		}
 		return *this;
@@ -253,12 +253,12 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 
 	template <access_mode M = Mode, int D = Dims>
 	std::enable_if_t<detail::access::mode_traits::is_producer(M) && M != access_mode::atomic && (D > 0), DataT&> operator[](id<Dims> index) const {
-		return detail::ranged_sycl_access(sycl_accessor, buffer_range, index - index_offset);
+		return detail::ranged_sycl_access(m_sycl_accessor, m_buffer_range, index - m_index_offset);
 	}
 
 	template <access_mode M = Mode, int D = Dims>
 	std::enable_if_t<detail::access::mode_traits::is_pure_consumer(M) && (D > 0), DataT> operator[](id<Dims> index) const {
-		return detail::ranged_sycl_access(sycl_accessor, buffer_range, index - index_offset);
+		return detail::ranged_sycl_access(m_sycl_accessor, m_buffer_range, index - m_index_offset);
 	}
 
 #pragma GCC diagnostic push
@@ -267,7 +267,7 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 	template <access_mode M = Mode, int D = Dims>
 	[[deprecated("Atomic accessors are deprecated as of SYCL 2020")]] std::enable_if_t<M == access_mode::atomic && (D > 0), cl::sycl::atomic<DataT>> operator[](
 	    id<Dims> index) const {
-		return detail::ranged_sycl_access(sycl_accessor, buffer_range, index - index_offset);
+		return detail::ranged_sycl_access(m_sycl_accessor, m_buffer_range, index - m_index_offset);
 	}
 #pragma GCC diagnostic pop
 
@@ -277,7 +277,7 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 	}
 
 	friend bool operator==(const accessor& lhs, const accessor& rhs) {
-		return lhs.sycl_accessor == rhs.sycl_accessor && lhs.buffer_range == rhs.buffer_range && lhs.index_offset == rhs.index_offset;
+		return lhs.m_sycl_accessor == rhs.m_sycl_accessor && lhs.m_buffer_range == rhs.m_buffer_range && lhs.m_index_offset == rhs.m_index_offset;
 	}
 
 	friend bool operator!=(const accessor& lhs, const accessor& rhs) { return !(lhs == rhs); }
@@ -298,17 +298,17 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 	friend accessor<T, D, M, target::device> detail::make_device_accessor(Args&&...);
 
 	// see init_from
-	cl::sycl::handler* const* eventual_sycl_cgh = nullptr;
-	sycl_accessor_t sycl_accessor;
-	sycl::id<Dims> index_offset;
-	sycl::range<Dims> buffer_range = detail::zero_range; // TODO remove this togehter with ComputeCpp < 2.8.0 support
+	cl::sycl::handler* const* m_eventual_sycl_cgh = nullptr;
+	sycl_accessor_t m_sycl_accessor;
+	sycl::id<Dims> m_index_offset;
+	sycl::range<Dims> m_buffer_range = detail::zero_range; // TODO remove this togehter with ComputeCpp < 2.8.0 support
 
 	accessor(
 	    cl::sycl::handler* const* eventual_sycl_cgh, cl::sycl::buffer<DataT, Dims>& buffer, const subrange<Dims>& effective_subrange, id<Dims> index_offset)
-	    : eventual_sycl_cgh(eventual_sycl_cgh),
+	    : m_eventual_sycl_cgh(eventual_sycl_cgh),
 	      // We pass a range and offset here to avoid interference from SYCL, but the offset must be relative to the *backing buffer*.
-	      sycl_accessor(sycl_accessor_t(buffer, effective_subrange.range, effective_subrange.offset)), index_offset(index_offset),
-	      buffer_range(buffer.get_range()) {
+	      m_sycl_accessor(sycl_accessor_t(buffer, effective_subrange.range, effective_subrange.offset)), m_index_offset(index_offset),
+	      m_buffer_range(buffer.get_range()) {
 		// SYCL 1.2.1 dictates that all kernel parameters must have standard layout.
 		// However, since we are wrapping a SYCL accessor, this assertion fails for some implementations,
 		// as it is currently unclear whether SYCL accessors must also have standard layout.
@@ -321,7 +321,7 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 	using constructor_args = std::tuple<cl::sycl::handler* const*, sycl_accessor_t, id<Dims>, range<Dims>>;
 
 	explicit accessor(constructor_args&& args)
-	    : eventual_sycl_cgh(std::get<0>(args)), sycl_accessor(std::get<1>(args)), index_offset(std::get<2>(args)), buffer_range(std::get<3>(args)) {
+	    : m_eventual_sycl_cgh(std::get<0>(args)), m_sycl_accessor(std::get<1>(args)), m_index_offset(std::get<2>(args)), m_buffer_range(std::get<3>(args)) {
 		// SYCL 1.2.1 dictates that all kernel parameters must have standard layout.
 		// However, since we are wrapping a SYCL accessor, this assertion fails for some implementations,
 		// as it is currently unclear whether SYCL accessors must also have standard layout.
@@ -364,18 +364,18 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 	}
 
 	void init_from(const accessor& other) {
-		eventual_sycl_cgh = other.eventual_sycl_cgh;
-		index_offset = other.index_offset;
-		buffer_range = other.buffer_range;
+		m_eventual_sycl_cgh = other.m_eventual_sycl_cgh;
+		m_index_offset = other.m_index_offset;
+		m_buffer_range = other.m_buffer_range;
 
 		// The call to sycl::handler::require must happen inside the SYCL CGF, but since get_access within the Celerity CGF is executed before
 		// the submission to SYCL, it needs to be deferred. We capture a reference to a SYCL handler pointer owned by the live pass handler that is
 		// initialized once the SYCL CGF is entered. We then abuse the copy constructor that is called implicitly when the lambda is copied for the SYCL
 		// kernel submission to call require().
 #if !defined(__SYCL_DEVICE_ONLY__) && !defined(SYCL_DEVICE_ONLY)
-		if(eventual_sycl_cgh != nullptr && *eventual_sycl_cgh != nullptr) {
-			(*eventual_sycl_cgh)->require(sycl_accessor);
-			eventual_sycl_cgh = nullptr; // only `require` once
+		if(m_eventual_sycl_cgh != nullptr && *m_eventual_sycl_cgh != nullptr) {
+			(*m_eventual_sycl_cgh)->require(m_sycl_accessor);
+			m_eventual_sycl_cgh = nullptr; // only `require` once
 		}
 #endif
 	}
@@ -421,10 +421,10 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 				auto access_info = detail::runtime::get_instance().get_buffer_manager().get_host_buffer<DataT, Dims>(
 				    detail::get_buffer_id(buff), Mode, detail::range_cast<3>(sr.range), detail::id_cast<3>(sr.offset));
 
-				mapped_subrange = sr;
-				optional_buffer = &access_info.buffer;
-				index_offset = access_info.offset;
-				virtual_buffer_range = buff.get_range();
+				m_mapped_subrange = sr;
+				m_optional_buffer = &access_info.buffer;
+				m_index_offset = access_info.offset;
+				m_virtual_buffer_range = buff.get_range();
 			}
 		}
 	}
@@ -475,17 +475,18 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 	 */
 	DataT* get_pointer() const {
 		bool illegal_access = false;
-		if(index_offset != detail::id_cast<Dims>(id<3>{0, 0, 0})) { illegal_access = true; }
+		if(m_index_offset != detail::id_cast<Dims>(id<3>{0, 0, 0})) { illegal_access = true; }
 		// We can be a bit more lenient for 1D buffers, in that the backing buffer doesn't have to have the full size.
 		// (Dereferencing the pointer outside of the requested range is UB anyways).
-		if(Dims > 1 && get_buffer().get_range() != virtual_buffer_range) { illegal_access = true; }
+		if(Dims > 1 && get_buffer().get_range() != m_virtual_buffer_range) { illegal_access = true; }
 		if(illegal_access) { throw std::logic_error("Buffer cannot be accessed with expected stride"); }
 		return get_buffer().get_pointer();
 	}
 
 	friend bool operator==(const accessor& lhs, const accessor& rhs) {
-		return (lhs.optional_buffer == rhs.optional_buffer || (lhs.optional_buffer && rhs.optional_buffer && *lhs.optional_buffer == *rhs.optional_buffer))
-		       && lhs.index_offset == rhs.index_offset;
+		return (lhs.m_optional_buffer == rhs.m_optional_buffer
+		           || (lhs.m_optional_buffer && rhs.m_optional_buffer && *lhs.m_optional_buffer == *rhs.m_optional_buffer))
+		       && lhs.m_index_offset == rhs.m_index_offset;
 	}
 
 	friend bool operator!=(const accessor& lhs, const accessor& rhs) { return !(lhs == rhs); }
@@ -504,11 +505,11 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 
 		return {
 		    get_buffer().get_pointer(),
-		    virtual_buffer_range,
+		    m_virtual_buffer_range,
 		    get_buffer().get_range(),
-		    mapped_subrange.range,
-		    index_offset,
-		    mapped_subrange.offset,
+		    m_mapped_subrange.range,
+		    m_index_offset,
+		    m_mapped_subrange.offset,
 		};
 	}
 
@@ -530,11 +531,11 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 
 		host_memory_layout::dimension_vector dimensions(Dims);
 		for(int d = 0; d < Dims; ++d) {
-			dimensions[d] = {/* global_size */ virtual_buffer_range[d],
-			    /* global_offset */ mapped_subrange.offset[d],
+			dimensions[d] = {/* global_size */ m_virtual_buffer_range[d],
+			    /* global_offset */ m_mapped_subrange.offset[d],
 			    /* local_size */ get_buffer().get_range()[d],
-			    /* local_offset */ mapped_subrange.offset[d] - index_offset[d],
-			    /* extent */ mapped_subrange.range[d]};
+			    /* local_offset */ m_mapped_subrange.offset[d] - m_index_offset[d],
+			    /* extent */ m_mapped_subrange.range[d]};
 		}
 
 		return {get_buffer().get_pointer(), host_memory_layout{dimensions}};
@@ -547,16 +548,16 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 
 	// Subange of the accessor, as set by the range mapper or requested by the user (master node host tasks only).
 	// This does not necessarily correspond to the backing buffer's range.
-	subrange<Dims> mapped_subrange;
+	subrange<Dims> m_mapped_subrange;
 
-	mutable detail::host_buffer<DataT, Dims>* optional_buffer = nullptr;
+	mutable detail::host_buffer<DataT, Dims>* m_optional_buffer = nullptr;
 
 	// Offset of the backing buffer relative to the virtual buffer.
-	id<Dims> index_offset;
+	id<Dims> m_index_offset;
 
 	// The range of the Celerity buffer as created by the user.
 	// We only need this to check whether it is safe to call get_pointer() or not.
-	range<Dims> virtual_buffer_range = detail::range_cast<Dims>(range<3>(0, 0, 0));
+	range<Dims> m_virtual_buffer_range = detail::range_cast<Dims>(range<3>(0, 0, 0));
 
 	/**
 	 * Constructor for pre-pass.
@@ -567,14 +568,14 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 	 * Constructor for live-pass.
 	 */
 	accessor(subrange<Dims> mapped_subrange, detail::host_buffer<DataT, Dims>& buffer, id<Dims> backing_buffer_offset, range<Dims> virtual_buffer_range)
-	    : mapped_subrange(mapped_subrange), optional_buffer(&buffer), index_offset(backing_buffer_offset), virtual_buffer_range(virtual_buffer_range) {}
+	    : m_mapped_subrange(mapped_subrange), m_optional_buffer(&buffer), m_index_offset(backing_buffer_offset), m_virtual_buffer_range(virtual_buffer_range) {}
 
 	detail::host_buffer<DataT, Dims>& get_buffer() const {
-		assert(optional_buffer != nullptr);
-		return *optional_buffer;
+		assert(m_optional_buffer != nullptr);
+		return *m_optional_buffer;
 	}
 
-	size_t get_linear_offset(id<Dims> index) const { return detail::get_linear_index(get_buffer().get_range(), index - index_offset); }
+	size_t get_linear_offset(id<Dims> index) const { return detail::get_linear_index(get_buffer().get_range(), index - m_index_offset); }
 };
 
 
@@ -593,19 +594,19 @@ class local_accessor {
 	using const_reference = const DataT&;
 	using size_type = size_t;
 
-	local_accessor() : sycl_acc{make_placeholder_sycl_accessor()}, allocation_size(detail::zero_range) {}
+	local_accessor() : m_sycl_acc{make_placeholder_sycl_accessor()}, m_allocation_size(detail::zero_range) {}
 
 #if !defined(__SYCL_DEVICE_ONLY__) && !defined(SYCL_DEVICE_ONLY)
-	local_accessor(const range<Dims>& allocation_size, handler& cgh) : sycl_acc{make_placeholder_sycl_accessor()}, allocation_size(allocation_size) {
+	local_accessor(const range<Dims>& allocation_size, handler& cgh) : m_sycl_acc{make_placeholder_sycl_accessor()}, m_allocation_size(allocation_size) {
 		if(!detail::is_prepass_handler(cgh)) {
 			auto& device_handler = dynamic_cast<detail::live_pass_device_handler&>(cgh);
-			eventual_sycl_cgh = device_handler.get_eventual_sycl_cgh();
+			m_eventual_sycl_cgh = device_handler.get_eventual_sycl_cgh();
 		}
 	}
 
 	local_accessor(const local_accessor& other)
-	    : sycl_acc(other.sycl_cgh() ? sycl_accessor{other.allocation_size, *other.sycl_cgh()} : other.sycl_acc), allocation_size(other.allocation_size),
-	      eventual_sycl_cgh(other.sycl_cgh() ? nullptr : other.eventual_sycl_cgh) {}
+	    : m_sycl_acc(other.sycl_cgh() ? sycl_accessor{other.m_allocation_size, *other.sycl_cgh()} : other.m_sycl_acc),
+	      m_allocation_size(other.m_allocation_size), m_eventual_sycl_cgh(other.sycl_cgh() ? nullptr : other.m_eventual_sycl_cgh) {}
 #else
 	local_accessor(const range<Dims>& allocation_size, handler& cgh);
 	local_accessor(const local_accessor&) = default;
@@ -613,29 +614,29 @@ class local_accessor {
 
 	local_accessor& operator=(const local_accessor&) = default;
 
-	size_type byte_size() const noexcept { return allocation_size.size() * sizeof(value_type); }
+	size_type byte_size() const noexcept { return m_allocation_size.size() * sizeof(value_type); }
 
-	size_type size() const noexcept { return allocation_size.size(); }
+	size_type size() const noexcept { return m_allocation_size.size(); }
 
-	size_type max_size() const noexcept { return sycl_acc.max_size(); }
+	size_type max_size() const noexcept { return m_sycl_acc.max_size(); }
 
-	bool empty() const noexcept { return sycl_acc.empty(); }
+	bool empty() const noexcept { return m_sycl_acc.empty(); }
 
-	range<Dims> get_range() const { return allocation_size; }
+	range<Dims> get_range() const { return m_allocation_size; }
 
-	std::add_pointer_t<value_type> get_pointer() const noexcept { return sycl_acc.get_pointer(); }
+	std::add_pointer_t<value_type> get_pointer() const noexcept { return m_sycl_acc.get_pointer(); }
 
 	// Workaround: ComputeCpp's legacy clang-8 has trouble deducing the return type of operator[] with decltype(auto), so we derive it manually.
 	// TODO replace trailing return type with decltype(auto) once we require the new ComputeCpp (experimental) compiler.
 	template <typename Index>
 	inline auto operator[](const Index& index) const -> decltype(std::declval<const sycl_accessor&>()[index]) {
-		return sycl_acc[index];
+		return m_sycl_acc[index];
 	}
 
   private:
-	sycl_accessor sycl_acc;
-	range<Dims> allocation_size;
-	cl::sycl::handler* const* eventual_sycl_cgh = nullptr;
+	sycl_accessor m_sycl_acc;
+	range<Dims> m_allocation_size;
+	cl::sycl::handler* const* m_eventual_sycl_cgh = nullptr;
 
 	static sycl_accessor make_placeholder_sycl_accessor() {
 #if CELERITY_WORKAROUND(DPCPP) || CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 9)
@@ -646,7 +647,7 @@ class local_accessor {
 #endif
 	}
 
-	cl::sycl::handler* sycl_cgh() const { return eventual_sycl_cgh != nullptr ? *eventual_sycl_cgh : nullptr; }
+	cl::sycl::handler* sycl_cgh() const { return m_eventual_sycl_cgh != nullptr ? *m_eventual_sycl_cgh : nullptr; }
 };
 
 
@@ -714,14 +715,14 @@ namespace detail {
 		using AccessorT = celerity::accessor<DataT, 3, Mode, Target>;
 
 	  public:
-		accessor_subscript_proxy(const AccessorT& acc, const size_t d0, const size_t d1) : acc(acc), d0(d0), d1(d1) {}
+		accessor_subscript_proxy(const AccessorT& acc, const size_t d0, const size_t d1) : m_acc(acc), m_d0(d0), m_d1(d1) {}
 
-		decltype(std::declval<AccessorT>()[{0, 0, 0}]) operator[](const size_t d2) const { return acc[{d0, d1, d2}]; }
+		decltype(std::declval<AccessorT>()[{0, 0, 0}]) operator[](const size_t d2) const { return m_acc[{m_d0, m_d1, d2}]; }
 
 	  private:
-		const AccessorT& acc;
-		size_t d0;
-		size_t d1;
+		const AccessorT& m_acc;
+		size_t m_d0;
+		size_t m_d1;
 	};
 
 	template <typename DataT, int Dims, cl::sycl::access::mode Mode, target Target>
@@ -730,23 +731,23 @@ namespace detail {
 		using AccessorT = celerity::accessor<DataT, D, Mode, Target>;
 
 	  public:
-		accessor_subscript_proxy(const AccessorT<Dims>& acc, const size_t d0) : acc(acc), d0(d0) {}
+		accessor_subscript_proxy(const AccessorT<Dims>& acc, const size_t d0) : m_acc(acc), m_d0(d0) {}
 
 		// Note that we currently have to use SFINAE over constexpr-if + decltype(auto), as ComputeCpp 2.6.0 has
 		// problems inferring the correct type in some cases (e.g. when DataT == sycl::id<>).
 		template <int D = Dims>
 		std::enable_if_t<D == 2, decltype(std::declval<AccessorT<2>>()[{0, 0}])> operator[](const size_t d1) const {
-			return acc[{d0, d1}];
+			return m_acc[{m_d0, d1}];
 		}
 
 		template <int D = Dims>
 		std::enable_if_t<D == 3, accessor_subscript_proxy<DataT, 3, Mode, Target, 2>> operator[](const size_t d1) const {
-			return {acc, d0, d1};
+			return {m_acc, m_d0, d1};
 		}
 
 	  private:
-		const AccessorT<Dims>& acc;
-		size_t d0;
+		const AccessorT<Dims>& m_acc;
+		size_t m_d0;
 	};
 
 } // namespace detail

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -44,11 +44,11 @@ class buffer {
   public:
 	static_assert(Dims > 0, "0-dimensional buffers NYI");
 
-	buffer(const DataT* host_ptr, celerity::range<Dims> range) : range(range) {
+	buffer(const DataT* host_ptr, celerity::range<Dims> range) : m_range(range) {
 		if(!detail::runtime::is_initialized()) { detail::runtime::init(nullptr, nullptr); }
 
-		lifetime_tracker = std::make_shared<detail::buffer_lifetime_tracker>();
-		id = lifetime_tracker->initialize<DataT, Dims>(detail::range_cast<3>(range), host_ptr);
+		m_lifetime_tracker = std::make_shared<detail::buffer_lifetime_tracker>();
+		m_id = m_lifetime_tracker->initialize<DataT, Dims>(detail::range_cast<3>(range), host_ptr);
 	}
 
 	buffer(celerity::range<Dims> range) : buffer(nullptr, range) {}
@@ -72,12 +72,12 @@ class buffer {
 		return accessor<DataT, Dims, Mode, Target>(*this, cgh, rmfn);
 	}
 
-	celerity::range<Dims> get_range() const { return range; }
+	celerity::range<Dims> get_range() const { return m_range; }
 
   private:
-	std::shared_ptr<detail::buffer_lifetime_tracker> lifetime_tracker = nullptr;
-	celerity::range<Dims> range;
-	detail::buffer_id id;
+	std::shared_ptr<detail::buffer_lifetime_tracker> m_lifetime_tracker = nullptr;
+	celerity::range<Dims> m_range;
+	detail::buffer_id m_id;
 
 	template <typename T, int D>
 	friend detail::buffer_id detail::get_buffer_id(const buffer<T, D>& buff);
@@ -87,7 +87,7 @@ namespace detail {
 
 	template <typename T, int D>
 	buffer_id get_buffer_id(const buffer<T, D>& buff) {
-		return buff.id;
+		return buff.m_id;
 	}
 
 } // namespace detail

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -85,7 +85,7 @@ namespace detail {
 		friend struct buffer_manager_testspy;
 
 	  public:
-		enum class buffer_lifecycle_event { REGISTERED, UNREGISTERED };
+		enum class buffer_lifecycle_event { registered, unregistered };
 
 		using buffer_lifecycle_callback = std::function<void(buffer_lifecycle_event, buffer_id)>;
 
@@ -125,7 +125,7 @@ namespace detail {
 				std::unique_lock lock(mutex);
 				bid = buffer_count++;
 				buffer_infos[bid] = buffer_info{range, sizeof(DataT), is_host_initialized};
-				newest_data_location.emplace(bid, region_map<data_location>(range, data_location::NOWHERE));
+				newest_data_location.emplace(bid, region_map<data_location>(range, data_location::nowhere));
 
 #if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 				buffer_types.emplace(bid, new buffer_type_guard<DataT, Dims>());
@@ -136,7 +136,7 @@ namespace detail {
 				auto info = get_host_buffer<DataT, Dims>(bid, cl::sycl::access::mode::discard_write, range, cl::sycl::id<3>(0, 0, 0));
 				std::memcpy(info.buffer.get_pointer(), host_init_ptr, range.size() * sizeof(DataT));
 			}
-			lifecycle_cb(buffer_lifecycle_event::REGISTERED, bid);
+			lifecycle_cb(buffer_lifecycle_event::registered, bid);
 			return bid;
 		}
 
@@ -344,7 +344,7 @@ namespace detail {
 			cl::sycl::range<3> new_range = {1, 1, 1};
 		};
 
-		enum class data_location { NOWHERE, HOST, DEVICE, HOST_AND_DEVICE };
+		enum class data_location { nowhere, host, device, host_and_device };
 
 #if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 		struct buffer_type_guard_base {

--- a/include/buffer_transfer_manager.h
+++ b/include/buffer_transfer_manager.h
@@ -67,13 +67,13 @@ namespace detail {
 			unique_frame_ptr<data_frame> frame;
 		};
 
-		std::list<std::unique_ptr<transfer_in>> incoming_transfers;
-		std::list<std::unique_ptr<transfer_out>> outgoing_transfers;
+		std::list<std::unique_ptr<transfer_in>> m_incoming_transfers;
+		std::list<std::unique_ptr<transfer_out>> m_outgoing_transfers;
 
 		// Here we store two types of handles:
 		//  - Incoming pushes that have not yet been requested through ::await_push
 		//  - Still outstanding pushes that have been requested through ::await_push
-		std::unordered_map<command_id, std::shared_ptr<incoming_transfer_handle>> push_blackboard;
+		std::unordered_map<command_id, std::shared_ptr<incoming_transfer_handle>> m_push_blackboard;
 
 		void poll_incoming_transfers();
 		void update_incoming_transfers();

--- a/include/command.h
+++ b/include/command.h
@@ -30,20 +30,20 @@ namespace detail {
 		friend class command_graph;
 
 	  protected:
-		abstract_command(command_id cid, node_id nid) : cid(cid), nid(nid) {}
+		abstract_command(command_id cid, node_id nid) : m_cid(cid), m_nid(nid) {}
 
 	  public:
 		virtual ~abstract_command() = 0;
 
-		command_id get_cid() const { return cid; }
+		command_id get_cid() const { return m_cid; }
 
-		node_id get_nid() const { return nid; }
+		node_id get_nid() const { return m_nid; }
 
 		void mark_as_flushed() {
-			assert(!flushed);
-			flushed = true;
+			assert(!m_flushed);
+			m_flushed = true;
 		}
-		bool is_flushed() const { return flushed; }
+		bool is_flushed() const { return m_flushed; }
 
 		// TODO: Consider only having this in debug builds
 		std::string debug_label;
@@ -54,72 +54,72 @@ namespace detail {
 		using parent_type::add_dependency;
 		using parent_type::remove_dependency;
 
-		command_id cid;
-		node_id nid;
-		bool flushed = false;
+		command_id m_cid;
+		node_id m_nid;
+		bool m_flushed = false;
 	};
 	inline abstract_command::~abstract_command() {}
 
 	class push_command final : public abstract_command {
 		friend class command_graph;
 		push_command(command_id cid, node_id nid, buffer_id bid, reduction_id rid, node_id target, subrange<3> push_range)
-		    : abstract_command(cid, nid), bid(bid), rid(rid), target(target), push_range(push_range) {}
+		    : abstract_command(cid, nid), m_bid(bid), m_rid(rid), m_target(target), m_push_range(push_range) {}
 
 	  public:
-		buffer_id get_bid() const { return bid; }
-		reduction_id get_rid() const { return rid; }
-		node_id get_target() const { return target; }
-		const subrange<3>& get_range() const { return push_range; }
+		buffer_id get_bid() const { return m_bid; }
+		reduction_id get_rid() const { return m_rid; }
+		node_id get_target() const { return m_target; }
+		const subrange<3>& get_range() const { return m_push_range; }
 
 	  private:
-		buffer_id bid;
-		reduction_id rid;
-		node_id target;
-		subrange<3> push_range;
+		buffer_id m_bid;
+		reduction_id m_rid;
+		node_id m_target;
+		subrange<3> m_push_range;
 	};
 
 	class await_push_command final : public abstract_command {
 		friend class command_graph;
-		await_push_command(command_id cid, node_id nid, push_command* source) : abstract_command(cid, nid), source(source) {}
+		await_push_command(command_id cid, node_id nid, push_command* source) : abstract_command(cid, nid), m_source(source) {}
 
 	  public:
-		push_command* get_source() const { return source; }
+		push_command* get_source() const { return m_source; }
 
 	  private:
-		push_command* source;
+		push_command* m_source;
 	};
 
 	class reduction_command final : public abstract_command {
 		friend class command_graph;
-		reduction_command(command_id cid, node_id nid, reduction_id rid) : abstract_command(cid, nid), rid(rid) {}
+		reduction_command(command_id cid, node_id nid, reduction_id rid) : abstract_command(cid, nid), m_rid(rid) {}
 
 	  public:
-		reduction_id get_rid() const { return rid; }
+		reduction_id get_rid() const { return m_rid; }
 
 	  private:
-		reduction_id rid;
+		reduction_id m_rid;
 	};
 
 	class task_command : public abstract_command {
 	  protected:
-		task_command(command_id cid, node_id nid, task_id tid) : abstract_command(cid, nid), tid(tid) {}
+		task_command(command_id cid, node_id nid, task_id tid) : abstract_command(cid, nid), m_tid(tid) {}
 
 	  public:
-		task_id get_tid() const { return tid; }
+		task_id get_tid() const { return m_tid; }
 
 	  private:
-		task_id tid;
+		task_id m_tid;
 	};
 
 	class epoch_command final : public task_command {
 		friend class command_graph;
-		epoch_command(const command_id& cid, const node_id& nid, const task_id& tid, epoch_action action) : task_command(cid, nid, tid), action(action) {}
+		epoch_command(const command_id& cid, const node_id& nid, const task_id& tid, epoch_action action) : task_command(cid, nid, tid), m_action(action) {}
 
 	  public:
-		epoch_action get_epoch_action() const { return action; }
+		epoch_action get_epoch_action() const { return m_action; }
 
 	  private:
-		epoch_action action;
+		epoch_action m_action;
 	};
 
 	class horizon_command final : public task_command {
@@ -132,18 +132,18 @@ namespace detail {
 
 	  protected:
 		execution_command(command_id cid, node_id nid, task_id tid, subrange<3> execution_range)
-		    : task_command(cid, nid, tid), execution_range(execution_range) {}
+		    : task_command(cid, nid, tid), m_execution_range(execution_range) {}
 
 	  public:
-		const subrange<3>& get_execution_range() const { return execution_range; }
+		const subrange<3>& get_execution_range() const { return m_execution_range; }
 
-		void set_is_reduction_initializer(bool is_initializer) { initialize_reductions = is_initializer; }
+		void set_is_reduction_initializer(bool is_initializer) { m_initialize_reductions = is_initializer; }
 
-		bool is_reduction_initializer() const { return initialize_reductions; }
+		bool is_reduction_initializer() const { return m_initialize_reductions; }
 
 	  private:
-		subrange<3> execution_range;
-		bool initialize_reductions = false;
+		subrange<3> m_execution_range;
+		bool m_initialize_reductions = false;
 	};
 
 	// ----------------------------------------------------------------------------------------------------------------

--- a/include/command.h
+++ b/include/command.h
@@ -13,7 +13,7 @@
 namespace celerity {
 namespace detail {
 
-	enum class command_type { EPOCH, HORIZON, EXECUTION, PUSH, AWAIT_PUSH, REDUCTION };
+	enum class command_type { epoch, horizon, execution, push, await_push, reduction };
 
 	// ----------------------------------------------------------------------------------------------------------------
 	// ------------------------------------------------ COMMAND GRAPH -------------------------------------------------
@@ -211,12 +211,12 @@ namespace detail {
 				    assert(!"calling get_command_type() on an empty command_pkg");
 				    std::terminate();
 			    },
-			    [](const horizon_data&) { return command_type::HORIZON; },
-			    [](const epoch_data&) { return command_type::EPOCH; },
-			    [](const execution_data&) { return command_type::EXECUTION; },
-			    [](const push_data&) { return command_type::PUSH; },
-			    [](const await_push_data&) { return command_type::AWAIT_PUSH; },
-			    [](const reduction_data&) { return command_type::REDUCTION; }
+			    [](const horizon_data&) { return command_type::horizon; },
+			    [](const epoch_data&) { return command_type::epoch; },
+			    [](const execution_data&) { return command_type::execution; },
+			    [](const push_data&) { return command_type::push; },
+			    [](const await_push_data&) { return command_type::await_push; },
+			    [](const reduction_data&) { return command_type::reduction; }
 			);
 			// clang-format on
 		}

--- a/include/config.h
+++ b/include/config.h
@@ -26,9 +26,9 @@ namespace detail {
 		 */
 		config(int* argc, char** argv[]);
 
-		log_level get_log_level() const { return log_lvl; }
+		log_level get_log_level() const { return m_log_lvl; }
 
-		const host_config& get_host_config() const { return host_cfg; }
+		const host_config& get_host_config() const { return m_host_cfg; }
 
 		/**
 		 * Returns the platform and device id as set by the CELERITY_DEVICES environment variable.
@@ -38,17 +38,17 @@ namespace detail {
 		 *
 		 * TODO: Should we support multiple platforms on the same host as well?
 		 */
-		const std::optional<device_config>& get_device_config() const { return device_cfg; };
-		std::optional<bool> get_enable_device_profiling() const { return enable_device_profiling; };
+		const std::optional<device_config>& get_device_config() const { return m_device_cfg; };
+		std::optional<bool> get_enable_device_profiling() const { return m_enable_device_profiling; };
 
-		size_t get_graph_print_max_verts() const { return graph_print_max_verts; };
+		size_t get_graph_print_max_verts() const { return m_graph_print_max_verts; };
 
 	  private:
-		log_level log_lvl;
-		host_config host_cfg;
-		std::optional<device_config> device_cfg;
-		std::optional<bool> enable_device_profiling;
-		size_t graph_print_max_verts = 200;
+		log_level m_log_lvl;
+		host_config m_host_cfg;
+		std::optional<device_config> m_device_cfg;
+		std::optional<bool> m_enable_device_profiling;
+		size_t m_graph_print_max_verts = 200;
 	};
 
 } // namespace detail

--- a/include/device_queue.h
+++ b/include/device_queue.h
@@ -55,12 +55,12 @@ namespace detail {
 		 */
 		template <typename Fn>
 		cl::sycl::event submit(Fn&& fn) {
-			auto evt = sycl_queue->submit([fn = std::forward<Fn>(fn)](cl::sycl::handler& sycl_handler) { fn(sycl_handler); });
+			auto evt = m_sycl_queue->submit([fn = std::forward<Fn>(fn)](cl::sycl::handler& sycl_handler) { fn(sycl_handler); });
 #if CELERITY_WORKAROUND(HIPSYCL)
 			// hipSYCL does not guarantee that command groups are actually scheduled until an explicit await operation, which we cannot insert without
 			// blocking the executor loop (see https://github.com/illuhad/hipSYCL/issues/599). Instead, we explicitly flush the queue to be able to continue
 			// using our polling-based approach.
-			hipsycl_flush_dag(*sycl_queue);
+			hipsycl_flush_dag(*m_sycl_queue);
 #endif
 			return evt;
 		}
@@ -68,21 +68,21 @@ namespace detail {
 		/**
 		 * @brief Waits until all currently submitted operations have completed.
 		 */
-		void wait() { sycl_queue->wait_and_throw(); }
+		void wait() { m_sycl_queue->wait_and_throw(); }
 
 		/**
 		 * @brief Returns whether device profiling is enabled.
 		 */
-		bool is_profiling_enabled() const { return device_profiling_enabled; }
+		bool is_profiling_enabled() const { return m_device_profiling_enabled; }
 
 		cl::sycl::queue& get_sycl_queue() const {
-			assert(sycl_queue != nullptr);
-			return *sycl_queue;
+			assert(m_sycl_queue != nullptr);
+			return *m_sycl_queue;
 		}
 
 	  private:
-		std::unique_ptr<cl::sycl::queue> sycl_queue;
-		bool device_profiling_enabled = false;
+		std::unique_ptr<cl::sycl::queue> m_sycl_queue;
+		bool m_device_profiling_enabled = false;
 
 		void handle_async_exceptions(cl::sycl::exception_list el) const;
 	};

--- a/include/distr_queue.h
+++ b/include/distr_queue.h
@@ -85,7 +85,7 @@ class distr_queue {
 	void slow_full_sync() { detail::runtime::get_instance().sync(); } // NOLINT(readability-convert-member-functions-to-static)
 
   private:
-	std::shared_ptr<detail::distr_queue_tracker> tracker;
+	std::shared_ptr<detail::distr_queue_tracker> m_tracker;
 
 	void init(detail::device_or_selector device_or_selector) {
 		if(!detail::runtime::is_initialized()) { detail::runtime::init(nullptr, nullptr, device_or_selector); }
@@ -94,7 +94,7 @@ class distr_queue {
 		} catch(detail::runtime_already_started_error&) {
 			throw std::runtime_error("Only one celerity::distr_queue can be created per process (but it can be copied!)");
 		}
-		tracker = std::make_shared<detail::distr_queue_tracker>();
+		m_tracker = std::make_shared<detail::distr_queue_tracker>();
 	}
 };
 

--- a/include/frame.h
+++ b/include/frame.h
@@ -44,22 +44,22 @@ class unique_frame_ptr : private std::unique_ptr<Frame, unique_frame_delete<Fram
 
 	unique_frame_ptr(from_payload_count_tag, size_t payload_count) : unique_frame_ptr(from_size_bytes, sizeof(Frame) + sizeof(payload_type) * payload_count) {}
 
-	unique_frame_ptr(from_size_bytes_tag, size_t size_bytes) : impl(make_frame(size_bytes)), size_bytes(size_bytes) {}
+	unique_frame_ptr(from_size_bytes_tag, size_t size_bytes) : impl(make_frame(size_bytes)), m_size_bytes(size_bytes) {}
 
-	unique_frame_ptr(unique_frame_ptr&& other) noexcept : impl(static_cast<impl&&>(other)), size_bytes(other.size_bytes) { other.size_bytes = 0; }
+	unique_frame_ptr(unique_frame_ptr&& other) noexcept : impl(static_cast<impl&&>(other)), m_size_bytes(other.m_size_bytes) { other.m_size_bytes = 0; }
 
 	unique_frame_ptr& operator=(unique_frame_ptr&& other) noexcept {
 		if(this == &other) return *this;                        // gracefully handle self-assignment
 		static_cast<impl&>(*this) = static_cast<impl&&>(other); // delegate to base class unique_ptr<Frame>::operator=() to delete previously held frame
-		size_bytes = other.size_bytes;
-		other.size_bytes = 0;
+		m_size_bytes = other.m_size_bytes;
+		other.m_size_bytes = 0;
 		return *this;
 	}
 
 	Frame* get_pointer() { return impl::get(); }
 	const Frame* get_pointer() const { return impl::get(); }
-	size_t get_size_bytes() const { return size_bytes; }
-	size_t get_payload_count() const { return (size_bytes - sizeof(Frame)) / sizeof(payload_type); }
+	size_t get_size_bytes() const { return m_size_bytes; }
+	size_t get_payload_count() const { return (m_size_bytes - sizeof(Frame)) / sizeof(payload_type); }
 
 	using impl::operator bool;
 	using impl::operator*;
@@ -73,7 +73,7 @@ class unique_frame_ptr : private std::unique_ptr<Frame, unique_frame_delete<Fram
 	}
 
   private:
-	size_t size_bytes = 0;
+	size_t m_size_bytes = 0;
 
 	static Frame* make_frame(const size_t size_bytes) {
 		assert(size_bytes >= sizeof(Frame));

--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -91,15 +91,15 @@ namespace detail {
 		void build_task(const task& tsk, const std::vector<graph_transformer*>& transformers);
 
 	  private:
-		reduction_manager& reduction_mngr;
-		const size_t num_nodes;
-		command_graph& cdag;
+		reduction_manager& m_reduction_mngr;
+		const size_t m_num_nodes;
+		command_graph& m_cdag;
 
 		// After completing an epoch, we need to wait until it is flushed before pruning predecessors from the CDAG, otherwise dependencies will not be flushed.
 		// We generate the initial epoch commands manually starting from cid 0, so initializing these to 0 is correct.
-		command_id min_epoch_for_new_commands = 0;
+		command_id m_min_epoch_for_new_commands = 0;
 		// Used to skip the pruning step if no new epoch has been completed.
-		command_id min_epoch_last_pruned_before = 0;
+		command_id m_min_epoch_last_pruned_before = 0;
 
 		// NOTE: We have several data structures that keep track of the "global state" of the distributed program, across all tasks and nodes.
 		// While it might seem that this is problematic when the ordering of tasks can be chosen freely (by the scheduler),
@@ -108,17 +108,17 @@ namespace detail {
 		// This is a data structure which keeps track of where (= on which node) valid regions of a buffer can be found.
 		// A valid region is any region that has not been written to on another node.
 		// This is updated with every task that is processed.
-		buffer_state_map buffer_states;
+		buffer_state_map m_buffer_states;
 
 		// For proper handling of anti-dependencies we also have to store for each command which buffer regions it reads.
 		// We do this because we cannot reconstruct the requirements from a command within the graph alone (e.g. for compute commands).
 		// While we could apply range mappers again etc., that is a bit wasteful. This is basically an optimization.
-		std::unordered_map<command_id, buffer_read_map> command_buffer_reads;
+		std::unordered_map<command_id, buffer_read_map> m_command_buffer_reads;
 
-		std::unordered_map<node_id, per_node_data> node_data;
+		std::unordered_map<node_id, per_node_data> m_node_data;
 
 		// This mutex mainly serves to protect per-buffer data structures, as new buffers might be added at any time.
-		std::mutex buffer_mutex;
+		std::mutex m_buffer_mutex;
 
 		void set_epoch_for_new_commands(per_node_data& node_data, const command_id epoch);
 

--- a/include/graph_serializer.h
+++ b/include/graph_serializer.h
@@ -21,7 +21,7 @@ namespace detail {
 		/*
 		 * @param flush_cb Callback invoked for each command that is being flushed
 		 */
-		graph_serializer(command_graph& cdag, flush_callback flush_cb) : cdag(cdag), flush_cb(flush_cb) {}
+		graph_serializer(command_graph& cdag, flush_callback flush_cb) : m_cdag(cdag), m_flush_cb(flush_cb) {}
 
 		void flush(task_id tid);
 
@@ -33,8 +33,8 @@ namespace detail {
 		void flush(const std::vector<task_command*>& cmds);
 
 	  private:
-		command_graph& cdag;
-		flush_callback flush_cb;
+		command_graph& m_cdag;
+		flush_callback m_flush_cb;
 
 
 		void flush_dependency(abstract_command* dep) const;

--- a/include/intrusive_graph.h
+++ b/include/intrusive_graph.h
@@ -12,8 +12,8 @@ namespace celerity {
 namespace detail {
 
 	enum class dependency_kind {
-		ANTI_DEP = 0, // Data anti-dependency, can be resolved by duplicating buffers
-		TRUE_DEP = 1, // True data flow or temporal dependency
+		anti_dep = 0, // Data anti-dependency, can be resolved by duplicating buffers
+		true_dep = 1, // True data flow or temporal dependency
 	};
 
 	enum class dependency_origin {
@@ -82,7 +82,7 @@ namespace detail {
 
 			if(const auto it = maybe_get_dep(dependencies, dep.node)) {
 				// We assume that for dependency kinds A and B, max(A, B) is strong enough to satisfy both.
-				static_assert(dependency_kind::ANTI_DEP < dependency_kind::TRUE_DEP);
+				static_assert(dependency_kind::anti_dep < dependency_kind::true_dep);
 
 				// Already exists, potentially upgrade to full dependency
 				if((*it)->kind < dep.kind) {

--- a/include/item.h
+++ b/include/item.h
@@ -51,22 +51,22 @@ namespace detail {
 
 	template <int Dims>
 	inline cl::sycl::nd_item<Dims>& get_sycl_item(nd_item<Dims>& nd_item) {
-		return nd_item.sycl_item;
+		return nd_item.m_sycl_item;
 	}
 
 	template <int Dims>
 	inline const cl::sycl::nd_item<Dims>& get_sycl_item(const nd_item<Dims>& nd_item) {
-		return nd_item.sycl_item;
+		return nd_item.m_sycl_item;
 	}
 
 	template <int Dims>
 	inline cl::sycl::nd_item<Dims>& get_sycl_item(group<Dims>& g) {
-		return g.sycl_item;
+		return g.m_sycl_item;
 	}
 
 	template <int Dims>
 	inline const cl::sycl::nd_item<Dims>& get_sycl_item(const group<Dims>& g) {
-		return g.sycl_item;
+		return g.m_sycl_item;
 	}
 
 } // namespace detail
@@ -78,37 +78,37 @@ class item {
 	item() = delete;
 
 	friend bool operator==(const item& lhs, const item& rhs) {
-		return lhs.absolute_global_id == rhs.absolute_global_id && lhs.global_offset == rhs.global_offset && lhs.global_range == rhs.global_range;
+		return lhs.m_absolute_global_id == rhs.m_absolute_global_id && lhs.m_global_offset == rhs.m_global_offset && lhs.m_global_range == rhs.m_global_range;
 	}
 
 	friend bool operator!=(const item& lhs, const item& rhs) { return !(lhs == rhs); }
 
-	id<Dims> get_id() const { return absolute_global_id; }
+	id<Dims> get_id() const { return m_absolute_global_id; }
 
-	size_t get_id(int dimension) const { return absolute_global_id[dimension]; }
+	size_t get_id(int dimension) const { return m_absolute_global_id[dimension]; }
 
-	operator id<Dims>() const { return absolute_global_id; } // NOLINT(google-explicit-constructor)
+	operator id<Dims>() const { return m_absolute_global_id; } // NOLINT(google-explicit-constructor)
 
-	size_t operator[](int dimension) const { return absolute_global_id[dimension]; }
+	size_t operator[](int dimension) const { return m_absolute_global_id[dimension]; }
 
-	range<Dims> get_range() const { return global_range; }
+	range<Dims> get_range() const { return m_global_range; }
 
-	size_t get_range(int dimension) const { return global_range[dimension]; }
+	size_t get_range(int dimension) const { return m_global_range[dimension]; }
 
-	size_t get_linear_id() const { return detail::get_linear_index(global_range, absolute_global_id - global_offset); }
+	size_t get_linear_id() const { return detail::get_linear_index(m_global_range, m_absolute_global_id - m_global_offset); }
 
-	id<Dims> get_offset() const { return global_offset; }
+	id<Dims> get_offset() const { return m_global_offset; }
 
   private:
 	template <int D>
 	friend item<D> celerity::detail::make_item(id<D>, id<D>, range<D>);
 
-	id<Dims> absolute_global_id;
-	id<Dims> global_offset;
-	range<Dims> global_range;
+	id<Dims> m_absolute_global_id;
+	id<Dims> m_global_offset;
+	range<Dims> m_global_range;
 
 	explicit item(id<Dims> absolute_global_id, id<Dims> global_offset, range<Dims> global_range)
-	    : absolute_global_id(absolute_global_id), global_offset(global_offset), global_range(global_range) {}
+	    : m_absolute_global_id(absolute_global_id), m_global_offset(global_offset), m_global_range(global_range) {}
 };
 
 
@@ -121,67 +121,67 @@ class group {
 	static constexpr int dimensions = Dims;
 	static constexpr memory_scope fence_scope = memory_scope_work_group;
 
-	id<Dims> get_group_id() const { return group_id; }
+	id<Dims> get_group_id() const { return m_group_id; }
 
-	size_t get_group_id(int dimension) const { return group_id[dimension]; }
+	size_t get_group_id(int dimension) const { return m_group_id[dimension]; }
 
-	id<Dims> get_local_id() const { return sycl_item.get_local_id(); }
+	id<Dims> get_local_id() const { return m_sycl_item.get_local_id(); }
 
-	size_t get_local_id(int dimension) const { return sycl_item.get_local_id(dimension); }
+	size_t get_local_id(int dimension) const { return m_sycl_item.get_local_id(dimension); }
 
-	range<Dims> get_local_range() const { return sycl_item.get_local_range(); }
+	range<Dims> get_local_range() const { return m_sycl_item.get_local_range(); }
 
-	size_t get_local_range(int dimension) const { return sycl_item.get_local_range(dimension); }
+	size_t get_local_range(int dimension) const { return m_sycl_item.get_local_range(dimension); }
 
-	range<Dims> get_group_range() const { return group_range; }
+	range<Dims> get_group_range() const { return m_group_range; }
 
-	size_t get_group_range(int dimension) const { return group_range[dimension]; }
+	size_t get_group_range(int dimension) const { return m_group_range[dimension]; }
 
-	range<Dims> get_max_local_range() const { return sycl_item.get_max_local_range(); }
+	range<Dims> get_max_local_range() const { return m_sycl_item.get_max_local_range(); }
 
-	size_t operator[](int dimension) const { return group_id[dimension]; }
+	size_t operator[](int dimension) const { return m_group_id[dimension]; }
 
-	size_t get_group_linear_id() const { return detail::get_linear_index(group_range, group_id); }
+	size_t get_group_linear_id() const { return detail::get_linear_index(m_group_range, m_group_id); }
 
-	size_t get_local_linear_id() const { return sycl_item.get_local_linear_id(); }
+	size_t get_local_linear_id() const { return m_sycl_item.get_local_linear_id(); }
 
-	size_t get_group_linear_range() const { return group_range.size(); }
+	size_t get_group_linear_range() const { return m_group_range.size(); }
 
-	size_t get_local_linear_range() const { return sycl_item.get_local_range().size(); }
+	size_t get_local_linear_range() const { return m_sycl_item.get_local_range().size(); }
 
-	bool leader() const { return sycl_item.get_local_id() == id<Dims>{}; }
+	bool leader() const { return m_sycl_item.get_local_id() == id<Dims>{}; }
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_local_ptr<T> dest, decorated_global_ptr<T> src, size_t num_elements) const {
-		return sycl_item.async_work_group_copy(dest, src, num_elements);
+		return m_sycl_item.async_work_group_copy(dest, src, num_elements);
 	}
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_global_ptr<T> dest, decorated_local_ptr<T> src, size_t num_elements) const {
-		return sycl_item.async_work_group_copy(dest, src, num_elements);
+		return m_sycl_item.async_work_group_copy(dest, src, num_elements);
 	}
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_local_ptr<T> dest, decorated_global_ptr<T> src, size_t num_elements, size_t src_stride) const {
-		return sycl_item.async_work_group_copy(dest, src, num_elements, src_stride);
+		return m_sycl_item.async_work_group_copy(dest, src, num_elements, src_stride);
 	}
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_global_ptr<T> dest, decorated_local_ptr<T> src, size_t num_elements, size_t dest_stride) const {
-		return sycl_item.async_work_group_copy(dest, src, num_elements, dest_stride);
+		return m_sycl_item.async_work_group_copy(dest, src, num_elements, dest_stride);
 	}
 
 	template <typename... DeviceEvents>
 	void wait_for(DeviceEvents... events) const {
-		sycl_item.wait_for(events...);
+		m_sycl_item.wait_for(events...);
 	}
 
   private:
 	// We capture SYCL `item` instead of `group` to provide celerity::group_barrier based on SYCL 1.2.1 nd_item.barrier()
 	// TODO consider capturing `group` once ComputeCpp resolves this issue (if that benefits us e.g. wrt. struct size)
-	cl::sycl::nd_item<Dims> sycl_item;
-	id<Dims> group_id;
-	range<Dims> group_range;
+	cl::sycl::nd_item<Dims> m_sycl_item;
+	id<Dims> m_group_id;
+	range<Dims> m_group_range;
 
 	template <int D>
 	friend group<D> celerity::detail::make_group(const cl::sycl::nd_item<D>& sycl_item, const id<D>& group_id, const range<D>& group_range);
@@ -193,7 +193,7 @@ class group {
 	friend const cl::sycl::nd_item<D>& celerity::detail::get_sycl_item(const group<D>&);
 
 	explicit group(const cl::sycl::nd_item<Dims>& sycl_item, const id<Dims>& group_id, const range<Dims>& group_range)
-	    : sycl_item(sycl_item), group_id(group_id), group_range(group_range) {}
+	    : m_sycl_item(sycl_item), m_group_id(group_id), m_group_range(group_range) {}
 };
 
 
@@ -203,76 +203,76 @@ class nd_item {
   public:
 	nd_item() = delete;
 
-	id<Dims> get_global_id() const { return global_id; }
+	id<Dims> get_global_id() const { return m_global_id; }
 
-	size_t get_global_id(int dimension) const { return global_id[dimension]; }
+	size_t get_global_id(int dimension) const { return m_global_id[dimension]; }
 
-	size_t get_global_linear_id() const { return detail::get_linear_index(global_range, global_id); }
+	size_t get_global_linear_id() const { return detail::get_linear_index(m_global_range, m_global_id); }
 
-	id<Dims> get_local_id() const { return sycl_item.get_local_id(); }
+	id<Dims> get_local_id() const { return m_sycl_item.get_local_id(); }
 
-	size_t get_local_id(int dimension) const { return sycl_item.get_local_id(dimension); }
+	size_t get_local_id(int dimension) const { return m_sycl_item.get_local_id(dimension); }
 
-	size_t get_local_linear_id() const { return sycl_item.get_local_linear_id(); }
+	size_t get_local_linear_id() const { return m_sycl_item.get_local_linear_id(); }
 
-	group<Dims> get_group() const { return detail::make_group<Dims>(sycl_item, group_id, group_range); }
+	group<Dims> get_group() const { return detail::make_group<Dims>(m_sycl_item, m_group_id, m_group_range); }
 
-	size_t get_group(int dimension) const { return group_id[dimension]; }
+	size_t get_group(int dimension) const { return m_group_id[dimension]; }
 
-	size_t get_group_linear_id() const { return detail::get_linear_index(group_range, group_id); }
+	size_t get_group_linear_id() const { return detail::get_linear_index(m_group_range, m_group_id); }
 
-	range<Dims> get_group_range() const { return group_range; }
+	range<Dims> get_group_range() const { return m_group_range; }
 
-	size_t get_group_range(int dimension) const { return group_range[dimension]; }
+	size_t get_group_range(int dimension) const { return m_group_range[dimension]; }
 
 #if !CELERITY_WORKAROUND(DPCPP) // no sub_group support
-	cl::sycl::sub_group get_sub_group() const { return sycl_item.get_sub_group(); }
+	cl::sycl::sub_group get_sub_group() const { return m_sycl_item.get_sub_group(); }
 #endif
 
-	range<Dims> get_global_range() const { return global_range; }
+	range<Dims> get_global_range() const { return m_global_range; }
 
-	size_t get_global_range(int dimension) const { return global_range[dimension]; }
+	size_t get_global_range(int dimension) const { return m_global_range[dimension]; }
 
-	range<Dims> get_local_range() const { return sycl_item.get_local_range(); }
+	range<Dims> get_local_range() const { return m_sycl_item.get_local_range(); }
 
-	size_t get_local_range(int dimension) const { return sycl_item.get_local_range(dimension); }
+	size_t get_local_range(int dimension) const { return m_sycl_item.get_local_range(dimension); }
 
-	id<Dims> get_offset() const { return global_offset; }
+	id<Dims> get_offset() const { return m_global_offset; }
 
-	celerity::nd_range<Dims> get_nd_range() const { return celerity::nd_range<Dims>{global_range, sycl_item.get_local_range(), global_offset}; }
+	celerity::nd_range<Dims> get_nd_range() const { return celerity::nd_range<Dims>{m_global_range, m_sycl_item.get_local_range(), m_global_offset}; }
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_local_ptr<T> dest, decorated_global_ptr<T> src, size_t num_elements) const {
-		return sycl_item.async_work_group_copy(dest, src, num_elements);
+		return m_sycl_item.async_work_group_copy(dest, src, num_elements);
 	}
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_global_ptr<T> dest, decorated_local_ptr<T> src, size_t num_elements) const {
-		return sycl_item.async_work_group_copy(dest, src, num_elements);
+		return m_sycl_item.async_work_group_copy(dest, src, num_elements);
 	}
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_local_ptr<T> dest, decorated_global_ptr<T> src, size_t num_elements, size_t src_stride) const {
-		return sycl_item.async_work_group_copy(dest, src, num_elements, src_stride);
+		return m_sycl_item.async_work_group_copy(dest, src, num_elements, src_stride);
 	}
 
 	template <typename T>
 	cl::sycl::device_event async_work_group_copy(decorated_global_ptr<T> dest, decorated_local_ptr<T> src, size_t num_elements, size_t dest_stride) const {
-		return sycl_item.async_work_group_copy(dest, src, num_elements, dest_stride);
+		return m_sycl_item.async_work_group_copy(dest, src, num_elements, dest_stride);
 	}
 
 	template <typename... DeviceEvents>
 	void wait_for(DeviceEvents... events) const {
-		sycl_item.wait_for(events...);
+		m_sycl_item.wait_for(events...);
 	}
 
   private:
-	cl::sycl::nd_item<Dims> sycl_item;
-	id<Dims> global_id;
-	id<Dims> global_offset;
-	range<Dims> global_range;
-	id<Dims> group_id;
-	range<Dims> group_range;
+	cl::sycl::nd_item<Dims> m_sycl_item;
+	id<Dims> m_global_id;
+	id<Dims> m_global_offset;
+	range<Dims> m_global_range;
+	id<Dims> m_group_id;
+	range<Dims> m_group_range;
 
 	template <int D>
 	friend nd_item<D> celerity::detail::make_nd_item(const cl::sycl::nd_item<D>&, const range<D>&, const id<D>&, const id<D>&, const range<D>&, const id<D>&);
@@ -285,8 +285,8 @@ class nd_item {
 
 	explicit nd_item(const cl::sycl::nd_item<Dims>& sycl_item, const range<Dims>& global_range, const id<Dims>& global_offset, const id<Dims>& chunk_offset,
 	    const range<Dims>& group_range, const id<Dims>& group_offset)
-	    : sycl_item(sycl_item), global_id(chunk_offset + sycl_item.get_global_id()), global_offset(global_offset), global_range(global_range),
-	      group_id(group_offset + detail::get_sycl_group_id(sycl_item.get_group())), group_range(group_range) {}
+	    : m_sycl_item(sycl_item), m_global_id(chunk_offset + sycl_item.get_global_id()), m_global_offset(global_offset), m_global_range(global_range),
+	      m_group_id(group_offset + detail::get_sycl_group_id(sycl_item.get_group())), m_group_range(group_range) {}
 };
 
 

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -42,16 +42,16 @@ namespace detail {
 		void schedule();
 
 	  private:
-		graph_generator& ggen;
-		graph_serializer& gsrlzr;
+		graph_generator& m_ggen;
+		graph_serializer& m_gsrlzr;
 
-		std::queue<scheduler_event> available_events;
-		std::queue<scheduler_event> in_flight_events;
+		std::queue<scheduler_event> m_available_events;
+		std::queue<scheduler_event> m_in_flight_events;
 
-		mutable std::mutex events_mutex;
-		std::condition_variable events_cv;
+		mutable std::mutex m_events_mutex;
+		std::condition_variable m_events_cv;
 
-		const size_t num_nodes;
+		const size_t m_num_nodes;
 
 		void notify(scheduler_event_type type, const task* tsk);
 	};
@@ -67,7 +67,7 @@ namespace detail {
 		void shutdown() override;
 
 	  private:
-		std::thread worker_thread;
+		std::thread m_worker_thread;
 	};
 
 } // namespace detail

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -12,7 +12,7 @@ namespace detail {
 	class graph_serializer;
 	class task;
 
-	enum class scheduler_event_type { TASK_AVAILABLE, SHUTDOWN };
+	enum class scheduler_event_type { task_available, shutdown };
 
 	struct scheduler_event {
 		scheduler_event_type type;
@@ -33,7 +33,7 @@ namespace detail {
 		/**
 		 * @brief Notifies the scheduler that a new task has been created and is ready for scheduling.
 		 */
-		void notify_task_created(const task* tsk) { notify(scheduler_event_type::TASK_AVAILABLE, tsk); }
+		void notify_task_created(const task* tsk) { notify(scheduler_event_type::task_available, tsk); }
 
 	  protected:
 		/**

--- a/include/side_effect.h
+++ b/include/side_effect.h
@@ -18,7 +18,7 @@ class side_effect {
 	using object_type = typename host_object<T>::object_type;
 	constexpr static inline side_effect_order order = Order;
 
-	explicit side_effect(const host_object<T>& object, handler& cgh) : object{object} {
+	explicit side_effect(const host_object<T>& object, handler& cgh) : m_object{object} {
 		if(detail::is_prepass_handler(cgh)) {
 			auto& prepass_cgh = static_cast<detail::prepass_handler&>(cgh);
 			prepass_cgh.add_requirement(object.get_id(), order);
@@ -27,16 +27,16 @@ class side_effect {
 
 	template <typename U = T>
 	std::enable_if_t<!std::is_void_v<U>, object_type>& operator*() const {
-		return *object.get_object();
+		return *m_object.get_object();
 	}
 
 	template <typename U = T>
 	std::enable_if_t<!std::is_void_v<U>, object_type>* operator->() const {
-		return object.get_object();
+		return m_object.get_object();
 	}
 
   private:
-	host_object<T> object;
+	host_object<T> m_object;
 };
 
 template <typename T>

--- a/include/sycl_wrappers.h
+++ b/include/sycl_wrappers.h
@@ -82,10 +82,11 @@ class nd_range {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	nd_range(cl::sycl::nd_range<Dims> s_range)
-	    : global_range(s_range.get_global_range()), local_range(s_range.get_local_range()), offset(s_range.get_offset()) {}
+	    : m_global_range(s_range.get_global_range()), m_local_range(s_range.get_local_range()), m_offset(s_range.get_offset()) {}
 #pragma GCC diagnostic pop
 
-	nd_range(range<Dims> global_range, range<Dims> local_range, id<Dims> offset = {}) : global_range(global_range), local_range(local_range), offset(offset) {
+	nd_range(range<Dims> global_range, range<Dims> local_range, id<Dims> offset = {})
+	    : m_global_range(global_range), m_local_range(local_range), m_offset(offset) {
 #ifndef __SYCL_DEVICE_ONLY__
 		for(int d = 0; d < Dims; ++d) {
 			if(local_range[d] == 0 || global_range[d] % local_range[d] != 0) { throw std::invalid_argument("global_range is not divisible by local_range"); }
@@ -93,23 +94,23 @@ class nd_range {
 #endif
 	}
 
-	operator cl::sycl::nd_range<Dims>() const { return cl::sycl::nd_range<Dims>{global_range, local_range, offset}; }
+	operator cl::sycl::nd_range<Dims>() const { return cl::sycl::nd_range<Dims>{m_global_range, m_local_range, m_offset}; }
 
-	range<Dims> get_global_range() const { return global_range; }
-	range<Dims> get_local_range() const { return local_range; }
-	range<Dims> get_group_range() const { return global_range / local_range; }
-	id<Dims> get_offset() const { return offset; }
+	range<Dims> get_global_range() const { return m_global_range; }
+	range<Dims> get_local_range() const { return m_local_range; }
+	range<Dims> get_group_range() const { return m_global_range / m_local_range; }
+	id<Dims> get_offset() const { return m_offset; }
 
 	friend bool operator==(const nd_range& lhs, const nd_range& rhs) {
-		return lhs.global_range == rhs.global_range && lhs.local_range == rhs.local_range && lhs.offset == rhs.offset;
+		return lhs.m_global_range == rhs.m_global_range && lhs.m_local_range == rhs.m_local_range && lhs.m_offset == rhs.m_offset;
 	}
 
 	friend bool operator!=(const nd_range& lhs, const nd_range& rhs) { return !(lhs == rhs); }
 
   private:
-	range<Dims> global_range;
-	range<Dims> local_range;
-	id<Dims> offset;
+	range<Dims> m_global_range;
+	range<Dims> m_local_range;
+	id<Dims> m_offset;
 };
 
 // Non-templated deduction guides allow construction of nd_range from range initializer lists like so: nd_range{{1, 2}, {3, 4}}

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -24,32 +24,32 @@ namespace detail {
 	// This is worth a separate class to encapsulate the synchronization behavior.
 	class epoch_monitor {
 	  public:
-		explicit epoch_monitor(const task_id epoch) : this_epoch(epoch) {}
+		explicit epoch_monitor(const task_id epoch) : m_this_epoch(epoch) {}
 
 		task_id get() const {
-			std::lock_guard lock{mutex};
-			return this_epoch;
+			std::lock_guard lock{m_mutex};
+			return m_this_epoch;
 		}
 
 		task_id await(const task_id min_tid_reached) const {
-			std::unique_lock lock{mutex};
-			epoch_changed.wait(lock, [=] { return this_epoch >= min_tid_reached; });
-			return this_epoch;
+			std::unique_lock lock{m_mutex};
+			m_epoch_changed.wait(lock, [=] { return m_this_epoch >= min_tid_reached; });
+			return m_this_epoch;
 		}
 
 		void set(const task_id epoch) {
 			{
-				std::lock_guard lock{mutex};
-				assert(epoch >= this_epoch);
-				this_epoch = epoch;
+				std::lock_guard lock{m_mutex};
+				assert(epoch >= m_this_epoch);
+				m_this_epoch = epoch;
 			}
-			epoch_changed.notify_all();
+			m_epoch_changed.notify_all();
 		}
 
 	  private:
-		task_id this_epoch;
-		mutable std::mutex mutex;
-		mutable std::condition_variable epoch_changed;
+		task_id m_this_epoch;
+		mutable std::mutex m_mutex;
+		mutable std::condition_variable m_epoch_changed;
 	};
 
 	class task_manager {
@@ -68,22 +68,22 @@ namespace detail {
 			task_id tid;
 			const task* tsk_ptr = nullptr;
 			{
-				std::lock_guard lock(task_mutex);
-				auto reservation = task_buffer.reserve_task_entry(await_free_task_slot_callback());
+				std::lock_guard lock(m_task_mutex);
+				auto reservation = m_task_buffer.reserve_task_entry(await_free_task_slot_callback());
 				tid = reservation.get_tid();
 
-				prepass_handler cgh(tid, std::make_unique<command_group_storage<CGF>>(cgf), num_collective_nodes);
+				prepass_handler cgh(tid, std::make_unique<command_group_storage<CGF>>(cgf), m_num_collective_nodes);
 				cgf(cgh);
 				task& task_ref = register_task_internal(std::move(reservation), std::move(cgh).into_task());
 				tsk_ptr = &task_ref;
 
 				compute_dependencies(task_ref);
-				if(queue) queue->require_collective_group(task_ref.get_collective_group_id());
+				if(m_queue) m_queue->require_collective_group(task_ref.get_collective_group_id());
 
 				// the following deletion is intentionally redundant with the one happening when waiting for free task slots
 				// we want to free tasks earlier than just when running out of slots,
 				// so that we can potentially reclaim additional resources such as buffers earlier
-				task_buffer.delete_up_to(latest_epoch_reached.get());
+				m_task_buffer.delete_up_to(m_latest_epoch_reached.get());
 			}
 			invoke_callbacks(tsk_ptr);
 			if(need_new_horizon()) { generate_horizon_task(); }
@@ -99,7 +99,7 @@ namespace detail {
 		/**
 		 * @brief Registers a new callback that will be called whenever a new task is created.
 		 */
-		void register_task_callback(task_callback cb) { task_callbacks.push_back(std::move(cb)); }
+		void register_task_callback(task_callback cb) { m_task_callbacks.push_back(std::move(cb)); }
 
 		/**
 		 * @brief Adds a new buffer for dependency tracking
@@ -135,11 +135,11 @@ namespace detail {
 		/**
 		 * @brief Shuts down the task_manager, freeing all stored tasks.
 		 */
-		void shutdown() { task_buffer.clear(); }
+		void shutdown() { m_task_buffer.clear(); }
 
 		void set_horizon_step(const int step) {
 			assert(step >= 0);
-			task_horizon_step_size = step;
+			m_task_horizon_step_size = step;
 		}
 
 		/**
@@ -162,60 +162,60 @@ namespace detail {
 		 * Returns the number of tasks created during the lifetime of the task_manager,
 		 * including tasks that have already been deleted.
 		 */
-		size_t get_total_task_count() const { return task_buffer.get_total_task_count(); }
+		size_t get_total_task_count() const { return m_task_buffer.get_total_task_count(); }
 
 		/**
 		 * Returns the number of tasks currently being managed by the task_manager.
 		 */
-		size_t get_current_task_count() const { return task_buffer.get_current_task_count(); }
+		size_t get_current_task_count() const { return m_task_buffer.get_current_task_count(); }
 
 	  private:
-		const size_t num_collective_nodes;
-		host_queue* queue;
+		const size_t m_num_collective_nodes;
+		host_queue* m_queue;
 
-		reduction_manager* reduction_mngr;
+		reduction_manager* m_reduction_mngr;
 
-		task_ring_buffer task_buffer;
+		task_ring_buffer m_task_buffer;
 
 		// The active epoch is used as the last writer for host-initialized buffers.
 		// This is useful so we can correctly generate anti-dependencies onto tasks that read host-initialized buffers.
 		// To ensure correct ordering, all tasks that have no other true-dependencies depend on this task.
-		task_id epoch_for_new_tasks{initial_epoch_task};
+		task_id m_epoch_for_new_tasks{initial_epoch_task};
 
 		// We store a map of which task last wrote to a certain region of a buffer.
 		// NOTE: This represents the state after the latest performed pre-pass.
-		buffer_writers_map buffers_last_writers;
+		buffer_writers_map m_buffers_last_writers;
 
-		std::unordered_map<collective_group_id, task_id> last_collective_tasks;
+		std::unordered_map<collective_group_id, task_id> m_last_collective_tasks;
 
 		// Stores which host object was last affected by which task.
-		std::unordered_map<host_object_id, task_id> host_object_last_effects;
+		std::unordered_map<host_object_id, task_id> m_host_object_last_effects;
 
 		// For simplicity we use a single mutex to control access to all task-related (i.e. the task graph, ...) data structures.
-		mutable std::mutex task_mutex;
+		mutable std::mutex m_task_mutex;
 
-		std::vector<task_callback> task_callbacks;
+		std::vector<task_callback> m_task_callbacks;
 
 		// maximum critical path length in the task graph before inserting a horizon
-		int task_horizon_step_size = 4;
+		int m_task_horizon_step_size = 4;
 
 		// This only (potentially) grows when adding dependencies,
 		// it never shrinks and does not take into account later changes further up in the dependency chain
-		int max_pseudo_critical_path_length = 0;
-		int current_horizon_critical_path_length = 0;
+		int m_max_pseudo_critical_path_length = 0;
+		int m_current_horizon_critical_path_length = 0;
 
 		// The latest horizon task created. Will be applied as the epoch for new tasks once the next horizon is created.
-		std::optional<task_id> current_horizon;
+		std::optional<task_id> m_current_horizon;
 
 		// The last horizon processed by the executor will become the latest_epoch_reached once the next horizon is completed as well.
 		// Only accessed in task_manager::notify_*, which are always called from the executor thread - no locking needed.
-		std::optional<task_id> latest_horizon_reached;
+		std::optional<task_id> m_latest_horizon_reached;
 
 		// The last epoch task that has been processed by the executor. Behind a monitor to allow awaiting this change from the main thread.
-		epoch_monitor latest_epoch_reached{initial_epoch_task};
+		epoch_monitor m_latest_epoch_reached{initial_epoch_task};
 
 		// Set of tasks with no dependents
-		std::unordered_set<task*> execution_front;
+		std::unordered_set<task*> m_execution_front;
 
 		task& register_task_internal(task_ring_buffer::reservation&& reserve, std::unique_ptr<task> task);
 
@@ -223,15 +223,15 @@ namespace detail {
 
 		void add_dependency(task& depender, task& dependee, dependency_kind kind, dependency_origin origin);
 
-		inline bool need_new_horizon() const { return max_pseudo_critical_path_length - current_horizon_critical_path_length >= task_horizon_step_size; }
+		inline bool need_new_horizon() const { return m_max_pseudo_critical_path_length - m_current_horizon_critical_path_length >= m_task_horizon_step_size; }
 
-		int get_max_pseudo_critical_path_length() const { return max_pseudo_critical_path_length; }
+		int get_max_pseudo_critical_path_length() const { return m_max_pseudo_critical_path_length; }
 
 		task& reduce_execution_front(task_ring_buffer::reservation&& reserve, std::unique_ptr<task> new_front);
 
 		void set_epoch_for_new_tasks(task_id epoch);
 
-		const std::unordered_set<task*>& get_execution_front() { return execution_front; }
+		const std::unordered_set<task*>& get_execution_front() { return m_execution_front; }
 
 		task_id generate_horizon_task();
 

--- a/include/task_ring_buffer.h
+++ b/include/task_ring_buffer.h
@@ -22,48 +22,48 @@ class task_ring_buffer {
 		friend class task_ring_buffer;
 
 	  public:
-		reservation(task_id tid, task_ring_buffer& buffer) : tid(tid), buffer(buffer) {}
+		reservation(task_id tid, task_ring_buffer& buffer) : m_tid(tid), m_buffer(buffer) {}
 		~reservation() {
-			if(!consumed) {
-				CELERITY_WARN("Consumed reservation for tid {} in destructor", tid);
-				buffer.revoke_reservation(std::move(*this));
+			if(!m_consumed) {
+				CELERITY_WARN("Consumed reservation for tid {} in destructor", m_tid);
+				m_buffer.revoke_reservation(std::move(*this));
 			}
 		}
 		reservation(const reservation&) = delete;            // non copyable
 		reservation& operator=(const reservation&) = delete; // non assignable
 		reservation(reservation&&) = default;                // movable
 
-		task_id get_tid() const { return tid; }
+		task_id get_tid() const { return m_tid; }
 
 	  private:
 		void consume() {
-			assert(consumed == false);
-			consumed = true;
+			assert(m_consumed == false);
+			m_consumed = true;
 		}
 
-		bool consumed = false;
-		task_id tid;
-		task_ring_buffer& buffer;
+		bool m_consumed = false;
+		task_id m_tid;
+		task_ring_buffer& m_buffer;
 	};
 
 	bool has_task(task_id tid) const {
-		return tid >= number_of_deleted_tasks.load(std::memory_order_relaxed) // best effort, only reliable from application thread
-		       && tid < next_active_tid.load(std::memory_order_acquire);      // synchronizes access to data with put(...)
+		return tid >= m_number_of_deleted_tasks.load(std::memory_order_relaxed) // best effort, only reliable from application thread
+		       && tid < m_next_active_tid.load(std::memory_order_acquire);      // synchronizes access to data with put(...)
 	}
 
-	size_t get_total_task_count() const { return next_active_tid.load(std::memory_order_relaxed); }
+	size_t get_total_task_count() const { return m_next_active_tid.load(std::memory_order_relaxed); }
 
-	task* find_task(task_id tid) const { return has_task(tid) ? data[tid % task_ringbuffer_size].get() : nullptr; }
+	task* find_task(task_id tid) const { return has_task(tid) ? m_data[tid % task_ringbuffer_size].get() : nullptr; }
 
 	task* get_task(task_id tid) const {
 		assert(has_task(tid));
-		return data[tid % task_ringbuffer_size].get();
+		return m_data[tid % task_ringbuffer_size].get();
 	}
 
 	// all member functions beyond this point may *only* be called by the main application thread
 
 	size_t get_current_task_count() const { //
-		return next_active_tid.load(std::memory_order_relaxed) - number_of_deleted_tasks.load(std::memory_order_relaxed);
+		return m_next_active_tid.load(std::memory_order_relaxed) - m_number_of_deleted_tasks.load(std::memory_order_relaxed);
 	}
 
 	// the task id passed to the wait callback identifies the lowest in-use TID that the ring buffer is aware of
@@ -71,68 +71,68 @@ class task_ring_buffer {
 
 	reservation reserve_task_entry(const wait_callback& wc) {
 		wait_for_available_slot(wc);
-		reservation ret(next_task_id, *this);
-		next_task_id++;
+		reservation ret(m_next_task_id, *this);
+		m_next_task_id++;
 		return ret;
 	}
 
 	void revoke_reservation(reservation&& reserve) {
 		reserve.consume();
-		assert(reserve.tid == next_task_id - 1); // this is the only allowed (and extant) pattern
-		next_task_id--;
+		assert(reserve.m_tid == m_next_task_id - 1); // this is the only allowed (and extant) pattern
+		m_next_task_id--;
 	}
 
 	void put(reservation&& reserve, std::unique_ptr<task> task) {
 		reserve.consume();
-		assert(next_active_tid.load(std::memory_order_relaxed) == reserve.tid);
-		data[reserve.tid % task_ringbuffer_size] = std::move(task);
-		next_active_tid.store(reserve.tid + 1, std::memory_order_release);
+		assert(m_next_active_tid.load(std::memory_order_relaxed) == reserve.m_tid);
+		m_data[reserve.m_tid % task_ringbuffer_size] = std::move(task);
+		m_next_active_tid.store(reserve.m_tid + 1, std::memory_order_release);
 	}
 
 	void delete_up_to(task_id target_tid) {
-		assert(target_tid >= number_of_deleted_tasks.load(std::memory_order_relaxed));
-		for(task_id tid = number_of_deleted_tasks.load(std::memory_order_relaxed); tid < target_tid; ++tid) {
-			data[tid % task_ringbuffer_size].reset();
+		assert(target_tid >= m_number_of_deleted_tasks.load(std::memory_order_relaxed));
+		for(task_id tid = m_number_of_deleted_tasks.load(std::memory_order_relaxed); tid < target_tid; ++tid) {
+			m_data[tid % task_ringbuffer_size].reset();
 		}
-		number_of_deleted_tasks.store(target_tid, std::memory_order_relaxed);
+		m_number_of_deleted_tasks.store(target_tid, std::memory_order_relaxed);
 	}
 
 	void clear() {
-		for(auto&& d : data) {
+		for(auto&& d : m_data) {
 			d.reset();
 		}
-		number_of_deleted_tasks.store(next_task_id, std::memory_order_relaxed);
+		m_number_of_deleted_tasks.store(m_next_task_id, std::memory_order_relaxed);
 	}
 
 	class task_buffer_iterator {
-		unsigned long id;
-		const task_ring_buffer& buffer;
+		unsigned long m_id;
+		const task_ring_buffer& m_buffer;
 
 	  public:
-		task_buffer_iterator(unsigned long id, const task_ring_buffer& buffer) : id(id), buffer(buffer) {}
-		task* operator*() { return buffer.get_task(id); }
-		void operator++() { id++; }
-		bool operator<(task_buffer_iterator other) { return id < other.id; }
-		bool operator!=(task_buffer_iterator other) { return &buffer != &other.buffer || id != other.id; }
+		task_buffer_iterator(unsigned long id, const task_ring_buffer& buffer) : m_id(id), m_buffer(buffer) {}
+		task* operator*() { return m_buffer.get_task(m_id); }
+		void operator++() { m_id++; }
+		bool operator<(task_buffer_iterator other) { return m_id < other.m_id; }
+		bool operator!=(task_buffer_iterator other) { return &m_buffer != &other.m_buffer || m_id != other.m_id; }
 	};
 
 	task_buffer_iterator begin() const { //
-		return task_buffer_iterator(number_of_deleted_tasks.load(std::memory_order_relaxed), *this);
+		return task_buffer_iterator(m_number_of_deleted_tasks.load(std::memory_order_relaxed), *this);
 	}
-	task_buffer_iterator end() const { return task_buffer_iterator(next_task_id, *this); }
+	task_buffer_iterator end() const { return task_buffer_iterator(m_next_task_id, *this); }
 
   private:
 	// the id of the next task that will be reserved
-	task_id next_task_id = 0;
+	task_id m_next_task_id = 0;
 	// the next task id that will actually be emplaced
-	std::atomic<task_id> next_active_tid = task_id(0);
+	std::atomic<task_id> m_next_active_tid = task_id(0);
 	// the number of deleted tasks (which is implicitly the start of the active range of the ringbuffer)
-	std::atomic<size_t> number_of_deleted_tasks = 0;
-	std::array<std::unique_ptr<task>, task_ringbuffer_size> data;
+	std::atomic<size_t> m_number_of_deleted_tasks = 0;
+	std::array<std::unique_ptr<task>, task_ringbuffer_size> m_data;
 
 	void wait_for_available_slot(const wait_callback& wc) const {
-		if(next_task_id - number_of_deleted_tasks.load(std::memory_order_relaxed) >= task_ringbuffer_size) {
-			wc(static_cast<task_id>(number_of_deleted_tasks.load(std::memory_order_relaxed)));
+		if(m_next_task_id - m_number_of_deleted_tasks.load(std::memory_order_relaxed) >= task_ringbuffer_size) {
+			wc(static_cast<task_id>(m_number_of_deleted_tasks.load(std::memory_order_relaxed)));
 		}
 	}
 };

--- a/include/transformers/naive_split.h
+++ b/include/transformers/naive_split.h
@@ -8,9 +8,9 @@ namespace detail {
 	class naive_split_transformer : public graph_transformer {
 	  public:
 		/**
-		 * The naive split transformer splits every DEVICE_COMPUTE command within a given task into a certain number of chunks.
+		 * The naive split transformer splits every device_compute command within a given task into a certain number of chunks.
 		 *
-		 * @arg num_chunks The number of chunks each DEVICE_COMPUTE command should be split into.
+		 * @arg num_chunks The number of chunks each device_compute command should be split into.
 		 * @arg num_workers The number of workers that the resulting chunks should be assigned to.
 		 */
 		naive_split_transformer(size_t num_chunks, size_t num_workers);

--- a/include/transformers/naive_split.h
+++ b/include/transformers/naive_split.h
@@ -18,8 +18,8 @@ namespace detail {
 		void transform_task(const task& tsk, command_graph& cdag) override;
 
 	  private:
-		const size_t num_chunks;
-		const size_t num_workers;
+		const size_t m_num_chunks;
+		const size_t m_num_workers;
 	};
 
 } // namespace detail

--- a/include/types.h
+++ b/include/types.h
@@ -18,18 +18,18 @@ namespace detail {
 		using underlying_t = T;
 
 		constexpr PhantomType() = default;
-		constexpr PhantomType(T const& value) : value(value) {}
-		constexpr PhantomType(T&& value) : value(std::move(value)) {}
+		constexpr PhantomType(T const& value) : m_value(value) {}
+		constexpr PhantomType(T&& value) : m_value(std::move(value)) {}
 
 		// Allow implicit conversion to underlying type, otherwise it becomes too annoying to use.
 		// Luckily compilers won't do more than one user-defined conversion, so something like
 		// PhantomType1<T> -> T -> PhantomType2<T>, can't happen. Therefore we still retain
 		// strong typesafety between phantom types with the same underlying type.
-		constexpr operator T&() { return value; }
-		constexpr operator const T&() const { return value; }
+		constexpr operator T&() { return m_value; }
+		constexpr operator const T&() const { return m_value; }
 
 	  private:
-		T value;
+		T m_value;
 	};
 
 } // namespace detail

--- a/include/user_bench.h
+++ b/include/user_bench.h
@@ -30,7 +30,7 @@ namespace experimental {
 
 				template <typename... Args>
 				void log_once(const std::string& format_string, Args&&... args) const {
-					if(this_nid == 0) { log(format_string, std::forward<Args>(args)...); }
+					if(m_this_nid == 0) { log(format_string, std::forward<Args>(args)...); }
 				}
 
 				template <typename... Args>
@@ -45,12 +45,13 @@ namespace experimental {
 
 				template <typename... Args>
 				void event(const std::string& format_string, Args&&... args) {
-					std::lock_guard lk{mutex};
+					std::lock_guard lk{m_mutex};
 					const auto now = bench_clock::now();
-					const auto dt =
-					    (last_event_tp != bench_clock::time_point{}) ? std::chrono::duration_cast<std::chrono::microseconds>(now - last_event_tp).count() : 0;
+					const auto dt = (m_last_event_tp != bench_clock::time_point{})
+					                    ? std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_event_tp).count()
+					                    : 0;
 					log(format_string + " (+{}us)", std::forward<Args>(args)..., dt);
-					last_event_tp = now;
+					m_last_event_tp = now;
 				}
 
 			  private:
@@ -62,12 +63,12 @@ namespace experimental {
 					bench_clock::time_point start;
 				};
 
-				mutable std::mutex mutex;
+				mutable std::mutex m_mutex;
 
-				node_id this_nid;
-				section_id next_section_id = 0;
-				std::stack<section> sections;
-				bench_clock::time_point last_event_tp = {};
+				node_id m_this_nid;
+				section_id m_next_section_id = 0;
+				std::stack<section> m_sections;
+				bench_clock::time_point m_last_event_tp = {};
 
 				void begin_section(std::string name);
 				void end_section(const std::string& name);

--- a/include/worker_job.h
+++ b/include/worker_job.h
@@ -71,7 +71,7 @@ namespace detail {
 
 	class horizon_job : public worker_job {
 	  public:
-		horizon_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm) { assert(pkg.get_command_type() == command_type::HORIZON); }
+		horizon_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm) { assert(pkg.get_command_type() == command_type::horizon); }
 
 	  private:
 		task_manager& task_mngr;
@@ -83,7 +83,7 @@ namespace detail {
 	class epoch_job : public worker_job {
 	  public:
 		epoch_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm), action(std::get<epoch_data>(pkg.data).action) {
-			assert(pkg.get_command_type() == command_type::EPOCH);
+			assert(pkg.get_command_type() == command_type::epoch);
 		}
 
 		epoch_action get_epoch_action() const { return action; }
@@ -102,7 +102,7 @@ namespace detail {
 	class await_push_job : public worker_job {
 	  public:
 		await_push_job(command_pkg pkg, buffer_transfer_manager& btm) : worker_job(pkg), btm(btm) {
-			assert(pkg.get_command_type() == command_type::AWAIT_PUSH);
+			assert(pkg.get_command_type() == command_type::await_push);
 		}
 
 	  private:
@@ -116,7 +116,7 @@ namespace detail {
 	class push_job : public worker_job {
 	  public:
 		push_job(command_pkg pkg, buffer_transfer_manager& btm, buffer_manager& bm) : worker_job(pkg), btm(btm), buffer_mngr(bm) {
-			assert(pkg.get_command_type() == command_type::PUSH);
+			assert(pkg.get_command_type() == command_type::push);
 		}
 
 	  private:
@@ -131,7 +131,7 @@ namespace detail {
 	class reduction_job : public worker_job {
 	  public:
 		reduction_job(command_pkg pkg, reduction_manager& rm) : worker_job(pkg, std::tuple{"rid", std::get<reduction_data>(pkg.data).rid}), rm(rm) {
-			assert(pkg.get_command_type() == command_type::REDUCTION);
+			assert(pkg.get_command_type() == command_type::reduction);
 		}
 
 	  private:
@@ -146,7 +146,7 @@ namespace detail {
 	  public:
 		host_execute_job(command_pkg pkg, detail::host_queue& queue, detail::task_manager& tm, buffer_manager& bm)
 		    : worker_job(pkg), queue(queue), task_mngr(tm), buffer_mngr(bm) {
-			assert(pkg.get_command_type() == command_type::EXECUTION);
+			assert(pkg.get_command_type() == command_type::execution);
 		}
 
 	  private:
@@ -168,7 +168,7 @@ namespace detail {
 	  public:
 		device_execute_job(command_pkg pkg, detail::device_queue& queue, detail::task_manager& tm, buffer_manager& bm, reduction_manager& rm, node_id local_nid)
 		    : worker_job(pkg), queue(queue), task_mngr(tm), buffer_mngr(bm), reduction_mngr(rm), local_nid(local_nid) {
-			assert(pkg.get_command_type() == command_type::EXECUTION);
+			assert(pkg.get_command_type() == command_type::execution);
 		}
 
 	  private:

--- a/include/worker_job.h
+++ b/include/worker_job.h
@@ -32,25 +32,25 @@ namespace detail {
 		void start();
 		void update();
 
-		bool is_running() const { return running; }
-		bool is_done() const { return done; }
+		bool is_running() const { return m_running; }
+		bool is_done() const { return m_done; }
 
 	  protected:
 		template <typename... Es>
-		explicit worker_job(command_pkg pkg, std::tuple<Es...> ctx = {}) : pkg(pkg), lctx(make_log_context(pkg, ctx)) {}
+		explicit worker_job(command_pkg pkg, std::tuple<Es...> ctx = {}) : m_pkg(pkg), m_lctx(make_log_context(pkg, ctx)) {}
 
 	  private:
-		command_pkg pkg;
-		log_context lctx;
-		bool running = false;
-		bool done = false;
+		command_pkg m_pkg;
+		log_context m_lctx;
+		bool m_running = false;
+		bool m_done = false;
 
 		// Benchmarking
-		std::chrono::steady_clock::time_point start_time;
-		std::chrono::microseconds bench_sum_execution_time = {};
-		size_t bench_sample_count = 0;
-		std::chrono::microseconds bench_min = std::numeric_limits<std::chrono::microseconds>::max();
-		std::chrono::microseconds bench_max = std::numeric_limits<std::chrono::microseconds>::min();
+		std::chrono::steady_clock::time_point m_start_time;
+		std::chrono::microseconds m_bench_sum_execution_time = {};
+		size_t m_bench_sample_count = 0;
+		std::chrono::microseconds m_bench_min = std::numeric_limits<std::chrono::microseconds>::max();
+		std::chrono::microseconds m_bench_max = std::numeric_limits<std::chrono::microseconds>::min();
 
 		template <typename... Es>
 		log_context make_log_context(const command_pkg& pkg, const std::tuple<Es...>& ctx = {}) {
@@ -71,10 +71,10 @@ namespace detail {
 
 	class horizon_job : public worker_job {
 	  public:
-		horizon_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm) { assert(pkg.get_command_type() == command_type::horizon); }
+		horizon_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), m_task_mngr(tm) { assert(pkg.get_command_type() == command_type::horizon); }
 
 	  private:
-		task_manager& task_mngr;
+		task_manager& m_task_mngr;
 
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;
@@ -82,15 +82,15 @@ namespace detail {
 
 	class epoch_job : public worker_job {
 	  public:
-		epoch_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), task_mngr(tm), action(std::get<epoch_data>(pkg.data).action) {
+		epoch_job(command_pkg pkg, task_manager& tm) : worker_job(pkg), m_task_mngr(tm), m_action(std::get<epoch_data>(pkg.data).action) {
 			assert(pkg.get_command_type() == command_type::epoch);
 		}
 
-		epoch_action get_epoch_action() const { return action; }
+		epoch_action get_epoch_action() const { return m_action; }
 
 	  private:
-		task_manager& task_mngr;
-		epoch_action action;
+		task_manager& m_task_mngr;
+		epoch_action m_action;
 
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;
@@ -101,13 +101,13 @@ namespace detail {
 	 */
 	class await_push_job : public worker_job {
 	  public:
-		await_push_job(command_pkg pkg, buffer_transfer_manager& btm) : worker_job(pkg), btm(btm) {
+		await_push_job(command_pkg pkg, buffer_transfer_manager& btm) : worker_job(pkg), m_btm(btm) {
 			assert(pkg.get_command_type() == command_type::await_push);
 		}
 
 	  private:
-		buffer_transfer_manager& btm;
-		std::shared_ptr<const buffer_transfer_manager::transfer_handle> data_handle = nullptr;
+		buffer_transfer_manager& m_btm;
+		std::shared_ptr<const buffer_transfer_manager::transfer_handle> m_data_handle = nullptr;
 
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;
@@ -115,14 +115,14 @@ namespace detail {
 
 	class push_job : public worker_job {
 	  public:
-		push_job(command_pkg pkg, buffer_transfer_manager& btm, buffer_manager& bm) : worker_job(pkg), btm(btm), buffer_mngr(bm) {
+		push_job(command_pkg pkg, buffer_transfer_manager& btm, buffer_manager& bm) : worker_job(pkg), m_btm(btm), m_buffer_mngr(bm) {
 			assert(pkg.get_command_type() == command_type::push);
 		}
 
 	  private:
-		buffer_transfer_manager& btm;
-		buffer_manager& buffer_mngr;
-		std::shared_ptr<const buffer_transfer_manager::transfer_handle> data_handle = nullptr;
+		buffer_transfer_manager& m_btm;
+		buffer_manager& m_buffer_mngr;
+		std::shared_ptr<const buffer_transfer_manager::transfer_handle> m_data_handle = nullptr;
 
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;
@@ -130,12 +130,12 @@ namespace detail {
 
 	class reduction_job : public worker_job {
 	  public:
-		reduction_job(command_pkg pkg, reduction_manager& rm) : worker_job(pkg, std::tuple{"rid", std::get<reduction_data>(pkg.data).rid}), rm(rm) {
+		reduction_job(command_pkg pkg, reduction_manager& rm) : worker_job(pkg, std::tuple{"rid", std::get<reduction_data>(pkg.data).rid}), m_rm(rm) {
 			assert(pkg.get_command_type() == command_type::reduction);
 		}
 
 	  private:
-		reduction_manager& rm;
+		reduction_manager& m_rm;
 
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;
@@ -145,16 +145,16 @@ namespace detail {
 	class host_execute_job : public worker_job {
 	  public:
 		host_execute_job(command_pkg pkg, detail::host_queue& queue, detail::task_manager& tm, buffer_manager& bm)
-		    : worker_job(pkg), queue(queue), task_mngr(tm), buffer_mngr(bm) {
+		    : worker_job(pkg), m_queue(queue), m_task_mngr(tm), m_buffer_mngr(bm) {
 			assert(pkg.get_command_type() == command_type::execution);
 		}
 
 	  private:
-		detail::host_queue& queue;
-		detail::task_manager& task_mngr;
-		detail::buffer_manager& buffer_mngr;
-		std::future<detail::host_queue::execution_info> future;
-		bool submitted = false;
+		detail::host_queue& m_queue;
+		detail::task_manager& m_task_mngr;
+		detail::buffer_manager& m_buffer_mngr;
+		std::future<detail::host_queue::execution_info> m_future;
+		bool m_submitted = false;
 
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;
@@ -167,18 +167,18 @@ namespace detail {
 	class device_execute_job : public worker_job {
 	  public:
 		device_execute_job(command_pkg pkg, detail::device_queue& queue, detail::task_manager& tm, buffer_manager& bm, reduction_manager& rm, node_id local_nid)
-		    : worker_job(pkg), queue(queue), task_mngr(tm), buffer_mngr(bm), reduction_mngr(rm), local_nid(local_nid) {
+		    : worker_job(pkg), m_queue(queue), m_task_mngr(tm), m_buffer_mngr(bm), m_reduction_mngr(rm), m_local_nid(local_nid) {
 			assert(pkg.get_command_type() == command_type::execution);
 		}
 
 	  private:
-		detail::device_queue& queue;
-		detail::task_manager& task_mngr;
-		detail::buffer_manager& buffer_mngr;
-		detail::reduction_manager& reduction_mngr;
-		node_id local_nid;
-		cl::sycl::event event;
-		bool submitted = false;
+		detail::device_queue& m_queue;
+		detail::task_manager& m_task_mngr;
+		detail::buffer_manager& m_buffer_mngr;
+		detail::reduction_manager& m_reduction_mngr;
+		node_id m_local_nid;
+		cl::sycl::event m_event;
+		bool m_submitted = false;
 
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;

--- a/src/buffer_transfer_manager.cc
+++ b/src/buffer_transfer_manager.cc
@@ -13,7 +13,7 @@ namespace celerity {
 namespace detail {
 
 	std::shared_ptr<const buffer_transfer_manager::transfer_handle> buffer_transfer_manager::push(const command_pkg& pkg) {
-		assert(pkg.get_command_type() == command_type::PUSH);
+		assert(pkg.get_command_type() == command_type::push);
 		auto t_handle = std::make_shared<transfer_handle>();
 		// We are blocking the caller until the buffer has been copied and submitted to MPI
 		// TODO: Investigate doing this in worker thread
@@ -48,7 +48,7 @@ namespace detail {
 	}
 
 	std::shared_ptr<const buffer_transfer_manager::transfer_handle> buffer_transfer_manager::await_push(const command_pkg& pkg) {
-		assert(pkg.get_command_type() == command_type::AWAIT_PUSH);
+		assert(pkg.get_command_type() == command_type::await_push);
 		const auto& data = std::get<await_push_data>(pkg.data);
 
 		std::shared_ptr<incoming_transfer_handle> t_handle;

--- a/src/command_graph.cc
+++ b/src/command_graph.cc
@@ -8,17 +8,17 @@ namespace detail {
 	void command_graph::erase(abstract_command* cmd) {
 		if(auto tcmd = dynamic_cast<task_command*>(cmd)) {
 			// TODO: If the number of commands per task gets large, this could become problematic. Maybe use an unordered_set instead?
-			by_task[tcmd->get_tid()].erase(std::find(by_task[tcmd->get_tid()].begin(), by_task[tcmd->get_tid()].end(), cmd));
+			m_by_task[tcmd->get_tid()].erase(std::find(m_by_task[tcmd->get_tid()].begin(), m_by_task[tcmd->get_tid()].end(), cmd));
 		}
-		execution_fronts[cmd->get_nid()].erase(cmd);
-		commands.erase(cmd->get_cid());
+		m_execution_fronts[cmd->get_nid()].erase(cmd);
+		m_commands.erase(cmd->get_cid());
 	}
 
 
 	void command_graph::erase_if(std::function<bool(abstract_command*)> condition) {
-		for(auto it = commands.begin(); it != commands.end();) {
+		for(auto it = m_commands.begin(); it != m_commands.end();) {
 			if(condition(it->second.get())) {
-				it = commands.erase(it);
+				it = m_commands.erase(it);
 			} else {
 				++it;
 			}

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -9,17 +9,17 @@ namespace celerity {
 namespace detail {
 
 	void device_queue::init(const config& cfg, const device_or_selector& user_device_or_selector) {
-		assert(sycl_queue == nullptr);
+		assert(m_sycl_queue == nullptr);
 		const auto profiling_cfg = cfg.get_enable_device_profiling();
-		device_profiling_enabled = profiling_cfg != std::nullopt && *profiling_cfg;
-		if(device_profiling_enabled) { CELERITY_INFO("Device profiling enabled."); }
+		m_device_profiling_enabled = profiling_cfg != std::nullopt && *profiling_cfg;
+		if(m_device_profiling_enabled) { CELERITY_INFO("Device profiling enabled."); }
 
-		const auto props = device_profiling_enabled ? cl::sycl::property_list{cl::sycl::property::queue::enable_profiling()} : cl::sycl::property_list{};
+		const auto props = m_device_profiling_enabled ? cl::sycl::property_list{cl::sycl::property::queue::enable_profiling()} : cl::sycl::property_list{};
 		const auto handle_exceptions = cl::sycl::async_handler{[this](cl::sycl::exception_list el) { this->handle_async_exceptions(el); }};
 
 		auto device = std::visit(
 		    [&cfg](const auto& value) { return ::celerity::detail::pick_device(cfg, value, cl::sycl::platform::get_platforms()); }, user_device_or_selector);
-		sycl_queue = std::make_unique<cl::sycl::queue>(device, handle_exceptions, props);
+		m_sycl_queue = std::make_unique<cl::sycl::queue>(device, handle_exceptions, props);
 	}
 
 	void device_queue::handle_async_exceptions(cl::sycl::exception_list el) const {

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -96,10 +96,10 @@ namespace detail {
 
 			// Process newly available jobs
 			if(!ready_jobs.empty()) {
-				// Make sure to start any PUSH jobs before other jobs, as on some platforms copying data from a compute device while
-				// also reading it from within a kernel is not supported. To avoid stalling other nodes, we thus perform the PUSH first.
+				// Make sure to start any push jobs before other jobs, as on some platforms copying data from a compute device while
+				// also reading it from within a kernel is not supported. To avoid stalling other nodes, we thus perform the push first.
 				std::sort(ready_jobs.begin(), ready_jobs.end(),
-				    [this](command_id a, command_id b) { return jobs[a].cmd == command_type::PUSH && jobs[b].cmd != command_type::PUSH; });
+				    [this](command_id a, command_id b) { return jobs[a].cmd == command_type::push && jobs[b].cmd != command_type::push; });
 				for(command_id cid : ready_jobs) {
 					auto* job = jobs.at(cid).job.get();
 					job->start();
@@ -148,13 +148,13 @@ namespace detail {
 		}
 
 		switch(frame.pkg.get_command_type()) {
-		case command_type::HORIZON: create_job<horizon_job>(frame, task_mngr); break;
-		case command_type::EPOCH: create_job<epoch_job>(frame, task_mngr); break;
-		case command_type::PUSH: create_job<push_job>(frame, *btm, buffer_mngr); break;
-		case command_type::AWAIT_PUSH: create_job<await_push_job>(frame, *btm); break;
-		case command_type::REDUCTION: create_job<reduction_job>(frame, reduction_mngr); break;
-		case command_type::EXECUTION:
-			if(task_mngr.get_task(frame.pkg.get_tid().value())->get_execution_target() == execution_target::HOST) {
+		case command_type::horizon: create_job<horizon_job>(frame, task_mngr); break;
+		case command_type::epoch: create_job<epoch_job>(frame, task_mngr); break;
+		case command_type::push: create_job<push_job>(frame, *btm, buffer_mngr); break;
+		case command_type::await_push: create_job<await_push_job>(frame, *btm); break;
+		case command_type::reduction: create_job<reduction_job>(frame, reduction_mngr); break;
+		case command_type::execution:
+			if(task_mngr.get_task(frame.pkg.get_tid().value())->get_execution_target() == execution_target::host) {
 				create_job<host_execute_job>(frame, h_queue, task_mngr, buffer_mngr);
 			} else {
 				create_job<device_execute_job>(frame, d_queue, task_mngr, buffer_mngr, reduction_mngr, local_nid);

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -14,51 +14,51 @@ constexpr size_t MAX_CONCURRENT_JOBS = 20;
 namespace celerity {
 namespace detail {
 	void duration_metric::resume() {
-		assert(!running);
-		current_start = clock.now();
-		running = true;
+		assert(!m_running);
+		m_current_start = m_clock.now();
+		m_running = true;
 	}
 
 	void duration_metric::pause() {
-		assert(running);
-		duration += std::chrono::duration_cast<std::chrono::microseconds>(clock.now() - current_start);
-		running = false;
+		assert(m_running);
+		m_duration += std::chrono::duration_cast<std::chrono::microseconds>(m_clock.now() - m_current_start);
+		m_running = false;
 	}
 
 	executor::executor(
 	    node_id local_nid, host_queue& h_queue, device_queue& d_queue, task_manager& tm, buffer_manager& buffer_mngr, reduction_manager& reduction_mngr)
-	    : local_nid(local_nid), h_queue(h_queue), d_queue(d_queue), task_mngr(tm), buffer_mngr(buffer_mngr), reduction_mngr(reduction_mngr) {
-		btm = std::make_unique<buffer_transfer_manager>();
-		metrics.initial_idle.resume();
+	    : m_local_nid(local_nid), m_h_queue(h_queue), m_d_queue(d_queue), m_task_mngr(tm), m_buffer_mngr(buffer_mngr), m_reduction_mngr(reduction_mngr) {
+		m_btm = std::make_unique<buffer_transfer_manager>();
+		m_metrics.initial_idle.resume();
 	}
 
 	void executor::startup() {
-		exec_thrd = std::thread(&executor::run, this);
-		set_thread_name(exec_thrd.native_handle(), "cy-executor");
+		m_exec_thrd = std::thread(&executor::run, this);
+		set_thread_name(m_exec_thrd.native_handle(), "cy-executor");
 	}
 
 	void executor::shutdown() {
-		if(exec_thrd.joinable()) { exec_thrd.join(); }
+		if(m_exec_thrd.joinable()) { m_exec_thrd.join(); }
 
-		CELERITY_DEBUG("Executor initial idle time = {}us, compute idle time = {}us, starvation time = {}us", metrics.initial_idle.get().count(),
-		    metrics.device_idle.get().count(), metrics.starvation.get().count());
+		CELERITY_DEBUG("Executor initial idle time = {}us, compute idle time = {}us, starvation time = {}us", m_metrics.initial_idle.get().count(),
+		    m_metrics.device_idle.get().count(), m_metrics.starvation.get().count());
 	}
 
 	void executor::run() {
 		bool done = false;
 		std::queue<unique_frame_ptr<command_frame>> command_queue;
-		while(!done || !jobs.empty()) {
+		while(!done || !m_jobs.empty()) {
 			// Bail if a device error ocurred.
-			if(running_device_compute_jobs > 0) { d_queue.get_sycl_queue().throw_asynchronous(); }
+			if(m_running_device_compute_jobs > 0) { m_d_queue.get_sycl_queue().throw_asynchronous(); }
 
 			// We poll transfers from here (in the same thread, interleaved with job updates),
 			// as it allows us to omit any sort of locking when interacting with the BTM through jobs.
 			// This actually makes quite a big difference, especially for lots of small transfers.
 			// The BTM uses non-blocking MPI routines internally, making this a relatively cheap operation.
-			btm->poll();
+			m_btm->poll();
 
 			std::vector<command_id> ready_jobs;
-			for(auto it = jobs.begin(); it != jobs.end();) {
+			for(auto it = m_jobs.begin(); it != m_jobs.end();) {
 				auto& job_handle = it->second;
 
 				if(job_handle.unsatisfied_dependencies > 0) {
@@ -79,19 +79,19 @@ namespace detail {
 				}
 
 				for(const auto& d : job_handle.dependents) {
-					assert(jobs.count(d) == 1);
-					jobs[d].unsatisfied_dependencies--;
-					if(jobs[d].unsatisfied_dependencies == 0) { ready_jobs.push_back(d); }
+					assert(m_jobs.count(d) == 1);
+					m_jobs[d].unsatisfied_dependencies--;
+					if(m_jobs[d].unsatisfied_dependencies == 0) { ready_jobs.push_back(d); }
 				}
 
 				if(isa<device_execute_job>(job_handle.job.get())) {
-					running_device_compute_jobs--;
+					m_running_device_compute_jobs--;
 				} else if(const auto epoch = dynamic_cast<epoch_job*>(job_handle.job.get()); epoch && epoch->get_epoch_action() == epoch_action::shutdown) {
 					assert(command_queue.empty());
 					done = true;
 				}
 
-				it = jobs.erase(it);
+				it = m_jobs.erase(it);
 			}
 
 			// Process newly available jobs
@@ -99,12 +99,12 @@ namespace detail {
 				// Make sure to start any push jobs before other jobs, as on some platforms copying data from a compute device while
 				// also reading it from within a kernel is not supported. To avoid stalling other nodes, we thus perform the push first.
 				std::sort(ready_jobs.begin(), ready_jobs.end(),
-				    [this](command_id a, command_id b) { return jobs[a].cmd == command_type::push && jobs[b].cmd != command_type::push; });
+				    [this](command_id a, command_id b) { return m_jobs[a].cmd == command_type::push && m_jobs[b].cmd != command_type::push; });
 				for(command_id cid : ready_jobs) {
-					auto* job = jobs.at(cid).job.get();
+					auto* job = m_jobs.at(cid).job.get();
 					job->start();
 					job->update();
-					if(isa<device_execute_job>(job)) { running_device_compute_jobs++; }
+					if(isa<device_execute_job>(job)) { m_running_device_compute_jobs++; }
 				}
 			}
 
@@ -120,14 +120,14 @@ namespace detail {
 				assert(frame->num_dependencies == frame.get_payload_count());
 				command_queue.push(std::move(frame));
 
-				if(!first_command_received) {
-					metrics.initial_idle.pause();
-					metrics.device_idle.resume();
-					first_command_received = true;
+				if(!m_first_command_received) {
+					m_metrics.initial_idle.pause();
+					m_metrics.device_idle.resume();
+					m_first_command_received = true;
 				}
 			}
 
-			if(jobs.size() < MAX_CONCURRENT_JOBS && !command_queue.empty()) {
+			if(m_jobs.size() < MAX_CONCURRENT_JOBS && !command_queue.empty()) {
 				if(!handle_command(*command_queue.front())) {
 					// In case the command couldn't be handled, don't pop it from the queue.
 					continue;
@@ -135,29 +135,29 @@ namespace detail {
 				command_queue.pop();
 			}
 
-			if(first_command_received) { update_metrics(); }
+			if(m_first_command_received) { update_metrics(); }
 		}
 
-		assert(running_device_compute_jobs == 0);
+		assert(m_running_device_compute_jobs == 0);
 	}
 
 	bool executor::handle_command(const command_frame& frame) {
 		// A worker might receive a task command before creating the corresponding task graph node
 		if(const auto tid = frame.pkg.get_tid()) {
-			if(!task_mngr.has_task(*tid)) { return false; }
+			if(!m_task_mngr.has_task(*tid)) { return false; }
 		}
 
 		switch(frame.pkg.get_command_type()) {
-		case command_type::horizon: create_job<horizon_job>(frame, task_mngr); break;
-		case command_type::epoch: create_job<epoch_job>(frame, task_mngr); break;
-		case command_type::push: create_job<push_job>(frame, *btm, buffer_mngr); break;
-		case command_type::await_push: create_job<await_push_job>(frame, *btm); break;
-		case command_type::reduction: create_job<reduction_job>(frame, reduction_mngr); break;
+		case command_type::horizon: create_job<horizon_job>(frame, m_task_mngr); break;
+		case command_type::epoch: create_job<epoch_job>(frame, m_task_mngr); break;
+		case command_type::push: create_job<push_job>(frame, *m_btm, m_buffer_mngr); break;
+		case command_type::await_push: create_job<await_push_job>(frame, *m_btm); break;
+		case command_type::reduction: create_job<reduction_job>(frame, m_reduction_mngr); break;
 		case command_type::execution:
-			if(task_mngr.get_task(frame.pkg.get_tid().value())->get_execution_target() == execution_target::host) {
-				create_job<host_execute_job>(frame, h_queue, task_mngr, buffer_mngr);
+			if(m_task_mngr.get_task(frame.pkg.get_tid().value())->get_execution_target() == execution_target::host) {
+				create_job<host_execute_job>(frame, m_h_queue, m_task_mngr, m_buffer_mngr);
 			} else {
-				create_job<device_execute_job>(frame, d_queue, task_mngr, buffer_mngr, reduction_mngr, local_nid);
+				create_job<device_execute_job>(frame, m_d_queue, m_task_mngr, m_buffer_mngr, m_reduction_mngr, m_local_nid);
 			}
 			break;
 		default: assert(!"Unexpected command");
@@ -166,15 +166,15 @@ namespace detail {
 	}
 
 	void executor::update_metrics() {
-		if(running_device_compute_jobs == 0) {
-			if(!metrics.device_idle.is_running()) { metrics.device_idle.resume(); }
+		if(m_running_device_compute_jobs == 0) {
+			if(!m_metrics.device_idle.is_running()) { m_metrics.device_idle.resume(); }
 		} else {
-			if(metrics.device_idle.is_running()) { metrics.device_idle.pause(); }
+			if(m_metrics.device_idle.is_running()) { m_metrics.device_idle.pause(); }
 		}
-		if(jobs.empty()) {
-			if(!metrics.starvation.is_running()) { metrics.starvation.resume(); }
+		if(m_jobs.empty()) {
+			if(!m_metrics.starvation.is_running()) { m_metrics.starvation.resume(); }
 		} else {
-			if(metrics.starvation.is_running()) { metrics.starvation.pause(); }
+			if(m_metrics.starvation.is_running()) { m_metrics.starvation.pause(); }
 		}
 	}
 } // namespace detail

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -12,37 +12,38 @@
 namespace celerity {
 namespace detail {
 
-	graph_generator::graph_generator(size_t num_nodes, reduction_manager& rm, command_graph& cdag) : reduction_mngr(rm), num_nodes(num_nodes), cdag(cdag) {
+	graph_generator::graph_generator(size_t num_nodes, reduction_manager& rm, command_graph& cdag)
+	    : m_reduction_mngr(rm), m_num_nodes(num_nodes), m_cdag(cdag) {
 		// Build initial epoch command for each node (these are required to properly handle anti-dependencies on host-initialized buffers).
 		// We manually generate the first set of commands, these will be replaced by applied horizons or explicit epochs down the line (see
 		// set_epoch_for_new_commands).
 		for(node_id nid = 0; nid < num_nodes; ++nid) {
 			const auto epoch_cmd = cdag.create<epoch_command>(nid, task_manager::initial_epoch_task, epoch_action::none);
 			epoch_cmd->mark_as_flushed(); // there is no point in flushing the initial epoch command
-			node_data[nid].epoch_for_new_commands = epoch_cmd->get_cid();
+			m_node_data[nid].epoch_for_new_commands = epoch_cmd->get_cid();
 		}
 	}
 
 	void graph_generator::add_buffer(buffer_id bid, const cl::sycl::range<3>& range) {
-		std::lock_guard<std::mutex> lock(buffer_mutex);
+		std::lock_guard<std::mutex> lock(m_buffer_mutex);
 		// Initialize the whole range to all nodes, so that we always use local buffer ranges when they haven't been written to (on any node) yet.
 		// TODO: Consider better handling for when buffers are not host initialized
-		std::vector<node_id> all_nodes(num_nodes);
-		for(auto i = 0u; i < num_nodes; ++i) {
+		std::vector<node_id> all_nodes(m_num_nodes);
+		for(auto i = 0u; i < m_num_nodes; ++i) {
 			all_nodes[i] = i;
-			node_data[i].buffer_last_writer.emplace(bid, range);
-			node_data[i].buffer_last_writer.at(bid).update_region(subrange_to_grid_box({cl::sycl::id<3>(), range}), node_data[i].epoch_for_new_commands);
+			m_node_data[i].buffer_last_writer.emplace(bid, range);
+			m_node_data[i].buffer_last_writer.at(bid).update_region(subrange_to_grid_box({cl::sycl::id<3>(), range}), m_node_data[i].epoch_for_new_commands);
 		}
 
-		buffer_states.emplace(bid, distributed_state{{range, std::move(all_nodes)}});
+		m_buffer_states.emplace(bid, distributed_state{{range, std::move(all_nodes)}});
 	}
 
 	void graph_generator::build_task(const task& tsk, const std::vector<graph_transformer*>& transformers) {
-		std::lock_guard<std::mutex> lock(buffer_mutex);
+		std::lock_guard<std::mutex> lock(m_buffer_mutex);
 		// TODO: Maybe assert that this task hasn't been processed before
 
 		const auto tid = tsk.get_id();
-		const auto min_epoch_to_prune_before = min_epoch_for_new_commands;
+		const auto min_epoch_to_prune_before = m_min_epoch_for_new_commands;
 
 		switch(tsk.get_type()) {
 		case task_type::epoch: generate_epoch_commands(tsk); break;
@@ -54,7 +55,7 @@ namespace detail {
 		}
 
 		for(auto& t : transformers) {
-			t->transform_task(tsk, cdag);
+			t->transform_task(tsk, m_cdag);
 		}
 
 		// Only execution tasks can have data requirements or reductions
@@ -69,7 +70,7 @@ namespace detail {
 			//     or non-commutative operations
 			if(!tsk.get_reductions().empty()) {
 				std::unordered_set<node_id> producer_nids;
-				for(auto& cmd : cdag.task_commands(tid)) {
+				for(auto& cmd : m_cdag.task_commands(tid)) {
 					assert(producer_nids.insert(cmd->get_nid()).second);
 				}
 			}
@@ -82,7 +83,7 @@ namespace detail {
 		}
 
 		// Commands without any other true-dependency must depend on the active epoch command to ensure they cannot be re-ordered before the epoch
-		for(const auto cmd : cdag.task_commands(tid)) {
+		for(const auto cmd : m_cdag.task_commands(tid)) {
 			generate_epoch_dependencies(cmd);
 		}
 
@@ -93,7 +94,7 @@ namespace detail {
 
 	void graph_generator::set_epoch_for_new_commands(per_node_data& node, const command_id epoch) { // NOLINT(readability-convert-member-functions-to-static)
 		// both an explicit epoch command and an applied horizon can be effective epochs
-		assert(isa<epoch_command>(cdag.get(epoch)) || isa<horizon_command>(cdag.get(epoch)));
+		assert(isa<epoch_command>(m_cdag.get(epoch)) || isa<horizon_command>(m_cdag.get(epoch)));
 
 		// update "buffer_last_writer" and "last_collective_commands" structures to subsume pre-epoch commands
 		for(auto& blw_pair : node.buffer_last_writer) {
@@ -115,21 +116,21 @@ namespace detail {
 
 	void graph_generator::reduce_execution_front_to(abstract_command* const new_front) {
 		const auto nid = new_front->get_nid();
-		const auto previous_execution_front = cdag.get_execution_front(nid);
+		const auto previous_execution_front = m_cdag.get_execution_front(nid);
 		for(const auto front_cmd : previous_execution_front) {
-			if(front_cmd != new_front) { cdag.add_dependency(new_front, front_cmd, dependency_kind::true_dep, dependency_origin::execution_front); }
+			if(front_cmd != new_front) { m_cdag.add_dependency(new_front, front_cmd, dependency_kind::true_dep, dependency_origin::execution_front); }
 		}
-		assert(cdag.get_execution_front(nid).size() == 1 && *cdag.get_execution_front(nid).begin() == new_front);
+		assert(m_cdag.get_execution_front(nid).size() == 1 && *m_cdag.get_execution_front(nid).begin() == new_front);
 	}
 
 	void graph_generator::generate_epoch_commands(const task& tsk) {
 		assert(tsk.get_type() == task_type::epoch);
 
 		command_id min_new_epoch;
-		for(node_id nid = 0; nid < num_nodes; ++nid) {
-			auto& node = node_data.at(nid);
+		for(node_id nid = 0; nid < m_num_nodes; ++nid) {
+			auto& node = m_node_data.at(nid);
 
-			const auto epoch = cdag.create<epoch_command>(nid, tsk.get_id(), tsk.get_epoch_action());
+			const auto epoch = m_cdag.create<epoch_command>(nid, tsk.get_id(), tsk.get_epoch_action());
 			const auto cid = epoch->get_cid();
 			if(nid == 0) { min_new_epoch = cid; }
 
@@ -140,17 +141,17 @@ namespace detail {
 			reduce_execution_front_to(epoch);
 		}
 
-		min_epoch_for_new_commands = min_new_epoch;
+		m_min_epoch_for_new_commands = min_new_epoch;
 	}
 
 	void graph_generator::generate_horizon_commands(const task& tsk) {
 		assert(tsk.get_type() == task_type::horizon);
 
 		std::optional<command_id> min_new_epoch;
-		for(node_id nid = 0; nid < num_nodes; ++nid) {
-			auto& node = node_data.at(nid);
+		for(node_id nid = 0; nid < m_num_nodes; ++nid) {
+			auto& node = m_node_data.at(nid);
 
-			const auto horizon = cdag.create<horizon_command>(nid, tsk.get_id());
+			const auto horizon = m_cdag.create<horizon_command>(nid, tsk.get_id());
 			const auto cid = horizon->get_cid();
 
 			if(node.current_horizon) {
@@ -168,26 +169,26 @@ namespace detail {
 		}
 
 		if(min_new_epoch) {
-			assert(!min_new_epoch.has_value() || min_epoch_for_new_commands < *min_new_epoch);
-			min_epoch_for_new_commands = *min_new_epoch;
+			assert(!min_new_epoch.has_value() || m_min_epoch_for_new_commands < *min_new_epoch);
+			m_min_epoch_for_new_commands = *min_new_epoch;
 		}
 	}
 
 	void graph_generator::generate_collective_execution_commands(const task& tsk) {
 		assert(tsk.get_type() == task_type::collective);
 
-		for(size_t nid = 0; nid < num_nodes; ++nid) {
+		for(size_t nid = 0; nid < m_num_nodes; ++nid) {
 			auto offset = cl::sycl::id<1>{nid};
 			auto range = cl::sycl::range<1>{1};
 			const auto sr = subrange_cast<3>(subrange<1>{offset, range});
-			auto* cmd = cdag.create<execution_command>(nid, tsk.get_id(), sr);
+			auto* cmd = m_cdag.create<execution_command>(nid, tsk.get_id(), sr);
 
 			// Collective host tasks have an implicit dependency on the previous task in the same collective group, which is required in order to guarantee
 			// they are executed in the same order on every node.
 			auto cgid = tsk.get_collective_group_id();
-			auto& last_collective_commands = node_data.at(nid).last_collective_commands;
+			auto& last_collective_commands = m_node_data.at(nid).last_collective_commands;
 			if(auto prev = last_collective_commands.find(cgid); prev != last_collective_commands.end()) {
-				cdag.add_dependency(cmd, cdag.get(prev->second), dependency_kind::true_dep, dependency_origin::collective_group_serialization);
+				m_cdag.add_dependency(cmd, m_cdag.get(prev->second), dependency_kind::true_dep, dependency_origin::collective_group_serialization);
 				last_collective_commands.erase(prev);
 			}
 			last_collective_commands.emplace(cgid, cmd->get_cid());
@@ -198,7 +199,7 @@ namespace detail {
 		assert(tsk.get_type() == task_type::host_compute || tsk.get_type() == task_type::device_compute || tsk.get_type() == task_type::master_node);
 
 		const auto sr = subrange<3>{tsk.get_global_offset(), tsk.get_global_size()};
-		cdag.create<execution_command>(0, tsk.get_id(), sr);
+		m_cdag.create<execution_command>(0, tsk.get_id(), sr);
 	}
 
 	using buffer_requirements_map = std::unordered_map<buffer_id, std::unordered_map<cl::sycl::access::mode, GridRegion<3>>>;
@@ -222,7 +223,7 @@ namespace detail {
 		for(auto& box_and_writers : last_writers) {
 			if(box_and_writers.second == std::nullopt) continue;
 			const command_id last_writer_cid = *box_and_writers.second;
-			const auto last_writer_cmd = cdag.get(last_writer_cid);
+			const auto last_writer_cmd = m_cdag.get(last_writer_cid);
 			assert(!isa<task_command>(last_writer_cmd) || static_cast<task_command*>(last_writer_cmd)->get_tid() != tid);
 
 			// Add anti-dependencies onto all dependents of the writer
@@ -237,13 +238,13 @@ namespace detail {
 				if(isa<task_command>(cmd) && static_cast<task_command*>(cmd)->get_tid() == tid) continue;
 
 				// So far we don't know whether the dependent actually intersects with the subrange we're writing
-				if(const auto command_reads_it = command_buffer_reads.find(cmd->get_cid()); command_reads_it != command_buffer_reads.end()) {
+				if(const auto command_reads_it = m_command_buffer_reads.find(cmd->get_cid()); command_reads_it != m_command_buffer_reads.end()) {
 					const auto& command_reads = command_reads_it->second;
 					// The task might be a dependent because of another buffer
 					if(const auto buffer_reads_it = command_reads.find(bid); buffer_reads_it != command_reads.end()) {
 						if(!GridRegion<3>::intersect(write_req, buffer_reads_it->second).empty()) {
 							has_dependents = true;
-							cdag.add_dependency(write_cmd, cmd, dependency_kind::anti_dep, dependency_origin::dataflow);
+							m_cdag.add_dependency(write_cmd, cmd, dependency_kind::anti_dep, dependency_origin::dataflow);
 						}
 					}
 				}
@@ -252,7 +253,7 @@ namespace detail {
 			// In some cases (horizons, master node host task, weird discard_* constructs...)
 			// the last writer might not have any dependents. Just add the anti-dependency onto the writer itself then.
 			if(!has_dependents) {
-				cdag.add_dependency(write_cmd, last_writer_cmd, dependency_kind::anti_dep, dependency_origin::dataflow);
+				m_cdag.add_dependency(write_cmd, last_writer_cmd, dependency_kind::anti_dep, dependency_origin::dataflow);
 
 				// This is a good time to validate our assumption that every await_push command has a dependent
 				assert(!isa<await_push_command>(last_writer_cmd));
@@ -276,7 +277,7 @@ namespace detail {
 
 		// Copy the list of task commands so we can safely modify the command graph in the loop below
 		// NOTE: We assume that none of these commands are deleted
-		const auto task_commands = cdag.task_commands(tid);
+		const auto task_commands = m_cdag.task_commands(tid);
 
 		// In reductions including the current buffer value, we need to designate a single command that will read from the output buffer. To avoid unnecessary
 		// data transfers to that reader, we choose a command on a node where that buffer is already present. We cannot in general guarantee an optimal choice
@@ -287,7 +288,7 @@ namespace detail {
 		{
 			std::unordered_set<command_id> optimal_reduction_initializer_cids;
 			for(auto rid : tsk.get_reductions()) {
-				auto reduction = reduction_mngr.get_reduction(rid);
+				auto reduction = m_reduction_mngr.get_reduction(rid);
 				if(reduction.initialize_from_buffer) {
 					if(optimal_reduction_initializer_cids.empty()) {
 						// lazy-initialize (there will be no buffer-initialized reductions most of the time)
@@ -300,7 +301,7 @@ namespace detail {
 					// If there is a command that does not need a transfer for *some* of the reductions, that's better than nothing
 					reduction_initializer_cid = *optimal_reduction_initializer_cids.begin();
 
-					auto& buffer_state = buffer_states.at(reduction.output_buffer_id);
+					auto& buffer_state = m_buffer_states.at(reduction.output_buffer_id);
 					if(auto* distr_state = std::get_if<distributed_state>(&buffer_state)) {
 						// set intersection: remove all commands on a node where the initial value is not present
 						const GridBox<3> box{GridPoint<3>{1, 1, 1}};
@@ -350,7 +351,7 @@ namespace detail {
 			// we simply include it in the pre-reduced state of a single execution_command.
 			std::unordered_map<buffer_id, reduction_id> buffer_reduction_map;
 			for(auto rid : tsk.get_reductions()) {
-				auto reduction = reduction_mngr.get_reduction(rid);
+				auto reduction = m_reduction_mngr.get_reduction(rid);
 
 				auto rmode = cl::sycl::access::mode::discard_write;
 				if(ecmd->is_reduction_initializer() && reduction.initialize_from_buffer) { rmode = cl::sycl::access::mode::read_write; }
@@ -373,8 +374,8 @@ namespace detail {
 				const buffer_id bid = it.first;
 				const auto& reqs_by_mode = it.second;
 
-				auto& buffer_state = buffer_states.at(bid);
-				const auto& node_buffer_last_writer = node_data.at(nid).buffer_last_writer.at(bid);
+				auto& buffer_state = m_buffer_states.at(bid);
+				const auto& node_buffer_last_writer = m_node_data.at(nid).buffer_last_writer.at(bid);
 
 				std::vector<cl::sycl::access::mode> required_modes;
 				for(const auto mode : detail::access::all_modes) {
@@ -405,7 +406,7 @@ namespace detail {
 
 					if(detail::access::mode_traits::is_consumer(mode)) {
 						// Store the read access for determining anti-dependencies later on
-						command_buffer_reads[cid][bid] = GridRegion<3>::merge(command_buffer_reads[cid][bid], req);
+						m_command_buffer_reads[cid][bid] = GridRegion<3>::merge(m_command_buffer_reads[cid][bid], req);
 
 						if(auto* distributed = std::get_if<distributed_state>(&buffer_state)) {
 							// Determine whether data transfers are required to fulfill the read requirements
@@ -419,7 +420,7 @@ namespace detail {
 
 								if(std::find(box_sources.cbegin(), box_sources.cend(), nid) != box_sources.cend()) {
 									// No need to push if found locally, but make sure to add dependencies
-									add_dependencies_for_box(cdag, cmd, node_buffer_last_writer, box);
+									add_dependencies_for_box(m_cdag, cmd, node_buffer_last_writer, box);
 									continue;
 								}
 
@@ -431,21 +432,22 @@ namespace detail {
 								// Generate push command
 								push_command* push_cmd;
 								{
-									push_cmd = cdag.create<push_command>(source_nid, bid, 0, nid, grid_box_to_subrange(box));
+									push_cmd = m_cdag.create<push_command>(source_nid, bid, 0, nid, grid_box_to_subrange(box));
 									generated_pushes.push_back(push_cmd);
 
 									// Store the read access on the pushing node
-									command_buffer_reads[push_cmd->get_cid()][bid] = GridRegion<3>::merge(command_buffer_reads[push_cmd->get_cid()][bid], box);
+									m_command_buffer_reads[push_cmd->get_cid()][bid] =
+									    GridRegion<3>::merge(m_command_buffer_reads[push_cmd->get_cid()][bid], box);
 
 									// Add dependencies on the source node between the push and the commands that last wrote that box
-									add_dependencies_for_box(cdag, push_cmd, node_data.at(source_nid).buffer_last_writer.at(bid), box);
+									add_dependencies_for_box(m_cdag, push_cmd, m_node_data.at(source_nid).buffer_last_writer.at(bid), box);
 								}
 
 								// Generate await_push command
 								{
-									auto await_push_cmd = cdag.create<await_push_command>(nid, push_cmd);
+									auto await_push_cmd = m_cdag.create<await_push_command>(nid, push_cmd);
 
-									cdag.add_dependency(cmd, await_push_cmd, dependency_kind::true_dep, dependency_origin::dataflow);
+									m_cdag.add_dependency(cmd, await_push_cmd, dependency_kind::true_dep, dependency_origin::dataflow);
 									generate_anti_dependencies(tid, bid, node_buffer_last_writer, box, await_push_cmd);
 									generate_epoch_dependencies(await_push_cmd);
 
@@ -479,7 +481,7 @@ namespace detail {
 					const GridBox<3> box{GridPoint<3>{1, 1, 1}};
 					const subrange<3> sr{{}, {1, 1, 1}};
 
-					auto reduce_cmd = cdag.create<reduction_command>(nid, rid);
+					auto reduce_cmd = m_cdag.create<reduction_command>(nid, rid);
 
 					// pending_reduction_state with 1 operand is equivalent to a distributed_state with 1 operand. We make sure to always generate the
 					// latter since it allows us to avoid generating a no-op reduction command (and also gets rid of an edge case)
@@ -487,19 +489,19 @@ namespace detail {
 
 					for(auto source_nid : pending_reduction.operand_sources) {
 						if(source_nid == nid) {
-							add_dependencies_for_box(cdag, reduce_cmd, node_data.at(source_nid).buffer_last_writer.at(bid), box);
+							add_dependencies_for_box(m_cdag, reduce_cmd, m_node_data.at(source_nid).buffer_last_writer.at(bid), box);
 						} else {
-							auto push_cmd = cdag.create<push_command>(source_nid, bid, rid, nid, sr);
-							command_buffer_reads[push_cmd->get_cid()][bid] = GridRegion<3>::merge(command_buffer_reads[push_cmd->get_cid()][bid], box);
-							add_dependencies_for_box(cdag, push_cmd, node_data.at(source_nid).buffer_last_writer.at(bid), box);
+							auto push_cmd = m_cdag.create<push_command>(source_nid, bid, rid, nid, sr);
+							m_command_buffer_reads[push_cmd->get_cid()][bid] = GridRegion<3>::merge(m_command_buffer_reads[push_cmd->get_cid()][bid], box);
+							add_dependencies_for_box(m_cdag, push_cmd, m_node_data.at(source_nid).buffer_last_writer.at(bid), box);
 
-							auto await_push_cmd = cdag.create<await_push_command>(nid, push_cmd);
-							cdag.add_dependency(reduce_cmd, await_push_cmd, dependency_kind::true_dep, dependency_origin::dataflow);
+							auto await_push_cmd = m_cdag.create<await_push_command>(nid, push_cmd);
+							m_cdag.add_dependency(reduce_cmd, await_push_cmd, dependency_kind::true_dep, dependency_origin::dataflow);
 							generate_epoch_dependencies(await_push_cmd);
 						}
 					}
 
-					cdag.add_dependency(cmd, reduce_cmd, dependency_kind::true_dep, dependency_origin::dataflow);
+					m_cdag.add_dependency(cmd, reduce_cmd, dependency_kind::true_dep, dependency_origin::dataflow);
 
 					// Unless this task also writes the reduction buffer, the reduction command becomes the last writer
 					if(!std::any_of(required_modes.begin(), required_modes.end(), detail::access::mode_traits::is_producer)) {
@@ -519,15 +521,15 @@ namespace detail {
 			GridBox<3> box{GridPoint<3>{1, 1, 1}};
 			distributed_state state_after_reduction{cl::sycl::range<3>{1, 1, 1}};
 			state_after_reduction.region_sources.update_region(box, nids);
-			buffer_states.at(bid) = distributed_state{std::move(state_after_reduction)};
+			m_buffer_states.at(bid) = distributed_state{std::move(state_after_reduction)};
 		}
 
 		// If there is only one chunk/command, it already implicitly generates the final reduced value and the buffer does not need to be flagged as
 		// a pending reduction.
 		if(task_commands.size() > 1) {
 			for(auto rid : tsk.get_reductions()) {
-				auto bid = reduction_mngr.get_reduction(rid).output_buffer_id;
-				buffer_states.at(bid) = pending_reduction_state{rid, {}};
+				auto bid = m_reduction_mngr.get_reduction(rid).output_buffer_id;
+				m_buffer_states.at(bid) = pending_reduction_state{rid, {}};
 			}
 		}
 
@@ -537,7 +539,7 @@ namespace detail {
 			const auto& bid = std::get<1>(write);
 			const auto& region = std::get<2>(write);
 
-			auto& state = buffer_states.at(bid);
+			auto& state = m_buffer_states.at(bid);
 			if(auto* distributed = std::get_if<distributed_state>(&state)) {
 				distributed->region_sources.update_region(region, {nid});
 			} else if(auto* pending = std::get_if<pending_reduction_state>(&state)) {
@@ -552,7 +554,7 @@ namespace detail {
 			const auto& bid = std::get<1>(write);
 			const auto& region = std::get<2>(write);
 			const auto& cid = std::get<3>(write);
-			node_data.at(nid).buffer_last_writer.at(bid).update_region(region, {cid});
+			m_node_data.at(nid).buffer_last_writer.at(bid).update_region(region, {cid});
 		}
 
 		// As the last step, we determine potential "intra-task" race conditions.
@@ -561,11 +563,11 @@ namespace detail {
 		for(auto cmd : generated_pushes) {
 			const auto push_cmd = static_cast<push_command*>(cmd);
 			const auto last_writers =
-			    node_data.at(push_cmd->get_nid()).buffer_last_writer.at(push_cmd->get_bid()).get_region_values(subrange_to_grid_box(push_cmd->get_range()));
+			    m_node_data.at(push_cmd->get_nid()).buffer_last_writer.at(push_cmd->get_bid()).get_region_values(subrange_to_grid_box(push_cmd->get_range()));
 			for(auto& box_and_writer : last_writers) {
 				assert(!box_and_writer.first.empty());         // If we want to push it it cannot be empty
 				assert(box_and_writer.second != std::nullopt); // Exactly one command last wrote to that box
-				const auto writer_cmd = cdag.get(*box_and_writer.second);
+				const auto writer_cmd = m_cdag.get(*box_and_writer.second);
 				assert(writer_cmd != nullptr);
 
 				// We're only interested in writes that happen within the same task as the push
@@ -577,7 +579,7 @@ namespace detail {
 						assert(isa<await_push_command>(writer_cmd));
 						continue;
 					}
-					cdag.add_dependency(writer_cmd, push_cmd, dependency_kind::anti_dep, dependency_origin::dataflow);
+					m_cdag.add_dependency(writer_cmd, push_cmd, dependency_kind::anti_dep, dependency_origin::dataflow);
 				}
 			}
 		}
@@ -587,14 +589,14 @@ namespace detail {
 		const task_id tid = tsk.get_id();
 		if(tsk.get_side_effect_map().empty()) return; // skip the loop in the common case
 
-		for(const auto cmd : cdag.task_commands(tid)) {
-			auto& nd = node_data.at(cmd->get_nid());
+		for(const auto cmd : m_cdag.task_commands(tid)) {
+			auto& nd = m_node_data.at(cmd->get_nid());
 
 			for(const auto& side_effect : tsk.get_side_effect_map()) {
 				const auto [hoid, order] = side_effect;
 				if(const auto last_effect = nd.host_object_last_effects.find(hoid); last_effect != nd.host_object_last_effects.end()) {
 					// TODO once we have different side_effect_orders, their interaction will determine the dependency kind
-					cdag.add_dependency(cmd, cdag.get(last_effect->second), dependency_kind::true_dep, dependency_origin::dataflow);
+					m_cdag.add_dependency(cmd, m_cdag.get(last_effect->second), dependency_kind::true_dep, dependency_origin::dataflow);
 				}
 
 				// Simplification: If there are multiple chunks per node, we generate true-dependencies between them in an arbitrary order, when all we really
@@ -619,23 +621,23 @@ namespace detail {
 
 		if(const auto deps = cmd->get_dependencies();
 		    std::none_of(deps.begin(), deps.end(), [](const abstract_command::dependency d) { return d.kind == dependency_kind::true_dep; })) {
-			auto last_epoch = node_data.at(cmd->get_nid()).epoch_for_new_commands;
+			auto last_epoch = m_node_data.at(cmd->get_nid()).epoch_for_new_commands;
 			assert(cmd->get_cid() != last_epoch);
-			cdag.add_dependency(cmd, cdag.get(last_epoch), dependency_kind::true_dep, dependency_origin::last_epoch);
+			m_cdag.add_dependency(cmd, m_cdag.get(last_epoch), dependency_kind::true_dep, dependency_origin::last_epoch);
 		}
 	}
 
 	void graph_generator::prune_commands_before(const command_id min_epoch) {
-		if(min_epoch > min_epoch_last_pruned_before) {
-			cdag.erase_if([&](abstract_command* cmd) {
+		if(min_epoch > m_min_epoch_last_pruned_before) {
+			m_cdag.erase_if([&](abstract_command* cmd) {
 				if(cmd->get_cid() < min_epoch) {
 					assert(cmd->is_flushed() && "Cannot prune unflushed command");
-					command_buffer_reads.erase(cmd->get_cid());
+					m_command_buffer_reads.erase(cmd->get_cid());
 					return true;
 				}
 				return false;
 			});
-			min_epoch_last_pruned_before = min_epoch;
+			m_min_epoch_last_pruned_before = min_epoch;
 		}
 	}
 

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -63,7 +63,7 @@ namespace detail {
 	}
 
 	void graph_serializer::flush_dependency(abstract_command* dep) const {
-		// Special casing for AWAIT_PUSH commands: Also flush the corresponding PUSH.
+		// Special casing for await_push commands: Also flush the corresponding push.
 		// This is necessary as we would otherwise not reach it when starting from task commands alone
 		// (unless there exists an anti-dependency, which is not true in most cases).
 		if(isa<await_push_command>(dep)) {

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -9,7 +9,7 @@
 namespace celerity {
 namespace detail {
 
-	void graph_serializer::flush(task_id tid) { flush(cdag.task_commands(tid)); }
+	void graph_serializer::flush(task_id tid) { flush(m_cdag.task_commands(tid)); }
 
 	bool is_virtual_dependency(const abstract_command* const cmd) {
 		// The initial epoch command is not flushed, so including it in dependencies is not useful
@@ -111,7 +111,7 @@ namespace detail {
 		frame->num_dependencies = dependencies.size();
 		std::copy(dependencies.begin(), dependencies.end(), frame->dependencies);
 
-		flush_cb(cmd->get_nid(), std::move(frame));
+		m_flush_cb(cmd->get_nid(), std::move(frame));
 		cmd->mark_as_flushed();
 	}
 

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -15,7 +15,7 @@ namespace detail {
 
 	template <typename Dependency>
 	const char* dependency_style(const Dependency& dep) {
-		if(dep.kind == dependency_kind::ANTI_DEP) return "color=limegreen";
+		if(dep.kind == dependency_kind::anti_dep) return "color=limegreen";
 		switch(dep.origin) {
 		case dependency_origin::collective_group_serialization: return "color=blue";
 		case dependency_origin::execution_front: return "color=orange";
@@ -26,12 +26,12 @@ namespace detail {
 
 	std::string get_task_label(const task* tsk) {
 		switch(tsk->get_type()) {
-		case task_type::EPOCH: return fmt::format("Task {} (epoch)", tsk->get_id());
-		case task_type::HOST_COMPUTE: return fmt::format("Task {} (host-compute)", tsk->get_id());
-		case task_type::DEVICE_COMPUTE: return fmt::format("Task {} ({})", tsk->get_id(), tsk->get_debug_name());
-		case task_type::COLLECTIVE: return fmt::format("Task {} (collective #{})", tsk->get_id(), static_cast<size_t>(tsk->get_collective_group_id()));
-		case task_type::MASTER_NODE: return fmt::format("Task {} (master-node)", tsk->get_id());
-		case task_type::HORIZON: return fmt::format("Task {} (horizon)", tsk->get_id());
+		case task_type::epoch: return fmt::format("Task {} (epoch)", tsk->get_id());
+		case task_type::host_compute: return fmt::format("Task {} (host-compute)", tsk->get_id());
+		case task_type::device_compute: return fmt::format("Task {} ({})", tsk->get_id(), tsk->get_debug_name());
+		case task_type::collective: return fmt::format("Task {} (collective #{})", tsk->get_id(), static_cast<size_t>(tsk->get_collective_group_id()));
+		case task_type::master_node: return fmt::format("Task {} (master-node)", tsk->get_id());
+		case task_type::horizon: return fmt::format("Task {} (horizon)", tsk->get_id());
 		default: assert(false); return fmt::format("Task {} (unknown)", tsk->get_id());
 		}
 	}
@@ -63,22 +63,22 @@ namespace detail {
 	std::string get_command_label(const abstract_command* cmd) {
 		std::string label = fmt::format("[{}] Node {}:\\n", cmd->get_cid(), cmd->get_nid());
 		if(const auto ecmd = dynamic_cast<const epoch_command*>(cmd)) {
-			label += "EPOCH";
+			label += "epoch";
 			if(ecmd->get_epoch_action() == epoch_action::barrier) { label += " (barrier)"; }
 			if(ecmd->get_epoch_action() == epoch_action::shutdown) { label += " (shutdown)"; }
 		} else if(const auto xcmd = dynamic_cast<const execution_command*>(cmd)) {
-			label += fmt::format("EXECUTION {}\\n{}", subrange_to_grid_box(xcmd->get_execution_range()), cmd->debug_label);
+			label += fmt::format("execution {}\\n{}", subrange_to_grid_box(xcmd->get_execution_range()), cmd->debug_label);
 		} else if(const auto pcmd = dynamic_cast<const push_command*>(cmd)) {
 			if(pcmd->get_rid()) { label += fmt::format("(R{}) ", pcmd->get_rid()); }
-			label += fmt::format("PUSH {} to {}\\n {}", pcmd->get_bid(), pcmd->get_target(), subrange_to_grid_box(pcmd->get_range()));
+			label += fmt::format("push {} to {}\\n {}", pcmd->get_bid(), pcmd->get_target(), subrange_to_grid_box(pcmd->get_range()));
 		} else if(const auto apcmd = dynamic_cast<const await_push_command*>(cmd)) {
 			if(apcmd->get_source()->get_rid()) { label += fmt::format("(R{}) ", apcmd->get_source()->get_rid()); }
-			label += fmt::format("AWAIT PUSH {} from {}\\n {}", apcmd->get_source()->get_bid(), apcmd->get_source()->get_nid(),
+			label += fmt::format("await push {} from {}\\n {}", apcmd->get_source()->get_bid(), apcmd->get_source()->get_nid(),
 			    subrange_to_grid_box(apcmd->get_source()->get_range()));
 		} else if(const auto rrcmd = dynamic_cast<const reduction_command*>(cmd)) {
-			label += fmt::format("REDUCTION {}", rrcmd->get_rid());
+			label += fmt::format("reduction {}", rrcmd->get_rid());
 		} else if(const auto hcmd = dynamic_cast<const horizon_command*>(cmd)) {
-			label += "HORIZON";
+			label += "horizon";
 		} else {
 			assert(!"Unkown command");
 			return fmt::format("[{}] UNKNOWN\\n{}", cmd->get_cid(), cmd->debug_label);
@@ -127,7 +127,7 @@ namespace detail {
 				main_ss << fmt::format("{} -> {} [{}];", d.node->get_cid(), cmd->get_cid(), dependency_style(d));
 			}
 
-			// Add a dashed line to the corresponding PUSH
+			// Add a dashed line to the corresponding push
 			if(isa<await_push_command>(cmd)) {
 				auto await_push = static_cast<await_push_command*>(cmd);
 				main_ss << fmt::format("{} -> {} [style=dashed color=gray40];", await_push->get_source()->get_cid(), cmd->get_cid());

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -124,8 +124,8 @@ namespace detail {
 		// Initialize worker classes (but don't start them up yet)
 		buffer_mngr = std::make_unique<buffer_manager>(*d_queue, [this](buffer_manager::buffer_lifecycle_event event, buffer_id bid) {
 			switch(event) {
-			case buffer_manager::buffer_lifecycle_event::REGISTERED: handle_buffer_registered(bid); break;
-			case buffer_manager::buffer_lifecycle_event::UNREGISTERED: handle_buffer_unregistered(bid); break;
+			case buffer_manager::buffer_lifecycle_event::registered: handle_buffer_registered(bid); break;
+			case buffer_manager::buffer_lifecycle_event::unregistered: handle_buffer_unregistered(bid); break;
 			default: assert(false && "Unexpected buffer lifecycle event");
 			}
 		});

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -11,7 +11,7 @@ namespace detail {
 	abstract_scheduler::abstract_scheduler(graph_generator& ggen, graph_serializer& gsrlzr, size_t num_nodes)
 	    : ggen(ggen), gsrlzr(gsrlzr), num_nodes(num_nodes) {}
 
-	void abstract_scheduler::shutdown() { notify(scheduler_event_type::SHUTDOWN, 0); }
+	void abstract_scheduler::shutdown() { notify(scheduler_event_type::shutdown, 0); }
 
 	void abstract_scheduler::schedule() {
 		std::queue<scheduler_event> in_flight_events;
@@ -26,12 +26,12 @@ namespace detail {
 				const auto event = std::move(in_flight_events.front()); // NOLINT(performance-move-const-arg)
 				in_flight_events.pop();
 
-				if(event.type == scheduler_event_type::SHUTDOWN) {
+				if(event.type == scheduler_event_type::shutdown) {
 					assert(in_flight_events.empty());
 					return;
 				}
 
-				assert(event.type == scheduler_event_type::TASK_AVAILABLE);
+				assert(event.type == scheduler_event_type::task_available);
 
 				const task* tsk = event.tsk;
 				assert(tsk != nullptr);

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -9,7 +9,7 @@ namespace celerity {
 namespace detail {
 
 	abstract_scheduler::abstract_scheduler(graph_generator& ggen, graph_serializer& gsrlzr, size_t num_nodes)
-	    : ggen(ggen), gsrlzr(gsrlzr), num_nodes(num_nodes) {}
+	    : m_ggen(ggen), m_gsrlzr(gsrlzr), m_num_nodes(num_nodes) {}
 
 	void abstract_scheduler::shutdown() { notify(scheduler_event_type::shutdown, 0); }
 
@@ -17,9 +17,9 @@ namespace detail {
 		std::queue<scheduler_event> in_flight_events;
 		while(true) {
 			{
-				std::unique_lock lk(events_mutex);
-				events_cv.wait(lk, [this] { return !available_events.empty(); });
-				std::swap(available_events, in_flight_events);
+				std::unique_lock lk(m_events_mutex);
+				m_events_cv.wait(lk, [this] { return !m_available_events.empty(); });
+				std::swap(m_available_events, in_flight_events);
 			}
 
 			while(!in_flight_events.empty()) {
@@ -35,29 +35,29 @@ namespace detail {
 
 				const task* tsk = event.tsk;
 				assert(tsk != nullptr);
-				naive_split_transformer naive_split(num_nodes, num_nodes);
-				ggen.build_task(*tsk, {&naive_split});
-				gsrlzr.flush(tsk->get_id());
+				naive_split_transformer naive_split(m_num_nodes, m_num_nodes);
+				m_ggen.build_task(*tsk, {&naive_split});
+				m_gsrlzr.flush(tsk->get_id());
 			}
 		}
 	}
 
 	void abstract_scheduler::notify(scheduler_event_type type, const task* tsk) {
 		{
-			std::lock_guard lk(events_mutex);
-			available_events.push({type, tsk});
+			std::lock_guard lk(m_events_mutex);
+			m_available_events.push({type, tsk});
 		}
-		events_cv.notify_one();
+		m_events_cv.notify_one();
 	}
 
 	void scheduler::startup() {
-		worker_thread = std::thread(&scheduler::schedule, this);
-		set_thread_name(worker_thread.native_handle(), "cy-scheduler");
+		m_worker_thread = std::thread(&scheduler::schedule, this);
+		set_thread_name(m_worker_thread.native_handle(), "cy-scheduler");
 	}
 
 	void scheduler::shutdown() {
 		abstract_scheduler::shutdown();
-		if(worker_thread.joinable()) { worker_thread.join(); }
+		if(m_worker_thread.joinable()) { m_worker_thread.join(); }
 	}
 
 } // namespace detail

--- a/src/task.cc
+++ b/src/task.cc
@@ -7,7 +7,7 @@ namespace detail {
 
 	std::unordered_set<buffer_id> buffer_access_map::get_accessed_buffers() const {
 		std::unordered_set<buffer_id> result;
-		for(auto& [bid, _] : map) {
+		for(auto& [bid, _] : m_map) {
 			result.emplace(bid);
 		}
 		return result;
@@ -15,7 +15,7 @@ namespace detail {
 
 	std::unordered_set<cl::sycl::access::mode> buffer_access_map::get_access_modes(buffer_id bid) const {
 		std::unordered_set<cl::sycl::access::mode> result;
-		for(auto [first, last] = map.equal_range(bid); first != last; ++first) {
+		for(auto [first, last] = m_map.equal_range(bid); first != last; ++first) {
 			result.insert(first->second->get_access_mode());
 		}
 		return result;
@@ -34,8 +34,8 @@ namespace detail {
 
 	GridRegion<3> buffer_access_map::get_requirements_for_access(
 	    buffer_id bid, cl::sycl::access::mode mode, int kernel_dims, const subrange<3>& sr, const cl::sycl::range<3>& global_size) const {
-		auto [first, last] = map.equal_range(bid);
-		if(first == map.end()) { return {}; }
+		auto [first, last] = m_map.equal_range(bid);
+		if(first == m_map.end()) { return {}; }
 
 		GridRegion<3> result;
 		for(auto iter = first; iter != last; ++iter) {

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -7,40 +7,40 @@ namespace celerity {
 namespace detail {
 
 	task_manager::task_manager(size_t num_collective_nodes, host_queue* queue, reduction_manager* reduction_mgr)
-	    : num_collective_nodes(num_collective_nodes), queue(queue), reduction_mngr(reduction_mgr) {
+	    : m_num_collective_nodes(num_collective_nodes), m_queue(queue), m_reduction_mngr(reduction_mgr) {
 		// We manually generate the initial epoch task, which we treat as if it has been reached immediately.
-		auto reserve = task_buffer.reserve_task_entry(await_free_task_slot_callback());
-		task_buffer.put(std::move(reserve), task::make_epoch(initial_epoch_task, epoch_action::none));
+		auto reserve = m_task_buffer.reserve_task_entry(await_free_task_slot_callback());
+		m_task_buffer.put(std::move(reserve), task::make_epoch(initial_epoch_task, epoch_action::none));
 	}
 
 	void task_manager::add_buffer(buffer_id bid, const cl::sycl::range<3>& range, bool host_initialized) {
-		std::lock_guard<std::mutex> lock(task_mutex);
-		buffers_last_writers.emplace(bid, range);
-		if(host_initialized) { buffers_last_writers.at(bid).update_region(subrange_to_grid_box(subrange<3>({}, range)), epoch_for_new_tasks); }
+		std::lock_guard<std::mutex> lock(m_task_mutex);
+		m_buffers_last_writers.emplace(bid, range);
+		if(host_initialized) { m_buffers_last_writers.at(bid).update_region(subrange_to_grid_box(subrange<3>({}, range)), m_epoch_for_new_tasks); }
 	}
 
-	const task* task_manager::find_task(task_id tid) const { return task_buffer.find_task(tid); }
+	const task* task_manager::find_task(task_id tid) const { return m_task_buffer.find_task(tid); }
 
-	bool task_manager::has_task(task_id tid) const { return task_buffer.has_task(tid); }
+	bool task_manager::has_task(task_id tid) const { return m_task_buffer.has_task(tid); }
 
 	// Note that we assume tasks are not modified after their initial creation, which is why
 	// we don't need to worry about thread-safety after returning the task pointer.
-	const task* task_manager::get_task(task_id tid) const { return task_buffer.get_task(tid); }
+	const task* task_manager::get_task(task_id tid) const { return m_task_buffer.get_task(tid); }
 
 	std::optional<std::string> task_manager::print_graph(size_t max_nodes) const {
-		std::lock_guard<std::mutex> lock(task_mutex);
-		if(task_buffer.get_current_task_count() <= max_nodes) { return detail::print_task_graph(task_buffer); }
+		std::lock_guard<std::mutex> lock(m_task_mutex);
+		if(m_task_buffer.get_current_task_count() <= max_nodes) { return detail::print_task_graph(m_task_buffer); }
 		return std::nullopt;
 	}
 
 	void task_manager::notify_horizon_reached(task_id horizon_tid) {
-		assert(task_buffer.get_task(horizon_tid)->get_type() == task_type::horizon);
-		assert(!latest_horizon_reached || *latest_horizon_reached < horizon_tid);
-		assert(latest_epoch_reached.get() < horizon_tid);
+		assert(m_task_buffer.get_task(horizon_tid)->get_type() == task_type::horizon);
+		assert(!m_latest_horizon_reached || *m_latest_horizon_reached < horizon_tid);
+		assert(m_latest_epoch_reached.get() < horizon_tid);
 
-		if(latest_horizon_reached) { latest_epoch_reached.set(*latest_horizon_reached); }
+		if(m_latest_horizon_reached) { m_latest_epoch_reached.set(*m_latest_horizon_reached); }
 
-		latest_horizon_reached = horizon_tid;
+		m_latest_horizon_reached = horizon_tid;
 	}
 
 	void task_manager::notify_epoch_reached(task_id epoch_tid) {
@@ -48,14 +48,14 @@ namespace detail {
 		// latest_horizon_reached does not need synchronization (see definition), all other accesses are implicitly synchronized.
 
 		assert(get_task(epoch_tid)->get_type() == task_type::epoch);
-		assert(!latest_horizon_reached || *latest_horizon_reached < epoch_tid);
-		assert(latest_epoch_reached.get() < epoch_tid);
+		assert(!m_latest_horizon_reached || *m_latest_horizon_reached < epoch_tid);
+		assert(m_latest_epoch_reached.get() < epoch_tid);
 
-		latest_epoch_reached.set(epoch_tid);
-		latest_horizon_reached = std::nullopt; // Any non-applied horizon is now behind the epoch and will therefore never become an epoch itself
+		m_latest_epoch_reached.set(epoch_tid);
+		m_latest_horizon_reached = std::nullopt; // Any non-applied horizon is now behind the epoch and will therefore never become an epoch itself
 	}
 
-	void task_manager::await_epoch(task_id epoch) { latest_epoch_reached.await(epoch); }
+	void task_manager::await_epoch(task_id epoch) { m_latest_epoch_reached.await(epoch); }
 
 	GridRegion<3> get_requirements(task const& tsk, buffer_id bid, const std::vector<cl::sycl::access::mode> modes) {
 		const auto& access_map = tsk.get_buffer_access_map();
@@ -74,8 +74,8 @@ namespace detail {
 
 		auto buffers = access_map.get_accessed_buffers();
 		for(auto rid : tsk.get_reductions()) {
-			assert(reduction_mngr != nullptr);
-			buffers.emplace(reduction_mngr->get_reduction(rid).output_buffer_id);
+			assert(m_reduction_mngr != nullptr);
+			buffers.emplace(m_reduction_mngr->get_reduction(rid).output_buffer_id);
 		}
 
 		for(const auto bid : buffers) {
@@ -83,7 +83,7 @@ namespace detail {
 
 			std::optional<reduction_info> reduction;
 			for(auto maybe_rid : tsk.get_reductions()) {
-				auto maybe_reduction = reduction_mngr->get_reduction(maybe_rid);
+				auto maybe_reduction = m_reduction_mngr->get_reduction(maybe_rid);
 				if(maybe_reduction.output_buffer_id == bid) {
 					if(reduction) { throw std::runtime_error(fmt::format("Multiple reductions attempt to write buffer {} in task {}", bid, tsk.get_id())); }
 					reduction = maybe_reduction;
@@ -100,14 +100,14 @@ namespace detail {
 			    || (reduction.has_value() && reduction->initialize_from_buffer)) {
 				auto read_requirements = get_requirements(tsk, bid, {detail::access::consumer_modes.cbegin(), detail::access::consumer_modes.cend()});
 				if(reduction.has_value()) { read_requirements = GridRegion<3>::merge(read_requirements, GridRegion<3>{{1, 1, 1}}); }
-				const auto last_writers = buffers_last_writers.at(bid).get_region_values(read_requirements);
+				const auto last_writers = m_buffers_last_writers.at(bid).get_region_values(read_requirements);
 
 				for(auto& p : last_writers) {
 					// This indicates that the buffer is being used for the first time by this task, or all previous tasks also only read from it.
 					// A valid use case (i.e., not reading garbage) for this is when the buffer has been initialized using a host pointer.
 					if(p.second == std::nullopt) continue;
 					const task_id last_writer = *p.second;
-					add_dependency(tsk, *task_buffer.get_task(last_writer), dependency_kind::true_dep, dependency_origin::dataflow);
+					add_dependency(tsk, *m_task_buffer.get_task(last_writer), dependency_kind::true_dep, dependency_origin::dataflow);
 				}
 			}
 
@@ -117,10 +117,10 @@ namespace detail {
 				if(reduction.has_value()) { write_requirements = GridRegion<3>::merge(write_requirements, GridRegion<3>{{1, 1, 1}}); }
 				if(write_requirements.empty()) continue;
 
-				const auto last_writers = buffers_last_writers.at(bid).get_region_values(write_requirements);
+				const auto last_writers = m_buffers_last_writers.at(bid).get_region_values(write_requirements);
 				for(auto& p : last_writers) {
 					if(p.second == std::nullopt) continue;
-					task* last_writer = task_buffer.get_task(*p.second);
+					task* last_writer = m_task_buffer.get_task(*p.second);
 
 					// Determine anti-dependencies by looking at all the dependents of the last writing task
 					bool has_anti_dependents = false;
@@ -151,43 +151,43 @@ namespace detail {
 					}
 				}
 
-				buffers_last_writers.at(bid).update_region(write_requirements, tsk.get_id());
+				m_buffers_last_writers.at(bid).update_region(write_requirements, tsk.get_id());
 			}
 		}
 
 		for(const auto& side_effect : tsk.get_side_effect_map()) {
 			const auto [hoid, order] = side_effect;
-			if(const auto last_effect = host_object_last_effects.find(hoid); last_effect != host_object_last_effects.end()) {
-				add_dependency(tsk, *task_buffer.get_task(last_effect->second), dependency_kind::true_dep, dependency_origin::dataflow);
+			if(const auto last_effect = m_host_object_last_effects.find(hoid); last_effect != m_host_object_last_effects.end()) {
+				add_dependency(tsk, *m_task_buffer.get_task(last_effect->second), dependency_kind::true_dep, dependency_origin::dataflow);
 			}
-			host_object_last_effects.insert_or_assign(hoid, tsk.get_id());
+			m_host_object_last_effects.insert_or_assign(hoid, tsk.get_id());
 		}
 
 		if(auto cgid = tsk.get_collective_group_id(); cgid != 0) {
-			if(auto prev = last_collective_tasks.find(cgid); prev != last_collective_tasks.end()) {
-				add_dependency(tsk, *task_buffer.get_task(prev->second), dependency_kind::true_dep, dependency_origin::collective_group_serialization);
-				last_collective_tasks.erase(prev);
+			if(auto prev = m_last_collective_tasks.find(cgid); prev != m_last_collective_tasks.end()) {
+				add_dependency(tsk, *m_task_buffer.get_task(prev->second), dependency_kind::true_dep, dependency_origin::collective_group_serialization);
+				m_last_collective_tasks.erase(prev);
 			}
-			last_collective_tasks.emplace(cgid, tsk.get_id());
+			m_last_collective_tasks.emplace(cgid, tsk.get_id());
 		}
 
 		// Tasks without any other true-dependency must depend on the last epoch to ensure they cannot be re-ordered before the epoch
 		if(const auto deps = tsk.get_dependencies();
 		    std::none_of(deps.begin(), deps.end(), [](const task::dependency d) { return d.kind == dependency_kind::true_dep; })) {
-			add_dependency(tsk, *task_buffer.get_task(epoch_for_new_tasks), dependency_kind::true_dep, dependency_origin::last_epoch);
+			add_dependency(tsk, *m_task_buffer.get_task(m_epoch_for_new_tasks), dependency_kind::true_dep, dependency_origin::last_epoch);
 		}
 	}
 
 	task& task_manager::register_task_internal(task_ring_buffer::reservation&& reserve, std::unique_ptr<task> task) {
 		auto& task_ref = *task;
 		assert(task != nullptr);
-		task_buffer.put(std::move(reserve), std::move(task));
-		execution_front.insert(&task_ref);
+		m_task_buffer.put(std::move(reserve), std::move(task));
+		m_execution_front.insert(&task_ref);
 		return task_ref;
 	}
 
 	void task_manager::invoke_callbacks(const task* tsk) const {
-		for(const auto& cb : task_callbacks) {
+		for(const auto& cb : m_task_callbacks) {
 			cb(tsk);
 		}
 	}
@@ -195,48 +195,48 @@ namespace detail {
 	void task_manager::add_dependency(task& depender, task& dependee, dependency_kind kind, dependency_origin origin) {
 		assert(&depender != &dependee);
 		depender.add_dependency({&dependee, kind, origin});
-		execution_front.erase(&dependee);
-		max_pseudo_critical_path_length = std::max(max_pseudo_critical_path_length, depender.get_pseudo_critical_path_length());
+		m_execution_front.erase(&dependee);
+		m_max_pseudo_critical_path_length = std::max(m_max_pseudo_critical_path_length, depender.get_pseudo_critical_path_length());
 	}
 
 	task& task_manager::reduce_execution_front(task_ring_buffer::reservation&& reserve, std::unique_ptr<task> new_front) {
 		// add dependencies from a copy of the front to this task
-		const auto current_front = execution_front;
+		const auto current_front = m_execution_front;
 		for(task* front_task : current_front) {
 			add_dependency(*new_front, *front_task, dependency_kind::true_dep, dependency_origin::execution_front);
 		}
-		assert(execution_front.empty());
+		assert(m_execution_front.empty());
 		return register_task_internal(std::move(reserve), std::move(new_front));
 	}
 
 	void task_manager::set_epoch_for_new_tasks(const task_id epoch) {
 		// apply the new epoch to buffers_last_writers and last_collective_tasks data structs
-		for(auto& [_, buffer_region_map] : buffers_last_writers) {
+		for(auto& [_, buffer_region_map] : m_buffers_last_writers) {
 			buffer_region_map.apply_to_values([epoch](const std::optional<task_id> tid) -> std::optional<task_id> {
 				if(!tid) return tid;
 				return {std::max(epoch, *tid)};
 			});
 		}
-		for(auto& [cgid, tid] : last_collective_tasks) {
+		for(auto& [cgid, tid] : m_last_collective_tasks) {
 			tid = std::max(epoch, tid);
 		}
-		for(auto& [hoid, tid] : host_object_last_effects) {
+		for(auto& [hoid, tid] : m_host_object_last_effects) {
 			tid = std::max(epoch, tid);
 		}
 
-		epoch_for_new_tasks = epoch;
+		m_epoch_for_new_tasks = epoch;
 	}
 
 	task_id task_manager::generate_horizon_task() {
 		// we are probably overzealous in locking here
 		task* new_horizon;
 		{
-			auto reserve = task_buffer.reserve_task_entry(await_free_task_slot_callback());
-			std::lock_guard lock(task_mutex);
-			current_horizon_critical_path_length = max_pseudo_critical_path_length;
-			const auto previous_horizon = current_horizon;
-			current_horizon = reserve.get_tid();
-			new_horizon = &reduce_execution_front(std::move(reserve), task::make_horizon_task(*current_horizon));
+			auto reserve = m_task_buffer.reserve_task_entry(await_free_task_slot_callback());
+			std::lock_guard lock(m_task_mutex);
+			m_current_horizon_critical_path_length = m_max_pseudo_critical_path_length;
+			const auto previous_horizon = m_current_horizon;
+			m_current_horizon = reserve.get_tid();
+			new_horizon = &reduce_execution_front(std::move(reserve), task::make_horizon_task(*m_current_horizon));
 			if(previous_horizon) { set_epoch_for_new_tasks(*previous_horizon); }
 		}
 
@@ -249,14 +249,14 @@ namespace detail {
 		// we are probably overzealous in locking here
 		task* new_epoch;
 		{
-			auto reserve = task_buffer.reserve_task_entry(await_free_task_slot_callback());
-			std::lock_guard lock(task_mutex);
+			auto reserve = m_task_buffer.reserve_task_entry(await_free_task_slot_callback());
+			std::lock_guard lock(m_task_mutex);
 			const auto tid = reserve.get_tid();
 			new_epoch = &reduce_execution_front(std::move(reserve), task::make_epoch(tid, action));
 			compute_dependencies(*new_epoch);
 			set_epoch_for_new_tasks(new_epoch->get_id());
-			current_horizon = std::nullopt; // this horizon is now behind the epoch_for_new_tasks, so it will never become an epoch itself
-			current_horizon_critical_path_length = max_pseudo_critical_path_length; // the explicit epoch resets the need to create horizons
+			m_current_horizon = std::nullopt; // this horizon is now behind the epoch_for_new_tasks, so it will never become an epoch itself
+			m_current_horizon_critical_path_length = m_max_pseudo_critical_path_length; // the explicit epoch resets the need to create horizons
 		}
 
 		// it's important that we don't hold the lock while doing this
@@ -266,10 +266,10 @@ namespace detail {
 
 	task_id task_manager::get_first_in_flight_epoch() const {
 		task_id current_horizon = 0;
-		task_id latest_epoch = latest_epoch_reached.get();
+		task_id latest_epoch = m_latest_epoch_reached.get();
 		// we need either one epoch or two horizons that have yet to be executed
 		// so that it is possible for task slots to be freed in the future
-		for(const auto& tsk : task_buffer) {
+		for(const auto& tsk : m_task_buffer) {
 			if(tsk->get_id() <= latest_epoch) continue;
 			if(tsk->get_type() == task_type::epoch) {
 				return tsk->get_id();
@@ -283,15 +283,15 @@ namespace detail {
 
 	task_ring_buffer::wait_callback task_manager::await_free_task_slot_callback() {
 		return [&](task_id previous_free_tid) {
-			if(get_first_in_flight_epoch() == latest_epoch_reached.get()) {
+			if(get_first_in_flight_epoch() == m_latest_epoch_reached.get()) {
 				// verify that the epoch didn't get reached between the invocation of the callback and the in flight check
-				if(latest_epoch_reached.get() < previous_free_tid + 1) {
+				if(m_latest_epoch_reached.get() < previous_free_tid + 1) {
 					throw std::runtime_error("Exhausted task slots with no horizons or epochs in flight."
 					                         "\nLikely due to generating a very large number of tasks with no dependencies.");
 				}
 			}
-			task_id reached_epoch = latest_epoch_reached.await(previous_free_tid + 1);
-			task_buffer.delete_up_to(reached_epoch);
+			task_id reached_epoch = m_latest_epoch_reached.await(previous_free_tid + 1);
+			m_task_buffer.delete_up_to(reached_epoch);
 		};
 	}
 

--- a/src/user_bench.cc
+++ b/src/user_bench.cc
@@ -11,13 +11,13 @@ namespace experimental {
 	namespace bench {
 		namespace detail {
 			user_benchmarker::~user_benchmarker() {
-				while(!sections.empty()) {
-					const auto sec = sections.top();
+				while(!m_sections.empty()) {
+					const auto sec = m_sections.top();
 					end_section(sec.name);
 				}
 			}
 
-			user_benchmarker::user_benchmarker(config& cfg, node_id this_nid) : this_nid(this_nid) {
+			user_benchmarker::user_benchmarker(config& cfg, node_id this_nid) : m_this_nid(this_nid) {
 				if(static_cast<double>(bench_clock::period::num) / bench_clock::period::den > static_cast<double>(std::micro::num) / std::micro::den) {
 					CELERITY_WARN("Available clock does not have sufficient precision");
 				}
@@ -26,16 +26,16 @@ namespace experimental {
 			user_benchmarker& get_user_benchmarker() { return celerity::detail::runtime::get_instance().get_user_benchmarker(); }
 
 			void user_benchmarker::begin_section(std::string name) {
-				std::lock_guard lk{mutex};
-				section sec = {next_section_id++, std::move(name), bench_clock::now()};
+				std::lock_guard lk{m_mutex};
+				section sec = {m_next_section_id++, std::move(name), bench_clock::now()};
 				log("Begin section {} \"{}\"", sec.id, sec.name);
-				sections.push(std::move(sec));
+				m_sections.push(std::move(sec));
 			}
 
 			void user_benchmarker::end_section(const std::string& name) {
-				std::lock_guard lk{mutex};
-				const auto sec = sections.top();
-				sections.pop();
+				std::lock_guard lk{m_mutex};
+				const auto sec = m_sections.top();
+				m_sections.pop();
 				if(sec.name != name) { throw std::runtime_error(fmt::format("Section name '{}' does not match last section '{}'", name, sec.name)); }
 				const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(bench_clock::now() - sec.start);
 				log("End section {} \"{}\" after {}us", sec.id, name, duration.count());

--- a/src/worker_job.cc
+++ b/src/worker_job.cc
@@ -17,33 +17,33 @@ namespace detail {
 	// --------------------------------------------------------------------------------------------------------------------
 
 	void worker_job::update() {
-		CELERITY_LOG_SET_SCOPED_CTX(lctx);
-		assert(running && !done);
+		CELERITY_LOG_SET_SCOPED_CTX(m_lctx);
+		assert(m_running && !m_done);
 		const auto before = std::chrono::steady_clock::now();
-		done = execute(pkg);
+		m_done = execute(m_pkg);
 
 		// TODO: We may want to make benchmarking optional with a macro
 		const auto dt = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - before);
-		bench_sum_execution_time += dt;
-		bench_sample_count++;
-		if(dt < bench_min) bench_min = dt;
-		if(dt > bench_max) bench_max = dt;
+		m_bench_sum_execution_time += dt;
+		m_bench_sample_count++;
+		if(dt < m_bench_min) m_bench_min = dt;
+		if(dt > m_bench_max) m_bench_max = dt;
 
-		if(done) {
-			const auto bench_avg = bench_sum_execution_time.count() / bench_sample_count;
-			const auto execution_time = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - start_time).count();
-			CELERITY_DEBUG("Job finished after {}us. Polling avg={}, min={}, max={}, samples={}", execution_time, bench_avg, bench_min.count(),
-			    bench_max.count(), bench_sample_count);
+		if(m_done) {
+			const auto bench_avg = m_bench_sum_execution_time.count() / m_bench_sample_count;
+			const auto execution_time = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - m_start_time).count();
+			CELERITY_DEBUG("Job finished after {}us. Polling avg={}, min={}, max={}, samples={}", execution_time, bench_avg, m_bench_min.count(),
+			    m_bench_max.count(), m_bench_sample_count);
 		}
 	}
 
 	void worker_job::start() {
-		CELERITY_LOG_SET_SCOPED_CTX(lctx);
-		assert(!running);
-		running = true;
+		CELERITY_LOG_SET_SCOPED_CTX(m_lctx);
+		assert(!m_running);
+		m_running = true;
 
-		CELERITY_DEBUG("Starting job: {}", get_description(pkg));
-		start_time = std::chrono::steady_clock::now();
+		CELERITY_DEBUG("Starting job: {}", get_description(m_pkg));
+		m_start_time = std::chrono::steady_clock::now();
 	}
 
 	// --------------------------------------------------------------------------------------------------------------------
@@ -54,7 +54,7 @@ namespace detail {
 
 	bool horizon_job::execute(const command_pkg& pkg) {
 		const auto data = std::get<horizon_data>(pkg.data);
-		task_mngr.notify_horizon_reached(data.tid);
+		m_task_mngr.notify_horizon_reached(data.tid);
 		return true;
 	};
 
@@ -66,13 +66,13 @@ namespace detail {
 
 	bool epoch_job::execute(const command_pkg& pkg) {
 		const auto data = std::get<epoch_data>(pkg.data);
-		action = data.action;
+		m_action = data.action;
 
 		// This barrier currently enables profiling Celerity programs on a cluster by issuing a queue.slow_full_sync() and
 		// then observing the execution times of barriers. TODO remove this once we have a better profiling workflow.
-		if(action == epoch_action::barrier) { MPI_Barrier(MPI_COMM_WORLD); }
+		if(m_action == epoch_action::barrier) { MPI_Barrier(MPI_COMM_WORLD); }
 
-		task_mngr.notify_epoch_reached(data.tid);
+		m_task_mngr.notify_epoch_reached(data.tid);
 		return true;
 	};
 
@@ -86,8 +86,8 @@ namespace detail {
 	}
 
 	bool await_push_job::execute(const command_pkg& pkg) {
-		if(data_handle == nullptr) { data_handle = btm.await_push(pkg); }
-		return data_handle->complete;
+		if(m_data_handle == nullptr) { m_data_handle = m_btm.await_push(pkg); }
+		return m_data_handle->complete;
 	}
 
 
@@ -101,20 +101,20 @@ namespace detail {
 	}
 
 	bool push_job::execute(const command_pkg& pkg) {
-		if(data_handle == nullptr) {
+		if(m_data_handle == nullptr) {
 			const auto data = std::get<push_data>(pkg.data);
 			// Getting buffer data from the buffer manager may incur a host-side buffer reallocation.
 			// If any other tasks are currently using this buffer for reading, we run into problems.
 			// To avoid this, we use a very crude buffer locking mechanism for now.
 			// FIXME: Get rid of this, replace with finer grained approach.
-			if(buffer_mngr.is_locked(data.bid)) { return false; }
+			if(m_buffer_mngr.is_locked(data.bid)) { return false; }
 
 			CELERITY_TRACE("Submit buffer to BTM");
-			data_handle = btm.push(pkg);
+			m_data_handle = m_btm.push(pkg);
 			CELERITY_TRACE("Buffer submitted to BTM");
 		}
 
-		return data_handle->complete;
+		return m_data_handle->complete;
 	}
 
 	// --------------------------------------------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ namespace detail {
 
 	bool reduction_job::execute(const command_pkg& pkg) {
 		const auto& data = std::get<reduction_data>(pkg.data);
-		rm.finish_reduction(data.rid);
+		m_rm.finish_reduction(data.rid);
 		return true;
 	}
 
@@ -139,34 +139,34 @@ namespace detail {
 	}
 
 	bool host_execute_job::execute(const command_pkg& pkg) {
-		if(!submitted) {
+		if(!m_submitted) {
 			const auto data = std::get<execution_data>(pkg.data);
 
-			auto tsk = task_mngr.get_task(data.tid);
+			auto tsk = m_task_mngr.get_task(data.tid);
 			assert(tsk->get_execution_target() == execution_target::host);
 			assert(!data.initialize_reductions); // For now, we do not support reductions in host tasks
 
-			if(!buffer_mngr.try_lock(pkg.cid, tsk->get_buffer_access_map().get_accessed_buffers())) { return false; }
+			if(!m_buffer_mngr.try_lock(pkg.cid, tsk->get_buffer_access_map().get_accessed_buffers())) { return false; }
 
 			CELERITY_TRACE("Execute live-pass, scheduling host task in thread pool");
 
 			// Note that for host tasks, there is no indirection through a queue->submit step like there is for SYCL tasks. The CGF is executed directly,
 			// which then schedules task in the thread pool through the host_queue.
 			auto& cgf = tsk->get_command_group();
-			live_pass_host_handler cgh(tsk, data.sr, data.initialize_reductions, queue);
+			live_pass_host_handler cgh(tsk, data.sr, data.initialize_reductions, m_queue);
 			cgf(cgh);
-			future = cgh.into_future();
+			m_future = cgh.into_future();
 
-			assert(future.valid());
-			submitted = true;
+			assert(m_future.valid());
+			m_submitted = true;
 			CELERITY_TRACE("Submitted host task to thread pool");
 		}
 
-		assert(future.valid());
-		if(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-			buffer_mngr.unlock(pkg.cid);
+		assert(m_future.valid());
+		if(m_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+			m_buffer_mngr.unlock(pkg.cid);
 
-			auto info = future.get();
+			auto info = m_future.get();
 			CELERITY_TRACE("Delta time submit -> start: {}us, start -> end: {}us",
 			    std::chrono::duration_cast<std::chrono::microseconds>(info.start_time - info.submit_time).count(),
 			    std::chrono::duration_cast<std::chrono::microseconds>(info.end_time - info.start_time).count());
@@ -185,42 +185,42 @@ namespace detail {
 	}
 
 	bool device_execute_job::execute(const command_pkg& pkg) {
-		if(!submitted) {
+		if(!m_submitted) {
 			const auto data = std::get<execution_data>(pkg.data);
-			auto tsk = task_mngr.get_task(data.tid);
+			auto tsk = m_task_mngr.get_task(data.tid);
 			assert(tsk->get_execution_target() == execution_target::device);
 
-			if(!buffer_mngr.try_lock(pkg.cid, tsk->get_buffer_access_map().get_accessed_buffers())) { return false; }
+			if(!m_buffer_mngr.try_lock(pkg.cid, tsk->get_buffer_access_map().get_accessed_buffers())) { return false; }
 
 			CELERITY_TRACE("Execute live-pass, submit kernel to SYCL");
 
-			live_pass_device_handler cgh(tsk, data.sr, data.initialize_reductions, queue);
+			live_pass_device_handler cgh(tsk, data.sr, data.initialize_reductions, m_queue);
 			auto& cgf = tsk->get_command_group();
 			cgf(cgh);
-			event = cgh.get_submission_event();
+			m_event = cgh.get_submission_event();
 
-			submitted = true;
+			m_submitted = true;
 			CELERITY_TRACE("Kernel submitted to SYCL");
 		}
 
-		const auto status = event.get_info<cl::sycl::info::event::command_execution_status>();
+		const auto status = m_event.get_info<cl::sycl::info::event::command_execution_status>();
 		if(status == cl::sycl::info::event_command_status::complete) {
-			buffer_mngr.unlock(pkg.cid);
+			m_buffer_mngr.unlock(pkg.cid);
 
 			const auto data = std::get<execution_data>(pkg.data);
-			auto tsk = task_mngr.get_task(data.tid);
+			auto tsk = m_task_mngr.get_task(data.tid);
 			for(auto rid : tsk->get_reductions()) {
-				auto reduction = reduction_mngr.get_reduction(rid);
-				const auto element_size = buffer_mngr.get_buffer_info(reduction.output_buffer_id).element_size;
+				auto reduction = m_reduction_mngr.get_reduction(rid);
+				const auto element_size = m_buffer_mngr.get_buffer_info(reduction.output_buffer_id).element_size;
 				auto operand = make_uninitialized_payload<std::byte>(element_size);
-				buffer_mngr.get_buffer_data(reduction.output_buffer_id, {{}, {1, 1, 1}}, operand.get_pointer());
-				reduction_mngr.push_overlapping_reduction_data(rid, local_nid, std::move(operand));
+				m_buffer_mngr.get_buffer_data(reduction.output_buffer_id, {{}, {1, 1, 1}}, operand.get_pointer());
+				m_reduction_mngr.push_overlapping_reduction_data(rid, m_local_nid, std::move(operand));
 			}
 
-			if(queue.is_profiling_enabled()) {
-				const auto submit = std::chrono::nanoseconds(event.get_profiling_info<cl::sycl::info::event_profiling::command_submit>());
-				const auto start = std::chrono::nanoseconds(event.get_profiling_info<cl::sycl::info::event_profiling::command_start>());
-				const auto end = std::chrono::nanoseconds(event.get_profiling_info<cl::sycl::info::event_profiling::command_end>());
+			if(m_queue.is_profiling_enabled()) {
+				const auto submit = std::chrono::nanoseconds(m_event.get_profiling_info<cl::sycl::info::event_profiling::command_submit>());
+				const auto start = std::chrono::nanoseconds(m_event.get_profiling_info<cl::sycl::info::event_profiling::command_start>());
+				const auto end = std::chrono::nanoseconds(m_event.get_profiling_info<cl::sycl::info::event_profiling::command_end>());
 
 				CELERITY_TRACE("Delta time submit -> start: {}us, start -> end: {}us",
 				    std::chrono::duration_cast<std::chrono::microseconds>(start - submit).count(),

--- a/src/worker_job.cc
+++ b/src/worker_job.cc
@@ -50,7 +50,7 @@ namespace detail {
 	// --------------------------------------------------- HORIZON --------------------------------------------------------
 	// --------------------------------------------------------------------------------------------------------------------
 
-	std::string horizon_job::get_description(const command_pkg& pkg) { return "HORIZON"; }
+	std::string horizon_job::get_description(const command_pkg& pkg) { return "horizon"; }
 
 	bool horizon_job::execute(const command_pkg& pkg) {
 		const auto data = std::get<horizon_data>(pkg.data);
@@ -62,7 +62,7 @@ namespace detail {
 	// ---------------------------------------------------- EPOCH ---------------------------------------------------------
 	// --------------------------------------------------------------------------------------------------------------------
 
-	std::string epoch_job::get_description(const command_pkg& pkg) { return "EPOCH"; }
+	std::string epoch_job::get_description(const command_pkg& pkg) { return "epoch"; }
 
 	bool epoch_job::execute(const command_pkg& pkg) {
 		const auto data = std::get<epoch_data>(pkg.data);
@@ -82,7 +82,7 @@ namespace detail {
 
 	std::string await_push_job::get_description(const command_pkg& pkg) {
 		const auto data = std::get<await_push_data>(pkg.data);
-		return fmt::format("AWAIT PUSH {} of buffer {} by node {}", data.sr, static_cast<size_t>(data.bid), static_cast<size_t>(data.source));
+		return fmt::format("await push {} of buffer {} by node {}", data.sr, static_cast<size_t>(data.bid), static_cast<size_t>(data.source));
 	}
 
 	bool await_push_job::execute(const command_pkg& pkg) {
@@ -97,7 +97,7 @@ namespace detail {
 
 	std::string push_job::get_description(const command_pkg& pkg) {
 		const auto data = std::get<push_data>(pkg.data);
-		return fmt::format("PUSH {} of buffer {} to node {}", data.sr, static_cast<size_t>(data.bid), static_cast<size_t>(data.target));
+		return fmt::format("push {} of buffer {} to node {}", data.sr, static_cast<size_t>(data.bid), static_cast<size_t>(data.target));
 	}
 
 	bool push_job::execute(const command_pkg& pkg) {
@@ -127,7 +127,7 @@ namespace detail {
 		return true;
 	}
 
-	std::string reduction_job::get_description(const command_pkg& pkg) { return "REDUCTION"; }
+	std::string reduction_job::get_description(const command_pkg& pkg) { return "reduction"; }
 
 	// --------------------------------------------------------------------------------------------------------------------
 	// --------------------------------------------------- HOST_EXECUTE ---------------------------------------------------
@@ -143,7 +143,7 @@ namespace detail {
 			const auto data = std::get<execution_data>(pkg.data);
 
 			auto tsk = task_mngr.get_task(data.tid);
-			assert(tsk->get_execution_target() == execution_target::HOST);
+			assert(tsk->get_execution_target() == execution_target::host);
 			assert(!data.initialize_reductions); // For now, we do not support reductions in host tasks
 
 			if(!buffer_mngr.try_lock(pkg.cid, tsk->get_buffer_access_map().get_accessed_buffers())) { return false; }
@@ -188,7 +188,7 @@ namespace detail {
 		if(!submitted) {
 			const auto data = std::get<execution_data>(pkg.data);
 			auto tsk = task_mngr.get_task(data.tid);
-			assert(tsk->get_execution_target() == execution_target::DEVICE);
+			assert(tsk->get_execution_target() == execution_target::device);
 
 			if(!buffer_mngr.try_lock(pkg.cid, tsk->get_buffer_access_map().get_accessed_buffers())) { return false; }
 

--- a/test/accessor_tests.cc
+++ b/test/accessor_tests.cc
@@ -203,7 +203,7 @@ namespace detail {
 			}
 		}
 
-		typename accessor_fixture<Dims>::access_target tgt = accessor_fixture<Dims>::access_target::HOST;
+		typename accessor_fixture<Dims>::access_target tgt = accessor_fixture<Dims>::access_target::host;
 		bool acc_check = accessor_fixture<Dims>::template buffer_reduce<size_t, Dims, class check_multi_dim_accessor<Dims>>(bid, tgt, range_cast<Dims>(range),
 		    {}, true,
 		    [range = range_cast<Dims>(range)](cl::sycl::id<Dims> idx, bool current, size_t value) { return current && value == get_linear_index(range, idx); });

--- a/test/accessor_tests.cc
+++ b/test/accessor_tests.cc
@@ -19,7 +19,7 @@ namespace detail {
 	struct accessor_testspy {
 		template <typename CelerityAccessor>
 		static auto& get_sycl_accessor(CelerityAccessor& celerity_acc) {
-			return celerity_acc.sycl_accessor;
+			return celerity_acc.m_sycl_accessor;
 		}
 	};
 

--- a/test/benchmark_reporters.cc
+++ b/test/benchmark_reporters.cc
@@ -103,7 +103,7 @@ class benchmark_csv_reporter : public benchmark_reporter_base {
   public:
 	using benchmark_reporter_base::benchmark_reporter_base;
 
-	static std::string getDescription() { return "Reporter for benchmarks in CSV format"; }
+	static std::string getDescription() { return "Reporter for benchmarks in CSV format"; } // NOLINT(readability-identifier-naming)
 
 	void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
 		benchmark_reporter_base::testRunStarting(testRunInfo);
@@ -198,7 +198,7 @@ class benchmark_md_reporter : public benchmark_reporter_base {
   public:
 	using benchmark_reporter_base::benchmark_reporter_base;
 
-	static std::string getDescription() { return "Generates a Markdown report for benchmark results"; }
+	static std::string getDescription() { return "Generates a Markdown report for benchmark results"; } // NOLINT(readability-identifier-naming)
 
 	void testRunStarting(Catch::TestRunInfo const& testRunInfo) override {
 		benchmark_reporter_base::testRunStarting(testRunInfo);

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -28,7 +28,7 @@ TEMPLATE_TEST_CASE_SIG("benchmark intrusive graph dependency handling with N nod
 		bench_graph_node n0;
 		bench_graph_node nodes[N];
 		for(int i = 0; i < N; ++i) {
-			n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+			n0.add_dependency({&nodes[i], dependency_kind::true_dep, dependency_origin::dataflow});
 		}
 		return n0.get_dependencies();
 	};
@@ -37,7 +37,7 @@ TEMPLATE_TEST_CASE_SIG("benchmark intrusive graph dependency handling with N nod
 	bench_graph_node nodes[N];
 	BENCHMARK("adding and removing dependencies") {
 		for(int i = 0; i < N; ++i) {
-			n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+			n0.add_dependency({&nodes[i], dependency_kind::true_dep, dependency_origin::dataflow});
 		}
 		for(int i = 0; i < N; ++i) {
 			n0.remove_dependency(&nodes[i]);
@@ -46,7 +46,7 @@ TEMPLATE_TEST_CASE_SIG("benchmark intrusive graph dependency handling with N nod
 	};
 
 	for(int i = 0; i < N; ++i) {
-		n0.add_dependency({&nodes[i], dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+		n0.add_dependency({&nodes[i], dependency_kind::true_dep, dependency_origin::dataflow});
 	}
 	BENCHMARK("checking for dependencies") {
 		int d = 0;
@@ -332,7 +332,7 @@ template <typename BenchmarkContext>
 }
 
 // Artificial: Generate expanding or contracting tree of tasks, with gather/scatter communication
-enum class tree_topology { Expanding, Contracting };
+enum class tree_topology { expanding, contracting };
 
 template <tree_topology Topology, typename BenchmarkContext>
 [[gnu::noinline]] BenchmarkContext&& generate_tree_graph(BenchmarkContext&& ctx, const size_t target_num_tasks) {
@@ -340,7 +340,7 @@ template <tree_topology Topology, typename BenchmarkContext>
 	test_utils::mock_buffer<2> buf = ctx.mbf.create_buffer(range<2>{ctx.num_nodes, tree_breadth}, true /* host initialized */);
 
 	for(size_t exp_step = 1; exp_step <= tree_breadth; exp_step *= 2) {
-		const auto sr_range = Topology == tree_topology::Expanding ? tree_breadth / exp_step : exp_step;
+		const auto sr_range = Topology == tree_topology::expanding ? tree_breadth / exp_step : exp_step;
 		for(size_t sr_off = 0; sr_off < tree_breadth; sr_off += sr_range) {
 			ctx.create_task(range<1>{ctx.num_nodes}, [&](handler& cgh) {
 				buf.get_access<access_mode::read>(cgh, [=](chunk<1> ck) { return subrange<2>{{0, sr_off}, {ck.global_size[0], sr_range}}; });
@@ -422,8 +422,8 @@ template <typename BenchmarkContextFactory>
 void run_benchmarks(BenchmarkContextFactory&& make_ctx) {
 	BENCHMARK("soup topology") { generate_soup_graph(make_ctx(), 100); };
 	BENCHMARK("chain topology") { generate_chain_graph(make_ctx(), 30); };
-	BENCHMARK("expanding tree topology") { generate_tree_graph<tree_topology::Expanding>(make_ctx(), 30); };
-	BENCHMARK("contracting tree topology") { generate_tree_graph<tree_topology::Contracting>(make_ctx(), 30); };
+	BENCHMARK("expanding tree topology") { generate_tree_graph<tree_topology::expanding>(make_ctx(), 30); };
+	BENCHMARK("contracting tree topology") { generate_tree_graph<tree_topology::contracting>(make_ctx(), 30); };
 	BENCHMARK("wave_sim topology") { generate_wave_sim_graph(make_ctx(), 50); };
 	BENCHMARK("jacobi topology") { generate_jacobi_graph(make_ctx(), 50); };
 }
@@ -457,8 +457,8 @@ template <typename BenchmarkContextFactory, typename BenchmarkContextConsumer>
 void debug_graphs(BenchmarkContextFactory&& make_ctx, BenchmarkContextConsumer&& debug_ctx) {
 	debug_ctx(generate_soup_graph(make_ctx(), 10));
 	debug_ctx(generate_chain_graph(make_ctx(), 5));
-	debug_ctx(generate_tree_graph<tree_topology::Expanding>(make_ctx(), 7));
-	debug_ctx(generate_tree_graph<tree_topology::Contracting>(make_ctx(), 7));
+	debug_ctx(generate_tree_graph<tree_topology::expanding>(make_ctx(), 7));
+	debug_ctx(generate_tree_graph<tree_topology::contracting>(make_ctx(), 7));
 	debug_ctx(generate_wave_sim_graph(make_ctx(), 2));
 	debug_ctx(generate_jacobi_graph(make_ctx(), 5));
 }

--- a/test/buffer_manager_test_utils.h
+++ b/test/buffer_manager_test_utils.h
@@ -19,7 +19,7 @@ namespace test_utils {
 
 	class buffer_manager_fixture : public device_queue_fixture {
 	  public:
-		enum class access_target { HOST, DEVICE };
+		enum class access_target { host, device };
 
 		void initialize(detail::buffer_manager::buffer_lifecycle_callback cb = [](detail::buffer_manager::buffer_lifecycle_event, detail::buffer_id) {}) {
 			assert(!bm);
@@ -33,13 +33,13 @@ namespace test_utils {
 		}
 
 		static access_target get_other_target(access_target tgt) {
-			if(tgt == access_target::HOST) return access_target::DEVICE;
-			return access_target::HOST;
+			if(tgt == access_target::host) return access_target::device;
+			return access_target::host;
 		}
 
 		template <typename DataT, int Dims>
 		cl::sycl::range<Dims> get_backing_buffer_range(detail::buffer_id bid, access_target tgt, cl::sycl::range<Dims> range, cl::sycl::id<Dims> offset) {
-			if(tgt == access_target::HOST) {
+			if(tgt == access_target::host) {
 				auto info = bm->get_host_buffer<DataT, Dims>(bid, cl::sycl::access::mode::read, detail::range_cast<3>(range), detail::id_cast<3>(offset));
 				return info.buffer.get_range();
 			}
@@ -52,7 +52,7 @@ namespace test_utils {
 			const auto range3 = detail::range_cast<3>(range);
 			const auto offset3 = detail::id_cast<3>(offset);
 
-			if(tgt == access_target::HOST) {
+			if(tgt == access_target::host) {
 				auto info = bm->get_host_buffer<DataT, Dims>(bid, Mode, range3, offset3);
 				const auto buf_range = detail::range_cast<3>(info.buffer.get_range());
 				for(size_t i = offset3[0]; i < offset3[0] + range3[0]; ++i) {
@@ -67,7 +67,7 @@ namespace test_utils {
 				}
 			}
 
-			if(tgt == access_target::DEVICE) {
+			if(tgt == access_target::device) {
 				auto info = bm->get_device_buffer<DataT, Dims>(bid, Mode, range3, offset3);
 				const auto buf_offset = info.offset;
 				get_device_queue()
@@ -88,7 +88,7 @@ namespace test_utils {
 			const auto range3 = detail::range_cast<3>(range);
 			const auto offset3 = detail::id_cast<3>(offset);
 
-			if(tgt == access_target::HOST) {
+			if(tgt == access_target::host) {
 				auto info = bm->get_host_buffer<DataT, Dims>(bid, cl::sycl::access::mode::read, range3, offset3);
 				const auto buf_range = detail::range_cast<3>(info.buffer.get_range());
 				ReduceT result = init;

--- a/test/buffer_manager_test_utils.h
+++ b/test/buffer_manager_test_utils.h
@@ -8,8 +8,8 @@ namespace detail {
 	struct buffer_manager_testspy {
 		template <typename DataT, int Dims>
 		static buffer_manager::access_info<DataT, Dims, device_buffer> get_device_buffer(buffer_manager& bm, buffer_id bid) {
-			std::unique_lock lock(bm.mutex);
-			auto& buf = bm.buffers.at(bid).device_buf;
+			std::unique_lock lock(bm.m_mutex);
+			auto& buf = bm.m_buffers.at(bid).device_buf;
 			return {dynamic_cast<device_buffer_storage<DataT, Dims>*>(buf.storage.get())->get_device_buffer(), id_cast<Dims>(buf.offset)};
 		}
 	};

--- a/test/buffer_manager_tests.cc
+++ b/test/buffer_manager_tests.cc
@@ -66,7 +66,7 @@ namespace detail {
 		REQUIRE(bm.get_buffer_info(0).range == cl::sycl::range<3>{1024, 1, 1});
 		REQUIRE(bm.get_buffer_info(0).is_host_initialized == false);
 		REQUIRE(cb_calls.size() == 1);
-		REQUIRE(cb_calls[0] == std::make_pair(buffer_manager::buffer_lifecycle_event::REGISTERED, buffer_id(0)));
+		REQUIRE(cb_calls[0] == std::make_pair(buffer_manager::buffer_lifecycle_event::registered, buffer_id(0)));
 
 		std::vector<float> host_buf(5 * 6 * 7);
 		bm.register_buffer<float, 3>({5, 6, 7}, host_buf.data());
@@ -74,11 +74,11 @@ namespace detail {
 		REQUIRE(bm.get_buffer_info(1).range == cl::sycl::range<3>{5, 6, 7});
 		REQUIRE(bm.get_buffer_info(1).is_host_initialized == true);
 		REQUIRE(cb_calls.size() == 2);
-		REQUIRE(cb_calls[1] == std::make_pair(buffer_manager::buffer_lifecycle_event::REGISTERED, buffer_id(1)));
+		REQUIRE(cb_calls[1] == std::make_pair(buffer_manager::buffer_lifecycle_event::registered, buffer_id(1)));
 
 		bm.unregister_buffer(0);
 		REQUIRE(cb_calls.size() == 3);
-		REQUIRE(cb_calls[2] == std::make_pair(buffer_manager::buffer_lifecycle_event::UNREGISTERED, buffer_id(0)));
+		REQUIRE(cb_calls[2] == std::make_pair(buffer_manager::buffer_lifecycle_event::unregistered, buffer_id(0)));
 		REQUIRE(bm.has_active_buffers());
 
 		bm.unregister_buffer(1);
@@ -197,8 +197,8 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using 1D device buffers") { run_1D_test(access_target::DEVICE); }
-		SECTION("when using 1D host buffers") { run_1D_test(access_target::HOST); }
+		SECTION("when using 1D device buffers") { run_1D_test(access_target::device); }
+		SECTION("when using 1D host buffers") { run_1D_test(access_target::host); }
 
 		auto run_2D_test = [&](access_target tgt) {
 			auto bid = bm.register_buffer<size_t, 2>(cl::sycl::range<3>(128, 128, 1));
@@ -218,8 +218,8 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using 2D device buffers") { run_2D_test(access_target::DEVICE); }
-		SECTION("when using 2D host buffers") { run_2D_test(access_target::HOST); }
+		SECTION("when using 2D device buffers") { run_2D_test(access_target::device); }
+		SECTION("when using 2D host buffers") { run_2D_test(access_target::host); }
 
 		// While the fix for bug that warranted adding a 2D test *should* also cover 3D buffers, it would be good to have a 3D test here as well.
 		// TODO: Can we also come up with a good 3D case?
@@ -263,11 +263,11 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using device buffers") { run_test(access_target::DEVICE, false); }
-		SECTION("when using host buffers") { run_test(access_target::HOST, false); }
+		SECTION("when using device buffers") { run_test(access_target::device, false); }
+		SECTION("when using host buffers") { run_test(access_target::host, false); }
 
-		SECTION("unless accessed range does not fully cover previous buffer size (using device buffers)") { run_test(access_target::DEVICE, true); }
-		SECTION("unless accessed range does not fully cover previous buffer size (using host buffers)") { run_test(access_target::HOST, true); }
+		SECTION("unless accessed range does not fully cover previous buffer size (using device buffers)") { run_test(access_target::device, true); }
+		SECTION("unless accessed range does not fully cover previous buffer size (using host buffers)") { run_test(access_target::host, true); }
 	}
 
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "buffer_manager ensures coherence between device and host buffers", "[buffer_manager]") {
@@ -289,8 +289,8 @@ namespace detail {
 			REQUIRE(valid);
 		};
 
-		SECTION("when writing separate parts on host and device, verifying on device") { run_test1(access_target::DEVICE); }
-		SECTION("when writing separate parts on host and device, verifying on host") { run_test1(access_target::HOST); }
+		SECTION("when writing separate parts on host and device, verifying on device") { run_test1(access_target::device); }
+		SECTION("when writing separate parts on host and device, verifying on host") { run_test1(access_target::host); }
 
 		// This test can be run in two slightly different variations, as overwriting a larger range incurs
 		// a resize operation internally, which then leads to a somewhat different code path during the coherency update.
@@ -312,11 +312,11 @@ namespace detail {
 			REQUIRE(valid);
 		};
 
-		SECTION("when initializing on device, updating on host, verifying on device") { run_test2(access_target::DEVICE, 256); }
-		SECTION("when initializing on host, updating on device, verifying on host") { run_test2(access_target::HOST, 256); }
+		SECTION("when initializing on device, updating on host, verifying on device") { run_test2(access_target::device, 256); }
+		SECTION("when initializing on host, updating on device, verifying on host") { run_test2(access_target::host, 256); }
 
-		SECTION("when initializing on device, partially updating larger portion on host, verifying on device") { run_test2(access_target::DEVICE, 512); }
-		SECTION("when initializing on host, partially updating larger portion on device, verifying on host") { run_test2(access_target::HOST, 512); }
+		SECTION("when initializing on device, partially updating larger portion on host, verifying on device") { run_test2(access_target::device, 512); }
+		SECTION("when initializing on host, partially updating larger portion on device, verifying on host") { run_test2(access_target::host, 512); }
 	}
 
 	TEST_CASE_METHOD(
@@ -339,8 +339,8 @@ namespace detail {
 			REQUIRE(valid);
 		};
 
-		SECTION("when initializing on host, verifying on device") { run_test(access_target::DEVICE); }
-		SECTION("when initializing on device, verifying on host") { run_test(access_target::HOST); }
+		SECTION("when initializing on host, verifying on device") { run_test(access_target::device); }
+		SECTION("when initializing on device, verifying on host") { run_test(access_target::host); }
 	}
 
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture,
@@ -371,8 +371,8 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using device buffers") { run_test(access_target::DEVICE); }
-		SECTION("when using host buffers") { run_test(access_target::HOST); }
+		SECTION("when using device buffers") { run_test(access_target::device); }
+		SECTION("when using host buffers") { run_test(access_target::host); }
 	}
 
 	/**
@@ -397,7 +397,7 @@ namespace detail {
 
 			// Initialize buffer on host.
 			buffer_for_each<size_t, 1, cl::sycl::access::mode::discard_write, class UKN(init)>(
-			    bid, access_target::HOST, {32}, {}, [](cl::sycl::id<1> idx, size_t& value) { value = idx[0]; });
+			    bid, access_target::host, {32}, {}, [](cl::sycl::id<1> idx, size_t& value) { value = idx[0]; });
 
 			// Read buffer on device. This makes the device buffer coherent with the host buffer.
 			bm.get_device_buffer<size_t, 1>(bid, cl::sycl::access::mode::read, cl::sycl::range<3>(32, 1, 1), cl::sycl::id<3>(0, 0, 0));
@@ -414,7 +414,7 @@ namespace detail {
 			// Verify that the data is still what we expect.
 			{
 				bool valid = buffer_reduce<size_t, 1, class UKN(check)>(
-				    bid, access_target::HOST, {32}, {0}, true, [](cl::sycl::id<1> idx, bool current, size_t value) { return current && value == idx[0]; });
+				    bid, access_target::host, {32}, {0}, true, [](cl::sycl::id<1> idx, bool current, size_t value) { return current && value == idx[0]; });
 				REQUIRE(valid);
 			}
 
@@ -427,7 +427,7 @@ namespace detail {
 			// Access device buffer. This should still contain the original data.
 			{
 				bool valid = buffer_reduce<size_t, 1, class UKN(check)>(
-				    bid, access_target::DEVICE, {32}, {0}, true, [](cl::sycl::id<1> idx, bool current, size_t value) { return current && value == idx[0]; });
+				    bid, access_target::device, {32}, {0}, true, [](cl::sycl::id<1> idx, bool current, size_t value) { return current && value == idx[0]; });
 				REQUIRE(valid);
 			}
 		}
@@ -443,7 +443,7 @@ namespace detail {
 
 			// Initialize buffer on device.
 			buffer_for_each<size_t, 1, cl::sycl::access::mode::discard_write, class UKN(init)>(
-			    bid, access_target::DEVICE, {32}, {}, [](cl::sycl::id<1> idx, size_t& value) { value = idx[0]; });
+			    bid, access_target::device, {32}, {}, [](cl::sycl::id<1> idx, size_t& value) { value = idx[0]; });
 
 			// Read buffer on host. This makes the host buffer coherent with the device buffer.
 			bm.get_host_buffer<size_t, 1>(bid, cl::sycl::access::mode::read, cl::sycl::range<3>(32, 1, 1), cl::sycl::id<3>(0, 0, 0));
@@ -521,8 +521,8 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using device buffers") { run_test(access_target::DEVICE); }
-		SECTION("when using host buffers") { run_test(access_target::HOST); }
+		SECTION("when using device buffers") { run_test(access_target::device); }
+		SECTION("when using host buffers") { run_test(access_target::host); }
 	}
 
 	// This test is in response to a bug that was caused by computing the region to be retained upon buffer resizing as the bounding box of the coherence
@@ -569,8 +569,8 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using device buffers") { run_test(access_target::DEVICE); }
-		SECTION("when using host buffers") { run_test(access_target::HOST); }
+		SECTION("when using device buffers") { run_test(access_target::device); }
+		SECTION("when using host buffers") { run_test(access_target::host); }
 	}
 
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "buffer_manager correctly updates buffer versioning for queued transfers", "[buffer_manager]") {
@@ -602,8 +602,8 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using device buffers") { run_test(access_target::DEVICE); }
-		SECTION("when using host buffers") { run_test(access_target::HOST); }
+		SECTION("when using device buffers") { run_test(access_target::device); }
+		SECTION("when using host buffers") { run_test(access_target::host); }
 	}
 
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "buffer_manager prioritizes queued transfers over resize/coherency copies for the same ranges",
@@ -631,11 +631,11 @@ namespace detail {
 			}
 		};
 
-		SECTION("when initializing, resizing and verifying on device") { run_test(access_target::DEVICE, true, false); }
-		SECTION("when initializing, resizing and verifying on host") { run_test(access_target::HOST, true, false); }
+		SECTION("when initializing, resizing and verifying on device") { run_test(access_target::device, true, false); }
+		SECTION("when initializing, resizing and verifying on host") { run_test(access_target::host, true, false); }
 
-		SECTION("when initializing on host, verifying on device") { run_test(access_target::DEVICE, false, true); }
-		SECTION("when initializing on device, verifying on host") { run_test(access_target::HOST, false, true); }
+		SECTION("when initializing on host, verifying on device") { run_test(access_target::device, false, true); }
+		SECTION("when initializing on device, verifying on host") { run_test(access_target::host, false, true); }
 	}
 
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "buffer_manager correctly handles transfers that partially overlap with requested buffer range",
@@ -674,8 +674,8 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using device buffers") { run_test(access_target::DEVICE); }
-		SECTION("when using host buffers") { run_test(access_target::HOST); }
+		SECTION("when using device buffers") { run_test(access_target::device); }
+		SECTION("when using host buffers") { run_test(access_target::host); }
 	}
 
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "buffer_manager returns the newest raw buffer data when requested", "[buffer_manager]") {
@@ -694,14 +694,14 @@ namespace detail {
 			}
 		};
 
-		SECTION("when newest data is on device") { run_test(access_target::DEVICE); }
-		SECTION("when newest data is on host") { run_test(access_target::HOST); }
+		SECTION("when newest data is on device") { run_test(access_target::device); }
+		SECTION("when newest data is on host") { run_test(access_target::host); }
 
 		SECTION("when newest data is split across host and device") {
 			buffer_for_each<size_t, 1, cl::sycl::access::mode::discard_write, class UKN(write_first_half)>(
-			    bid, access_target::DEVICE, {16}, {0}, [](cl::sycl::id<1> idx, size_t& value) { value = idx[0]; });
+			    bid, access_target::device, {16}, {0}, [](cl::sycl::id<1> idx, size_t& value) { value = idx[0]; });
 			buffer_for_each<size_t, 1, cl::sycl::access::mode::discard_write, class UKN(write_second_half)>(
-			    bid, access_target::HOST, {16}, {16}, [](cl::sycl::id<1> idx, size_t& value) { value = idx[0] * 2; });
+			    bid, access_target::host, {16}, {16}, [](cl::sycl::id<1> idx, size_t& value) { value = idx[0] * 2; });
 			std::vector<size_t> data(32);
 			bm.get_buffer_data(bid, {{0, 0, 0}, {32, 1, 1}}, data.data());
 			for(size_t i = 0; i < 32; ++i) {
@@ -725,18 +725,18 @@ namespace detail {
 
 		SECTION("when accessed on host") {
 			// Host buffers need to accomodate the full host-initialized data range.
-			REQUIRE(get_backing_buffer_range<size_t, 2>(bid, access_target::HOST, {7, 5}, {0, 0}) == cl::sycl::range<2>{SIZE, SIZE});
+			REQUIRE(get_backing_buffer_range<size_t, 2>(bid, access_target::host, {7, 5}, {0, 0}) == cl::sycl::range<2>{SIZE, SIZE});
 
-			bool valid = buffer_reduce<size_t, 2, class UKN(check)>(bid, access_target::HOST, {7, 5}, {0, 0}, true,
+			bool valid = buffer_reduce<size_t, 2, class UKN(check)>(bid, access_target::host, {7, 5}, {0, 0}, true,
 			    [](cl::sycl::id<2> idx, bool current, size_t value) { return current && (value == idx[0] * 5 + idx[1]); });
 			REQUIRE(valid);
 		}
 
 		SECTION("when accessed on device") {
 			// Device buffers still are only as large as required.
-			REQUIRE(get_backing_buffer_range<size_t, 2>(bid, access_target::DEVICE, {7, 5}, {0, 0}) == cl::sycl::range<2>{7, 5});
+			REQUIRE(get_backing_buffer_range<size_t, 2>(bid, access_target::device, {7, 5}, {0, 0}) == cl::sycl::range<2>{7, 5});
 
-			bool valid = buffer_reduce<size_t, 2, class UKN(check)>(bid, access_target::DEVICE, {7, 5}, {0, 0}, true,
+			bool valid = buffer_reduce<size_t, 2, class UKN(check)>(bid, access_target::device, {7, 5}, {0, 0}, true,
 			    [](cl::sycl::id<2> idx, bool current, size_t value) { return current && (value == idx[0] * 5 + idx[1]); });
 			REQUIRE(valid);
 		}
@@ -1005,7 +1005,7 @@ namespace detail {
 		SECTION("for 1D buffers") {
 			auto bid = bm.register_buffer<cl::sycl::id<3>, 1>(cl::sycl::range<3>(8, 1, 1));
 			buffer_for_each<cl::sycl::id<3>, 1, cl::sycl::access::mode::discard_write, class UKN(init)>(
-			    bid, access_target::DEVICE, {8}, {0}, [](cl::sycl::id<1> idx, cl::sycl::id<3>& value) { value = id_cast<3>(idx); });
+			    bid, access_target::device, {8}, {0}, [](cl::sycl::id<1> idx, cl::sycl::id<3>& value) { value = id_cast<3>(idx); });
 			auto acc = get_host_accessor<cl::sycl::id<3>, 1, cl::sycl::access::mode::read>(bid, {8}, {0});
 			check_values(acc.get_pointer(), {8, 1, 1});
 		}
@@ -1013,7 +1013,7 @@ namespace detail {
 		SECTION("for 2D buffers") {
 			auto bid = bm.register_buffer<cl::sycl::id<3>, 2>(cl::sycl::range<3>(8, 8, 1));
 			buffer_for_each<cl::sycl::id<3>, 2, cl::sycl::access::mode::discard_write, class UKN(init)>(
-			    bid, access_target::DEVICE, {8, 8}, {0, 0}, [](cl::sycl::id<2> idx, cl::sycl::id<3>& value) { value = id_cast<3>(idx); });
+			    bid, access_target::device, {8, 8}, {0, 0}, [](cl::sycl::id<2> idx, cl::sycl::id<3>& value) { value = id_cast<3>(idx); });
 			auto acc = get_host_accessor<cl::sycl::id<3>, 2, cl::sycl::access::mode::read>(bid, {8, 8}, {0, 0});
 			check_values(acc.get_pointer(), {8, 8, 1});
 		}
@@ -1021,7 +1021,7 @@ namespace detail {
 		SECTION("for 3D buffers") {
 			auto bid = bm.register_buffer<cl::sycl::id<3>, 3>(cl::sycl::range<3>(8, 8, 8));
 			buffer_for_each<cl::sycl::id<3>, 3, cl::sycl::access::mode::discard_write, class UKN(init)>(
-			    bid, access_target::DEVICE, {8, 8, 8}, {0, 0, 0}, [](cl::sycl::id<3> idx, cl::sycl::id<3>& value) { value = id_cast<3>(idx); });
+			    bid, access_target::device, {8, 8, 8}, {0, 0, 0}, [](cl::sycl::id<3> idx, cl::sycl::id<3>& value) { value = id_cast<3>(idx); });
 			auto acc = get_host_accessor<cl::sycl::id<3>, 3, cl::sycl::access::mode::read>(bid, {8, 8, 8}, {0, 0, 0});
 			check_values(acc.get_pointer(), {8, 8, 8});
 		}

--- a/test/buffer_manager_tests.cc
+++ b/test/buffer_manager_tests.cc
@@ -171,7 +171,7 @@ namespace detail {
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "buffer_manager retains existing data when resizing buffers", "[buffer_manager]") {
 		auto& bm = get_buffer_manager();
 
-		auto run_1D_test = [&](access_target tgt) {
+		auto run_1_d_test = [&](access_target tgt) {
 			auto bid = bm.register_buffer<size_t, 1>(cl::sycl::range<3>(160, 1, 1));
 
 			// Request a 64 element buffer at offset 32 and initialize it with known values.
@@ -197,10 +197,10 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using 1D device buffers") { run_1D_test(access_target::device); }
-		SECTION("when using 1D host buffers") { run_1D_test(access_target::host); }
+		SECTION("when using 1D device buffers") { run_1_d_test(access_target::device); }
+		SECTION("when using 1D host buffers") { run_1_d_test(access_target::host); }
 
-		auto run_2D_test = [&](access_target tgt) {
+		auto run_2_d_test = [&](access_target tgt) {
 			auto bid = bm.register_buffer<size_t, 2>(cl::sycl::range<3>(128, 128, 1));
 
 			// Request a set of columns and initialize it with known values.
@@ -218,8 +218,8 @@ namespace detail {
 			}
 		};
 
-		SECTION("when using 2D device buffers") { run_2D_test(access_target::device); }
-		SECTION("when using 2D host buffers") { run_2D_test(access_target::host); }
+		SECTION("when using 2D device buffers") { run_2_d_test(access_target::device); }
+		SECTION("when using 2D host buffers") { run_2_d_test(access_target::host); }
 
 		// While the fix for bug that warranted adding a 2D test *should* also cover 3D buffers, it would be good to have a 3D test here as well.
 		// TODO: Can we also come up with a good 3D case?
@@ -713,19 +713,19 @@ namespace detail {
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "buffer_manager correctly handles host-initialized buffers", "[buffer_manager]") {
 		auto& bm = get_buffer_manager();
 
-		constexpr size_t SIZE = 64;
-		std::vector<size_t> host_buf(SIZE * SIZE);
+		constexpr size_t size = 64;
+		std::vector<size_t> host_buf(size * size);
 		for(size_t i = 0; i < 7; ++i) {
 			for(size_t j = 0; j < 5; ++j) {
-				host_buf[i * SIZE + j] = i * 5 + j;
+				host_buf[i * size + j] = i * 5 + j;
 			}
 		}
 
-		auto bid = bm.register_buffer<size_t, 2>(cl::sycl::range<3>(SIZE, SIZE, 1), host_buf.data());
+		auto bid = bm.register_buffer<size_t, 2>(cl::sycl::range<3>(size, size, 1), host_buf.data());
 
 		SECTION("when accessed on host") {
 			// Host buffers need to accomodate the full host-initialized data range.
-			REQUIRE(get_backing_buffer_range<size_t, 2>(bid, access_target::host, {7, 5}, {0, 0}) == cl::sycl::range<2>{SIZE, SIZE});
+			REQUIRE(get_backing_buffer_range<size_t, 2>(bid, access_target::host, {7, 5}, {0, 0}) == cl::sycl::range<2>{size, size});
 
 			bool valid = buffer_reduce<size_t, 2, class UKN(check)>(bid, access_target::host, {7, 5}, {0, 0}, true,
 			    [](cl::sycl::id<2> idx, bool current, size_t value) { return current && (value == idx[0] * 5 + idx[1]); });

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -108,7 +108,7 @@ namespace detail {
 		const auto total_horizons_per_node = num_timesteps / horizon_step_size;
 		for(node_id n = 0; n < num_nodes; ++n) {
 			CAPTURE(n);
-			const auto total_horizons = static_cast<int>(inspector.get_commands(std::nullopt, n, command_type::HORIZON).size());
+			const auto total_horizons = static_cast<int>(inspector.get_commands(std::nullopt, n, command_type::horizon).size());
 			CHECK(total_horizons == total_horizons_per_node);
 		}
 
@@ -197,7 +197,7 @@ namespace detail {
 		REQUIRE(horizon_dep != deps.end());
 
 		// check that the dependee is the first horizon
-		auto horizon_cmds = inspector.get_commands({}, {}, command_type::HORIZON);
+		auto horizon_cmds = inspector.get_commands({}, {}, command_type::horizon);
 		CHECK(horizon_cmds.size() == 2);
 		CHECK(*horizon_dep == *horizon_cmds.cbegin());
 
@@ -205,7 +205,7 @@ namespace detail {
 		auto write_b_cmd = ctx.get_command_graph().get(*cmds.cbegin());
 		auto write_b_dependencies = write_b_cmd->get_dependencies();
 		CHECK(!write_b_dependencies.empty());
-		CHECK(write_b_dependencies.front().kind == dependency_kind::ANTI_DEP);
+		CHECK(write_b_dependencies.front().kind == dependency_kind::anti_dep);
 
 		test_utils::maybe_print_graphs(ctx);
 	}
@@ -249,7 +249,7 @@ namespace detail {
 		}
 
 		// check that all horizons were flushed
-		auto horizon_cmds = inspector.get_commands({}, {}, command_type::HORIZON);
+		auto horizon_cmds = inspector.get_commands({}, {}, command_type::horizon);
 		CHECK(horizon_cmds.size() == 4);
 
 		test_utils::maybe_print_graphs(ctx);
@@ -373,9 +373,9 @@ namespace detail {
 
 			CHECK(std::distance(second_deps.begin(), second_deps.end()) == 2);
 			REQUIRE(master_node_dep != second_deps.end());
-			CHECK(master_node_dep->kind == dependency_kind::TRUE_DEP);
+			CHECK(master_node_dep->kind == dependency_kind::true_dep);
 			REQUIRE(horizon_dep != second_deps.end());
-			CHECK(horizon_dep->kind == dependency_kind::TRUE_DEP);
+			CHECK(horizon_dep->kind == dependency_kind::true_dep);
 		}
 
 		test_utils::maybe_print_graphs(ctx);
@@ -417,7 +417,7 @@ namespace detail {
 			const auto second_deps = cdag.get(second_cid)->get_dependencies();
 			CHECK(std::distance(second_deps.begin(), second_deps.end()) == 1);
 			for(const auto& dep : second_deps) {
-				CHECK(dep.kind == dependency_kind::TRUE_DEP);
+				CHECK(dep.kind == dependency_kind::true_dep);
 				CHECK(isa<horizon_command>(dep.node));
 			}
 		}
@@ -482,9 +482,9 @@ namespace detail {
 		REQUIRE(tm.has_task(init_tid));
 		check_task_has_exact_dependencies("initial epoch task", init_tid, {});
 		REQUIRE(tm.has_task(writer_tid));
-		check_task_has_exact_dependencies("writer", writer_tid, {{init_tid, dependency_kind::TRUE_DEP, dependency_origin::last_epoch}});
+		check_task_has_exact_dependencies("writer", writer_tid, {{init_tid, dependency_kind::true_dep, dependency_origin::last_epoch}});
 		REQUIRE(tm.has_task(epoch_tid));
-		check_task_has_exact_dependencies("epoch before", epoch_tid, {{writer_tid, dependency_kind::TRUE_DEP, dependency_origin::execution_front}});
+		check_task_has_exact_dependencies("epoch before", epoch_tid, {{writer_tid, dependency_kind::true_dep, dependency_origin::execution_front}});
 
 		tm.notify_epoch_reached(epoch_tid);
 
@@ -503,15 +503,15 @@ namespace detail {
 		REQUIRE(tm.has_task(epoch_tid));
 		check_task_has_exact_dependencies("epoch after", epoch_tid, {});
 		REQUIRE(tm.has_task(reader_writer_tid));
-		check_task_has_exact_dependencies("reader-writer", reader_writer_tid, {{epoch_tid, dependency_kind::TRUE_DEP, dependency_origin::dataflow}});
+		check_task_has_exact_dependencies("reader-writer", reader_writer_tid, {{epoch_tid, dependency_kind::true_dep, dependency_origin::dataflow}});
 		REQUIRE(tm.has_task(late_writer_tid));
-		check_task_has_exact_dependencies("late writer", late_writer_tid, {{epoch_tid, dependency_kind::TRUE_DEP, dependency_origin::last_epoch}});
+		check_task_has_exact_dependencies("late writer", late_writer_tid, {{epoch_tid, dependency_kind::true_dep, dependency_origin::last_epoch}});
 		REQUIRE(tm.has_task(reader_tid));
 		check_task_has_exact_dependencies("reader", reader_tid,
 		    {
-		        {epoch_tid, dependency_kind::ANTI_DEP, dependency_origin::dataflow},
-		        {reader_writer_tid, dependency_kind::TRUE_DEP, dependency_origin::dataflow},
-		        {late_writer_tid, dependency_kind::TRUE_DEP, dependency_origin::dataflow},
+		        {epoch_tid, dependency_kind::anti_dep, dependency_origin::dataflow},
+		        {reader_writer_tid, dependency_kind::true_dep, dependency_origin::dataflow},
+		        {late_writer_tid, dependency_kind::true_dep, dependency_origin::dataflow},
 		    });
 
 		maybe_print_graphs(ctx);

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -24,25 +24,25 @@ namespace detail {
 	struct region_map_testspy {
 		template <typename T>
 		static size_t get_num_regions(const region_map<T>& map) {
-			return map.region_values.size();
+			return map.m_region_values.size();
 		}
 	};
 
 	struct graph_generator_testspy {
 		static size_t get_buffer_states_num_regions(const graph_generator& ggen, const buffer_id bid) {
-			if(auto* distr_state = std::get_if<graph_generator::distributed_state>(&ggen.buffer_states.at(bid))) {
+			if(auto* distr_state = std::get_if<graph_generator::distributed_state>(&ggen.m_buffer_states.at(bid))) {
 				return region_map_testspy::get_num_regions(distr_state->region_sources);
 			} else {
 				return 1;
 			}
 		}
 		static size_t get_buffer_last_writer_num_regions(const graph_generator& ggen, const buffer_id bid) {
-			return region_map_testspy::get_num_regions(ggen.node_data.at(node_id{0}).buffer_last_writer.at(bid));
+			return region_map_testspy::get_num_regions(ggen.m_node_data.at(node_id{0}).buffer_last_writer.at(bid));
 		}
-		static size_t get_command_buffer_reads_size(const graph_generator& ggen) { return ggen.command_buffer_reads.size(); }
+		static size_t get_command_buffer_reads_size(const graph_generator& ggen) { return ggen.m_command_buffer_reads.size(); }
 		static std::vector<command_id> get_current_horizons(const graph_generator& ggen) {
 			std::vector<command_id> horizons;
-			for(const auto& [nid, data] : ggen.node_data) {
+			for(const auto& [nid, data] : ggen.m_node_data) {
 				if(data.current_horizon) { horizons.push_back(*data.current_horizon); }
 			}
 			return horizons;

--- a/test/graph_gen_granularity_tests.cc
+++ b/test/graph_gen_granularity_tests.cc
@@ -190,7 +190,7 @@ namespace detail {
 		CHECK(!inspector.has_dependency(read_cmds[1]->get_cid(), write_cmds[1]->get_cid()));
 
 		{
-			const auto pushes = inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH);
+			const auto pushes = inspector.get_commands(std::nullopt, std::nullopt, command_type::push);
 			REQUIRE(pushes.size() == 1);
 			const auto push_cmd = cdag.get<push_command>(*pushes.begin());
 			CHECK(push_cmd->get_nid() == 0);
@@ -198,7 +198,7 @@ namespace detail {
 		}
 
 		{
-			const auto await_pushes = inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH);
+			const auto await_pushes = inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push);
 			REQUIRE(await_pushes.size() == 1);
 			const auto await_push_cmd = cdag.get<await_push_command>(*await_pushes.begin());
 			CHECK(await_push_cmd->get_nid() == 1);

--- a/test/graph_gen_reduction_tests.cc
+++ b/test/graph_gen_reduction_tests.cc
@@ -125,7 +125,7 @@ namespace detail {
 		test_utils::build_and_flush(ctx, num_nodes, tid_consume);
 
 		CHECK(has_dependency(tm, tid_consume, tid_reduce));
-		CHECK(ctx.get_inspector().get_commands(std::nullopt, std::nullopt, command_type::REDUCTION).empty());
+		CHECK(ctx.get_inspector().get_commands(std::nullopt, std::nullopt, command_type::reduction).empty());
 
 		test_utils::maybe_print_graphs(ctx);
 	}
@@ -150,7 +150,7 @@ namespace detail {
 			buf_0.get_access<mode::discard_write>(cgh, fixed<1>({0, 1}));
 		}));
 
-		CHECK(ctx.get_inspector().get_commands(std::nullopt, std::nullopt, command_type::REDUCTION).empty());
+		CHECK(ctx.get_inspector().get_commands(std::nullopt, std::nullopt, command_type::reduction).empty());
 
 		test_utils::maybe_print_graphs(ctx);
 	}
@@ -177,7 +177,7 @@ namespace detail {
 			buf_0.get_access<mode::write>(cgh, fixed<1>({0, 1}));
 		}));
 
-		CHECK(ctx.get_inspector().get_commands(std::nullopt, std::nullopt, command_type::REDUCTION).size() == 1);
+		CHECK(ctx.get_inspector().get_commands(std::nullopt, std::nullopt, command_type::reduction).size() == 1);
 
 		test_utils::maybe_print_graphs(ctx);
 	}
@@ -205,7 +205,7 @@ namespace detail {
 		auto& cdag = ctx.get_command_graph();
 		for(auto host_cid : inspector.get_commands(host_tid, std::nullopt, std::nullopt)) {
 			for(auto compute_cid : inspector.get_commands(compute_tid, std::nullopt, std::nullopt)) {
-				CHECK(!cdag.get(host_cid)->has_dependency(cdag.get(compute_cid), dependency_kind::ANTI_DEP));
+				CHECK(!cdag.get(host_cid)->has_dependency(cdag.get(compute_cid), dependency_kind::anti_dep));
 			}
 		}
 

--- a/test/graph_gen_transfer_tests.cc
+++ b/test/graph_gen_transfer_tests.cc
@@ -174,8 +174,8 @@ namespace detail {
 	TEST_CASE("graph_generator uses original producer as source for push rather than building dependency chain", "[graph_generator][command-graph]") {
 		using namespace cl::sycl::access;
 
-		constexpr int NUM_NODES = 3;
-		test_utils::cdag_test_context ctx(NUM_NODES);
+		constexpr int num_nodes = 3;
+		test_utils::cdag_test_context ctx(num_nodes);
 		auto& inspector = ctx.get_inspector();
 		test_utils::mock_buffer_factory mbf(ctx);
 		auto full_range = cl::sycl::range<1>(300);
@@ -186,13 +186,13 @@ namespace detail {
 		        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::discard_write>(cgh, one_to_one{}); }, full_range));
 
 		SECTION("when distributing a single reading task across nodes") {
-			test_utils::build_and_flush(ctx, NUM_NODES,
+			test_utils::build_and_flush(ctx, num_nodes,
 			    test_utils::add_compute_task<class UKN(producer)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read>(cgh, one_to_one{}); }, full_range));
 		}
 
 		SECTION("when distributing a single read-write task across nodes") {
-			test_utils::build_and_flush(ctx, NUM_NODES,
+			test_utils::build_and_flush(ctx, num_nodes,
 			    test_utils::add_compute_task<class UKN(producer)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read_write>(cgh, one_to_one{}); }, full_range));
 		}
@@ -201,16 +201,16 @@ namespace detail {
 			auto full_range_for_single_node = [=](node_id node) {
 				return [=](chunk<1> chnk) -> subrange<1> {
 					if(chnk.range == full_range) return chnk;
-					if(chnk.offset[0] == (full_range.size() / NUM_NODES) * node) { return {0, full_range}; }
+					if(chnk.offset[0] == (full_range.size() / num_nodes) * node) { return {0, full_range}; }
 					return {0, 0};
 				};
 			};
 
-			test_utils::build_and_flush(ctx, NUM_NODES,
+			test_utils::build_and_flush(ctx, num_nodes,
 			    test_utils::add_compute_task<class UKN(producer)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read>(cgh, full_range_for_single_node(1)); }, full_range));
 
-			test_utils::build_and_flush(ctx, NUM_NODES,
+			test_utils::build_and_flush(ctx, num_nodes,
 			    test_utils::add_compute_task<class UKN(producer)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read>(cgh, full_range_for_single_node(2)); }, full_range));
 		}

--- a/test/graph_gen_transfer_tests.cc
+++ b/test/graph_gen_transfer_tests.cc
@@ -40,21 +40,21 @@ namespace detail {
 		        },
 		        cl::sycl::range<1>{300}));
 
-		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 4);
-		CHECK(inspector.get_commands(tid_a, node_id(1), command_type::EXECUTION).size() == 1);
-		CHECK(inspector.get_commands(tid_a, node_id(2), command_type::EXECUTION).size() == 1);
-		CHECK(inspector.get_commands(tid_a, node_id(3), command_type::EXECUTION).size() == 1);
+		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 4);
+		CHECK(inspector.get_commands(tid_a, node_id(1), command_type::execution).size() == 1);
+		CHECK(inspector.get_commands(tid_a, node_id(2), command_type::execution).size() == 1);
+		CHECK(inspector.get_commands(tid_a, node_id(3), command_type::execution).size() == 1);
 
 		test_utils::build_and_flush(ctx, 4,
 		    test_utils::add_compute_task<class UKN(task_b)>(
 		        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::read>(cgh, one_to_one{}); }, cl::sycl::range<1>{300}));
 
-		REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 2);
-		REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH).size() == 1);
-		REQUIRE(inspector.get_commands(std::nullopt, node_id(2), command_type::PUSH).size() == 1);
-		REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 2);
-		REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::AWAIT_PUSH).size() == 1);
-		REQUIRE(inspector.get_commands(std::nullopt, node_id(2), command_type::AWAIT_PUSH).size() == 1);
+		REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 2);
+		REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::push).size() == 1);
+		REQUIRE(inspector.get_commands(std::nullopt, node_id(2), command_type::push).size() == 1);
+		REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 2);
+		REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::await_push).size() == 1);
+		REQUIRE(inspector.get_commands(std::nullopt, node_id(2), command_type::await_push).size() == 1);
 
 		test_utils::maybe_print_graphs(ctx);
 	}
@@ -78,11 +78,11 @@ namespace detail {
 				buf_a.get_access<mode::write>(cgh, fixed<1>({0, 100}));
 			}));
 
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::EXECUTION).size() == 3);
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH).size() == 1);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::execution).size() == 3);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::await_push).size() == 1);
 
 			test_utils::maybe_print_graphs(ctx);
 		}
@@ -101,13 +101,13 @@ namespace detail {
 			        },
 			        cl::sycl::range<1>(100)));
 
-			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 4);
-			const auto computes = inspector.get_commands(tid_b, node_id(1), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 4);
+			const auto computes = inspector.get_commands(tid_b, node_id(1), command_type::execution);
 			CHECK(computes.size() == 2);
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::AWAIT_PUSH).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::await_push).size() == 1);
 
 			test_utils::maybe_print_graphs(ctx);
 		}
@@ -124,20 +124,20 @@ namespace detail {
 				buf_b.get_access<mode::discard_write>(cgh, fixed<1>({0, 100}));
 			}));
 
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::await_push).size() == 1);
 
 			test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf_a.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 				buf_b.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
 
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::EXECUTION).size() == 4);
-			// Assert that the number of PUSHes / AWAIT_PUSHes hasn't changed
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 1);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::execution).size() == 4);
+			// Assert that the number of pushes / await_pushes hasn't changed
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 1);
 
 			test_utils::maybe_print_graphs(ctx);
 		}
@@ -147,31 +147,31 @@ namespace detail {
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 2);
 
 			test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf_a.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
 
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(1), command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::await_push).size() == 1);
 
 			test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf_a.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
 
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::EXECUTION).size() == 4);
-			// Assert that the number of PUSHes / AWAIT_PUSHes hasn't changed
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 1);
-			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 1);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::execution).size() == 4);
+			// Assert that the number of pushes / await_pushes hasn't changed
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 1);
+			REQUIRE(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 1);
 
 			test_utils::maybe_print_graphs(ctx);
 		}
 	}
 
-	TEST_CASE("graph_generator uses original producer as source for PUSH rather than building dependency chain", "[graph_generator][command-graph]") {
+	TEST_CASE("graph_generator uses original producer as source for push rather than building dependency chain", "[graph_generator][command-graph]") {
 		using namespace cl::sycl::access;
 
 		constexpr int NUM_NODES = 3;
@@ -215,16 +215,16 @@ namespace detail {
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read>(cgh, full_range_for_single_node(2)); }, full_range));
 		}
 
-		CHECK(inspector.get_commands(std::nullopt, node_id(0), command_type::PUSH).size() == 2);
-		CHECK(inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH).size() == 0);
-		CHECK(inspector.get_commands(std::nullopt, node_id(2), command_type::PUSH).size() == 0);
-		CHECK(inspector.get_commands(std::nullopt, node_id(1), command_type::AWAIT_PUSH).size() == 1);
-		CHECK(inspector.get_commands(std::nullopt, node_id(2), command_type::AWAIT_PUSH).size() == 1);
+		CHECK(inspector.get_commands(std::nullopt, node_id(0), command_type::push).size() == 2);
+		CHECK(inspector.get_commands(std::nullopt, node_id(1), command_type::push).size() == 0);
+		CHECK(inspector.get_commands(std::nullopt, node_id(2), command_type::push).size() == 0);
+		CHECK(inspector.get_commands(std::nullopt, node_id(1), command_type::await_push).size() == 1);
+		CHECK(inspector.get_commands(std::nullopt, node_id(2), command_type::await_push).size() == 1);
 
 		test_utils::maybe_print_graphs(ctx);
 	}
 
-	TEST_CASE("graph_generator consolidates PUSH commands for adjacent subranges", "[graph_generator][command-graph]") {
+	TEST_CASE("graph_generator consolidates push commands for adjacent subranges", "[graph_generator][command-graph]") {
 		using namespace cl::sycl::access;
 
 		test_utils::cdag_test_context ctx(2);
@@ -237,7 +237,7 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(task_a)>(
 		        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{64},
 		        cl::sycl::id<1>{0}));
-		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 2);
+		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 2);
 
 		const auto tid_b = test_utils::build_and_flush(ctx, 2,
 		    test_utils::add_compute_task<class UKN(task_b)>(
@@ -253,13 +253,13 @@ namespace detail {
 			        });
 		        },
 		        cl::sycl::range<1>{64}, cl::sycl::id<1>{64}));
-		CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 2);
+		CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 2);
 
 		test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 			buf.get_access<mode::read>(cgh, fixed<1>({0, 128}));
 		}));
 
-		auto push_commands = inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH);
+		auto push_commands = inspector.get_commands(std::nullopt, node_id(1), command_type::push);
 		REQUIRE(push_commands.size() == 1);
 		REQUIRE(inspector.get_dependency_count(*push_commands.cbegin()) == 2);
 
@@ -301,7 +301,7 @@ namespace detail {
 		test_utils::maybe_print_graphs(ctx);
 	}
 
-	TEST_CASE("graph_generator generates dependencies for PUSH commands", "[graph_generator][command-graph]") {
+	TEST_CASE("graph_generator generates dependencies for push commands", "[graph_generator][command-graph]") {
 		using namespace cl::sycl::access;
 
 		test_utils::cdag_test_context ctx(2);
@@ -314,16 +314,16 @@ namespace detail {
 			const auto tid_a = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 2);
-			const auto computes = inspector.get_commands(tid_a, node_id(1), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 2);
+			const auto computes = inspector.get_commands(tid_a, node_id(1), command_type::execution);
 			CHECK(computes.size() == 1);
 
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).empty());
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).empty());
 			test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 1);
-			const auto pushes = inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 1);
+			const auto pushes = inspector.get_commands(std::nullopt, node_id(1), command_type::push);
 			CHECK(pushes.size() == 1);
 
 			REQUIRE(inspector.has_dependency(*pushes.cbegin(), *computes.cbegin()));
@@ -331,14 +331,14 @@ namespace detail {
 			test_utils::maybe_print_graphs(ctx);
 		}
 
-		SECTION("if data is produced by an AWAIT_PUSH command") {
-			// There currently is no good way of reliably testing this because the source node for a PUSH is currently
+		SECTION("if data is produced by an await_push command") {
+			// There currently is no good way of reliably testing this because the source node for a push is currently
 			// selected "randomly" (i.e. the first in an unordered_set is used, ordering depends on STL implementation)
 			// TODO: Revisit in the future
 		}
 	}
 
-	TEST_CASE("graph_generator generates anti-dependencies for AWAIT_PUSH commands", "[graph_generator][command-graph]") {
+	TEST_CASE("graph_generator generates anti-dependencies for await_push commands", "[graph_generator][command-graph]") {
 		using namespace cl::sycl::access;
 
 		test_utils::cdag_test_context ctx(2);
@@ -352,8 +352,8 @@ namespace detail {
 				buf.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
 
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 1);
-			const auto master_node_tasks_a = inspector.get_commands(tid_a, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 1);
+			const auto master_node_tasks_a = inspector.get_commands(tid_a, node_id(0), command_type::execution);
 			CHECK(master_node_tasks_a.size() == 1);
 
 			// Meanwhile, the worker node writes to buf
@@ -361,8 +361,8 @@ namespace detail {
 			    test_utils::add_compute_task<class UKN(task_b)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 2);
-			const auto computes_b_0 = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 2);
+			const auto computes_b_0 = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 			CHECK(computes_b_0.size() == 1);
 			CHECK(inspector.has_dependency(*computes_b_0.cbegin(), *master_node_tasks_a.cbegin()));
 
@@ -371,46 +371,46 @@ namespace detail {
 				buf.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
 
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 1);
-			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 1);
+			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(0), command_type::await_push);
 			CHECK(await_pushes.size() == 1);
-			const auto master_node_tasks_c = inspector.get_commands(tid_c, node_id(0), command_type::EXECUTION);
+			const auto master_node_tasks_c = inspector.get_commands(tid_c, node_id(0), command_type::execution);
 			CHECK(master_node_tasks_c.size() == 1);
 			CHECK(inspector.has_dependency(*master_node_tasks_c.cbegin(), *await_pushes.cbegin()));
 
-			// The AWAIT_PUSH command has to wait until the MASTER_NODE in task_a is complete.
+			// The await_push command has to wait until the master_node in task_a is complete.
 			REQUIRE(inspector.has_dependency(*await_pushes.cbegin(), *master_node_tasks_a.cbegin()));
 
 			test_utils::maybe_print_graphs(ctx);
 		}
 
-		SECTION("if writing to region used by PUSH command") {
+		SECTION("if writing to region used by push command") {
 			// Worker node writes to buf
 			const auto tid_a = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 2);
 
-			// Master node reads from buf, requiring a PUSH, while also writing to it
+			// Master node reads from buf, requiring a push, while also writing to it
 			test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf.get_access<mode::read_write>(cgh, fixed<1>({0, 100}));
 			}));
 
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 1);
-			const auto pushes = inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 1);
+			const auto pushes = inspector.get_commands(std::nullopt, node_id(1), command_type::push);
 			CHECK(pushes.size() == 1);
 
-			// Finally, the worker node reads buf again, requiring an AWAIT_PUSH
-			// Note that in this example the AWAIT_PUSH can never occur during the PUSH to master, as they are effectively
+			// Finally, the worker node reads buf again, requiring an await_push
+			// Note that in this example the await_push can never occur during the push to master, as they are effectively
 			// in a distributed dependency relationship, however more complex examples could give rise to situations where this can happen.
 			const auto tid_c = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_c)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::read>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::EXECUTION).size() == 2);
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 2);
-			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(1), command_type::AWAIT_PUSH);
+			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::execution).size() == 2);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 2);
+			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(1), command_type::await_push);
 			CHECK(await_pushes.size() == 1);
 
 			REQUIRE(inspector.has_dependency(*await_pushes.cbegin(), *pushes.cbegin()));
@@ -418,30 +418,30 @@ namespace detail {
 			test_utils::maybe_print_graphs(ctx);
 		}
 
-		SECTION("if writing to region used by another AWAIT_PUSH command") {
+		SECTION("if writing to region used by another await_push command") {
 			const auto tid_a = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 2);
 
 			const auto tid_b = test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
-			CHECK(inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH).size() == 1);
-			const auto master_node_tasks_b = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(std::nullopt, node_id(0), command_type::await_push).size() == 1);
+			const auto master_node_tasks_b = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 			CHECK(master_node_tasks_b.size() == 1);
 
 			const auto tid_c = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_c)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::execution).size() == 2);
 
 			test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
-			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH);
+			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(0), command_type::await_push);
 			CHECK(await_pushes.size() == 2);
 
 			// The anti-dependency is delegated to the reader (i.e. the master_node_task)
@@ -469,8 +469,8 @@ namespace detail {
 				        buf.get_access<mode::discard_write>(cgh, fixed<1>{{0, 50}});
 			        },
 			        cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 1);
-			const auto computes_a = inspector.get_commands(tid_a, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 1);
+			const auto computes_a = inspector.get_commands(tid_a, node_id(0), command_type::execution);
 			CHECK(computes_a.size() == 1);
 
 			// task_b reads the first half
@@ -481,8 +481,8 @@ namespace detail {
 				        buf.get_access<mode::read>(cgh, fixed<1>{{0, 50}});
 			        },
 			        cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 1);
-			const auto computes_b = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 1);
+			const auto computes_b = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 			CHECK(computes_b.size() == 1);
 			CHECK(inspector.has_dependency(*computes_b.cbegin(), *computes_a.cbegin()));
 
@@ -494,8 +494,8 @@ namespace detail {
 				        buf.get_access<mode::discard_write>(cgh, fixed<1>{{50, 50}});
 			        },
 			        cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::EXECUTION).size() == 1);
-			const auto computes_c = inspector.get_commands(tid_c, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::execution).size() == 1);
+			const auto computes_c = inspector.get_commands(tid_c, node_id(0), command_type::execution);
 			CHECK(computes_c.size() == 1);
 
 			// task_c should not have an anti-dependency onto task_b (or task_a)
@@ -505,35 +505,35 @@ namespace detail {
 			test_utils::maybe_print_graphs(ctx);
 		}
 
-		SECTION("for AWAIT_PUSH commands") {
+		SECTION("for await_push commands") {
 			// task_a writes the full buffer
 			const auto tid_a = test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf.get_access<mode::discard_write>(cgh, fixed<1>({0, 100}));
 			}));
-			const auto master_node_tasks_a = inspector.get_commands(tid_a, node_id(0), command_type::EXECUTION);
+			const auto master_node_tasks_a = inspector.get_commands(tid_a, node_id(0), command_type::execution);
 			CHECK(master_node_tasks_a.size() == 1);
 
 			// task_b only reads the second half
 			const auto tid_b = test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf.get_access<mode::read>(cgh, fixed<1>({50, 50}));
 			}));
-			const auto master_node_tasks_b = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+			const auto master_node_tasks_b = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 			CHECK(master_node_tasks_b.size() == 1);
 
 			// task_c writes to the first half
 			const auto tid_c = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_c)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{50}));
-			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::execution).size() == 2);
 
 			// task_d reads the first half
 			test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf.get_access<mode::read>(cgh, fixed<1>({0, 50}));
 			}));
 
-			// This should generate an AWAIT_PUSH command that does NOT have an anti-dependency onto task_b, only task_a
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 1);
-			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH);
+			// This should generate an await_push command that does NOT have an anti-dependency onto task_b, only task_a
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 1);
+			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(0), command_type::await_push);
 			REQUIRE(inspector.has_dependency(*await_pushes.cbegin(), *master_node_tasks_a.cbegin()));
 			REQUIRE_FALSE(inspector.has_dependency(*await_pushes.cbegin(), *master_node_tasks_b.cbegin()));
 

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -63,7 +63,7 @@ namespace detail {
 			expected_front.erase(t0);
 			auto t2 = cdag.create<execution_command>(node, 2, subrange<3>{});
 			expected_front.insert(t2);
-			cdag.add_dependency(t2, t0, dependency_kind::TRUE_DEP, dependency_origin::dataflow);
+			cdag.add_dependency(t2, t0, dependency_kind::true_dep, dependency_origin::dataflow);
 			REQUIRE(expected_front == cdag.get_execution_front(node));
 			return expected_front;
 		};
@@ -100,18 +100,18 @@ namespace detail {
 			const auto tid_a = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 2);
 			const auto tid_b = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_b)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_b.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 2);
 			const auto tid_c = test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf_a.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 				buf_b.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
-			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH);
+			const auto await_pushes = inspector.get_commands(std::nullopt, node_id(0), command_type::await_push);
 			REQUIRE(await_pushes.size() == 2);
-			const auto master_node_tasks = inspector.get_commands(tid_c, node_id(0), command_type::EXECUTION);
+			const auto master_node_tasks = inspector.get_commands(tid_c, node_id(0), command_type::execution);
 			CHECK(master_node_tasks.size() == 1);
 			REQUIRE(inspector.has_dependency(*master_node_tasks.cbegin(), *await_pushes.cbegin()));
 			REQUIRE(inspector.has_dependency(*master_node_tasks.cbegin(), *(await_pushes.cbegin()++)));
@@ -123,18 +123,18 @@ namespace detail {
 			const auto tid_a = test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 2);
 			test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf_a.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
-			const auto await_pushes_b = inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH);
+			const auto await_pushes_b = inspector.get_commands(std::nullopt, node_id(0), command_type::await_push);
 			REQUIRE(await_pushes_b.size() == 1);
 			const auto tid_c = test_utils::build_and_flush(ctx, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 				buf_a.get_access<mode::read>(cgh, fixed<1>({0, 100}));
 			}));
-			// Assert that the number of AWAIT_PUSHes hasn't changed (i.e., none were added)
-			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::AWAIT_PUSH).size() == 1);
-			const auto master_node_tasks = inspector.get_commands(tid_c, node_id(0), command_type::EXECUTION);
+			// Assert that the number of await_pushes hasn't changed (i.e., none were added)
+			REQUIRE(inspector.get_commands(std::nullopt, node_id(0), command_type::await_push).size() == 1);
+			const auto master_node_tasks = inspector.get_commands(tid_c, node_id(0), command_type::execution);
 			REQUIRE(master_node_tasks.size() == 1);
 			REQUIRE(inspector.has_dependency(*master_node_tasks.cbegin(), *await_pushes_b.cbegin()));
 
@@ -145,13 +145,13 @@ namespace detail {
 			const auto tid_a = test_utils::build_and_flush(ctx, 1,
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 1);
-			const auto computes_a = inspector.get_commands(tid_a, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 1);
+			const auto computes_a = inspector.get_commands(tid_a, node_id(0), command_type::execution);
 			const auto tid_b = test_utils::build_and_flush(ctx, 1,
 			    test_utils::add_compute_task<class UKN(task_b)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf_b.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 1);
-			const auto computes_b = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 1);
+			const auto computes_b = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 			const auto tid_c = test_utils::build_and_flush(ctx, 1,
 			    test_utils::add_compute_task<class UKN(task_c)>(
 			        ctx.get_task_manager(),
@@ -160,8 +160,8 @@ namespace detail {
 				        buf_b.get_access<mode::read>(cgh, one_to_one{});
 			        },
 			        cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::EXECUTION).size() == 1);
-			const auto computes_c = inspector.get_commands(tid_c, node_id(0), command_type::EXECUTION);
+			CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::execution).size() == 1);
+			const auto computes_c = inspector.get_commands(tid_c, node_id(0), command_type::execution);
 			REQUIRE(inspector.has_dependency(*computes_c.cbegin(), *computes_a.cbegin()));
 			REQUIRE(inspector.has_dependency(*computes_c.cbegin(), *computes_b.cbegin()));
 
@@ -192,7 +192,7 @@ namespace detail {
 		        cl::sycl::range<1>{100}));
 
 		// Another solution could be to not split the task at all
-		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 1);
+		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 1);
 
 		test_utils::build_and_flush(ctx, 3,
 		    test_utils::add_compute_task<class UKN(task_b)>(
@@ -203,7 +203,7 @@ namespace detail {
 		        cl::sycl::range<1>{100}));
 
 		// Right now this generates a push command from the second node to the first, which also doesn't make much sense
-		CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).empty());
+		CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).empty());
 
 		test_utils::maybe_print_graphs(ctx);
 	}
@@ -226,9 +226,9 @@ namespace detail {
 			        buf_b.get_access<mode::discard_write>(cgh, one_to_one{});
 		        },
 		        cl::sycl::range<1>{100}));
-		const auto computes_a_node1 = inspector.get_commands(tid_a, node_id(1), command_type::EXECUTION);
+		const auto computes_a_node1 = inspector.get_commands(tid_a, node_id(1), command_type::execution);
 		CHECK(computes_a_node1.size() == 1);
-		const auto computes_a_node2 = inspector.get_commands(tid_a, node_id(2), command_type::EXECUTION);
+		const auto computes_a_node2 = inspector.get_commands(tid_a, node_id(2), command_type::execution);
 		CHECK(computes_a_node2.size() == 1);
 
 		// Read from buf_a but overwrite buf_b
@@ -249,9 +249,9 @@ namespace detail {
 			        buf_b.get_access<mode::discard_write>(cgh, one_to_one{});
 		        },
 		        cl::sycl::range<1>{100}));
-		const auto computes_b_node1 = inspector.get_commands(tid_b, node_id(1), command_type::EXECUTION);
+		const auto computes_b_node1 = inspector.get_commands(tid_b, node_id(1), command_type::execution);
 		CHECK(computes_b_node1.size() == 1);
-		const auto computes_b_node2 = inspector.get_commands(tid_b, node_id(2), command_type::EXECUTION);
+		const auto computes_b_node2 = inspector.get_commands(tid_b, node_id(2), command_type::execution);
 		CHECK(computes_b_node2.size() == 1);
 
 		CHECK(inspector.has_dependency(*computes_b_node1.cbegin(), *computes_a_node1.cbegin()));
@@ -307,15 +307,15 @@ namespace detail {
 
 		// Even though we're testing for different conditions, we can use the same assertions here.
 
-		const auto computes = inspector.get_commands(std::nullopt, std::nullopt, command_type::EXECUTION);
+		const auto computes = inspector.get_commands(std::nullopt, std::nullopt, command_type::execution);
 		CHECK(computes.size() == 3);
 
-		const auto computes_a = inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION);
+		const auto computes_a = inspector.get_commands(tid_a, std::nullopt, command_type::execution);
 		CHECK(computes_a.size() == 1);
-		const auto computes_b = inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION);
+		const auto computes_b = inspector.get_commands(tid_b, std::nullopt, command_type::execution);
 		CHECK(computes_b.size() == 1);
 		CHECK(inspector.has_dependency(*computes_b.cbegin(), *computes_a.cbegin()));
-		const auto computes_c = inspector.get_commands(tid_c, std::nullopt, command_type::EXECUTION);
+		const auto computes_c = inspector.get_commands(tid_c, std::nullopt, command_type::execution);
 		CHECK(computes_c.size() == 1);
 		CHECK(inspector.has_dependency(*computes_c.cbegin(), *computes_a.cbegin()));
 
@@ -334,11 +334,11 @@ namespace detail {
 		const auto tid_a = test_utils::build_and_flush(ctx, 3, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 			buf.get_access<mode::discard_write>(cgh, fixed<1>({0, 100}));
 		}));
-		const auto master_node_tasks_a = inspector.get_commands(tid_a, node_id(0), command_type::EXECUTION);
+		const auto master_node_tasks_a = inspector.get_commands(tid_a, node_id(0), command_type::execution);
 		const auto tid_b = test_utils::build_and_flush(ctx, 3, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler& cgh) {
 			buf.get_access<mode::discard_write>(cgh, fixed<1>({0, 100}));
 		}));
-		const auto master_node_tasks_b = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+		const auto master_node_tasks_b = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 		CHECK(master_node_tasks_b.size() == 1);
 		REQUIRE(inspector.has_dependency(*master_node_tasks_b.cbegin(), *master_node_tasks_a.cbegin()));
 
@@ -346,7 +346,7 @@ namespace detail {
 	}
 
 	// TODO: This test is too white-boxy. Come up with a different solution (ideally by simplifying the approach inside graph_generator).
-	TEST_CASE("graph_generator generates anti-dependencies for execution commands onto PUSHes within the same task", "[graph_generator][command-graph]") {
+	TEST_CASE("graph_generator generates anti-dependencies for execution commands onto pushes within the same task", "[graph_generator][command-graph]") {
 		using namespace cl::sycl::access;
 		test_utils::cdag_test_context ctx(2);
 		auto& inspector = ctx.get_inspector();
@@ -358,7 +358,7 @@ namespace detail {
 		// 	   - The second is done by the "intra-task" loop at the end.
 		// TODO DRY this up
 
-		SECTION("if the PUSH is generated before the execution command") {
+		SECTION("if the push is generated before the execution command") {
 			test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
@@ -380,20 +380,20 @@ namespace detail {
 				        });
 			        },
 			        cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 2);
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 2);
-			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 2);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 2);
+			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 2);
 
-			const auto pushes_master = inspector.get_commands(std::nullopt, node_id(0), command_type::PUSH);
+			const auto pushes_master = inspector.get_commands(std::nullopt, node_id(0), command_type::push);
 			CHECK(pushes_master.size() == 1);
-			const auto computes_master = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+			const auto computes_master = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 			CHECK(computes_master.size() == 1);
 			// Since the master node does not write to the buffer, there is no anti-dependency...
 			REQUIRE_FALSE(inspector.has_dependency(*computes_master.cbegin(), *pushes_master.cbegin()));
 
-			const auto pushes_node1 = inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH);
+			const auto pushes_node1 = inspector.get_commands(std::nullopt, node_id(1), command_type::push);
 			CHECK(pushes_node1.size() == 1);
-			const auto computes_node1 = inspector.get_commands(tid_b, node_id(1), command_type::EXECUTION);
+			const auto computes_node1 = inspector.get_commands(tid_b, node_id(1), command_type::execution);
 			CHECK(computes_node1.size() == 1);
 			// ...however for the worker, there is.
 			REQUIRE(inspector.has_dependency(*computes_node1.cbegin(), *pushes_node1.cbegin()));
@@ -401,7 +401,7 @@ namespace detail {
 			test_utils::maybe_print_graphs(ctx);
 		}
 
-		SECTION("if the PUSH is generated after the execution command") {
+		SECTION("if the push is generated after the execution command") {
 			test_utils::build_and_flush(ctx, 2,
 			    test_utils::add_compute_task<class UKN(task_a)>(
 			        ctx.get_task_manager(), [&](handler& cgh) { buf.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
@@ -423,20 +423,20 @@ namespace detail {
 				        });
 			        },
 			        cl::sycl::range<1>{100}));
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::PUSH).size() == 2);
-			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::AWAIT_PUSH).size() == 2);
-			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 2);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::push).size() == 2);
+			CHECK(inspector.get_commands(std::nullopt, std::nullopt, command_type::await_push).size() == 2);
+			CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 2);
 
-			const auto pushes_node1 = inspector.get_commands(std::nullopt, node_id(1), command_type::PUSH);
+			const auto pushes_node1 = inspector.get_commands(std::nullopt, node_id(1), command_type::push);
 			CHECK(pushes_node1.size() == 1);
-			const auto computes_node1 = inspector.get_commands(tid_b, node_id(1), command_type::EXECUTION);
+			const auto computes_node1 = inspector.get_commands(tid_b, node_id(1), command_type::execution);
 			CHECK(computes_node1.size() == 1);
 			// Since the worker node does not write to the buffer, there is no anti-dependency...
 			REQUIRE_FALSE(inspector.has_dependency(*computes_node1.cbegin(), *pushes_node1.cbegin()));
 
-			const auto pushes_master = inspector.get_commands(std::nullopt, node_id(0), command_type::PUSH);
+			const auto pushes_master = inspector.get_commands(std::nullopt, node_id(0), command_type::push);
 			CHECK(pushes_master.size() == 1);
-			const auto computes_master = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+			const auto computes_master = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 			CHECK(computes_master.size() == 1);
 			// ...however for the master, there is.
 			REQUIRE(inspector.has_dependency(*computes_master.cbegin(), *pushes_master.cbegin()));
@@ -460,8 +460,8 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(task_a)>(
 		        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::read>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::EXECUTION).size() == 1);
-		const auto computes_a = inspector.get_commands(tid_a, node_id(0), command_type::EXECUTION);
+		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 1);
+		const auto computes_a = inspector.get_commands(tid_a, node_id(0), command_type::execution);
 		CHECK(computes_a.size() == 1);
 
 		// task_b writes to the same buffer a
@@ -469,8 +469,8 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(task_b)>(
 		        ctx.get_task_manager(), [&](handler& cgh) { buf_a.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-		CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::EXECUTION).size() == 1);
-		const auto computes_b = inspector.get_commands(tid_b, node_id(0), command_type::EXECUTION);
+		CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 1);
+		const auto computes_b = inspector.get_commands(tid_b, node_id(0), command_type::execution);
 		CHECK(computes_b.size() == 1);
 		// task_b should have an anti-dependency onto task_a
 		REQUIRE(inspector.has_dependency(*computes_b.cbegin(), *computes_a.cbegin()));
@@ -480,8 +480,8 @@ namespace detail {
 		    test_utils::add_compute_task<class UKN(task_c)>(
 		        ctx.get_task_manager(), [&](handler& cgh) { buf_b.get_access<mode::discard_write>(cgh, one_to_one{}); }, cl::sycl::range<1>{100}));
 
-		CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::EXECUTION).size() == 1);
-		const auto computes_c = inspector.get_commands(tid_c, node_id(0), command_type::EXECUTION);
+		CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::execution).size() == 1);
+		const auto computes_c = inspector.get_commands(tid_c, node_id(0), command_type::execution);
 		CHECK(computes_c.size() == 1);
 		// task_c should not have any anti-dependencies at all
 		REQUIRE(inspector.get_dependency_count(*computes_c.cbegin()) == 0);
@@ -497,8 +497,8 @@ namespace detail {
 
 		auto all_command_dependencies = [&](task_id depender, task_id dependency, auto predicate) {
 			auto& cdag = ctx.get_command_graph();
-			auto depender_commands = inspector.get_commands(depender, std::nullopt, command_type::EXECUTION);
-			auto dependency_commands = inspector.get_commands(dependency, std::nullopt, command_type::EXECUTION);
+			auto depender_commands = inspector.get_commands(depender, std::nullopt, command_type::execution);
+			auto dependency_commands = inspector.get_commands(dependency, std::nullopt, command_type::execution);
 			for(auto depender_cid : depender_commands) {
 				auto depender_cmd = cdag.get(depender_cid);
 				for(auto dependency_cid : dependency_commands) {
@@ -511,7 +511,7 @@ namespace detail {
 
 		auto has_dependencies_on_same_node = [&](task_id depender, task_id dependency) {
 			return all_command_dependencies(depender, dependency, [](auto depender_cmd, auto dependency_cmd) {
-				return depender_cmd->has_dependency(dependency_cmd, dependency_kind::TRUE_DEP) == (depender_cmd->get_nid() == dependency_cmd->get_nid());
+				return depender_cmd->has_dependency(dependency_cmd, dependency_kind::true_dep) == (depender_cmd->get_nid() == dependency_cmd->get_nid());
 			});
 		};
 
@@ -570,7 +570,7 @@ namespace detail {
 
 		// TODO placeholder: complete with dependency types for other side effect orders
 		const auto expected_dependencies = std::unordered_map<std::pair<order, order>, std::optional<dependency_kind>, pair_hash>{
-		    {{order::sequential, order::sequential}, dependency_kind::TRUE_DEP},
+		    {{order::sequential, order::sequential}, dependency_kind::true_dep},
 		};
 
 		const auto order_a = GENERATE(values(side_effect_orders));
@@ -714,7 +714,7 @@ namespace detail {
 				const auto deps = cdag.get(cid)->get_dependencies();
 				CHECK(std::distance(deps.begin(), deps.end()) == 1);
 				for(const auto& d : deps) {
-					CHECK(d.kind == dependency_kind::TRUE_DEP);
+					CHECK(d.kind == dependency_kind::true_dep);
 					CHECKED_IF(isa<task_command>(d.node)) { CHECK(static_cast<task_command*>(d.node)->get_tid() == tid_before); }
 				}
 			}
@@ -783,7 +783,7 @@ namespace detail {
 				const auto cmd = cdag.get(cid);
 				for(const auto& dep : cmd->get_dependents()) {
 					const auto dep_cid = dep.node->get_cid();
-					if(dep.kind == dependency_kind::TRUE_DEP && !transitive_dependents.count(dep_cid)) { new_dependent_front.insert(dep_cid); }
+					if(dep.kind == dependency_kind::true_dep && !transitive_dependents.count(dep_cid)) { new_dependent_front.insert(dep_cid); }
 				}
 			}
 			dependent_front = std::move(new_dependent_front);

--- a/test/intrusive_graph_tests.cc
+++ b/test/intrusive_graph_tests.cc
@@ -12,9 +12,9 @@ namespace detail {
 			// Adding and removing true dependency
 			{
 				my_graph_node n0, n1;
-				n0.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
-				REQUIRE(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
-				REQUIRE(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
+				n0.add_dependency({&n1, dependency_kind::true_dep, dependency_origin::dataflow});
+				REQUIRE(n0.has_dependency(&n1, dependency_kind::true_dep));
+				REQUIRE(n1.has_dependent(&n0, dependency_kind::true_dep));
 				n0.remove_dependency(&n1);
 				REQUIRE_FALSE(n0.has_dependency(&n1));
 				REQUIRE_FALSE(n1.has_dependent(&n0));
@@ -22,18 +22,18 @@ namespace detail {
 			// Pseudo- or anti-dependency is upgraded to true dependency
 			{
 				my_graph_node n0, n1, n2;
-				n0.add_dependency({&n1, dependency_kind::ANTI_DEP, dependency_origin::dataflow});
-				n0.add_dependency({&n2, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
-				CHECK(n0.has_dependency(&n1, dependency_kind::ANTI_DEP));
-				CHECK(n1.has_dependent(&n0, dependency_kind::ANTI_DEP));
-				n0.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
-				n0.add_dependency({&n2, dependency_kind::ANTI_DEP, dependency_origin::dataflow});
-				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::ANTI_DEP));
-				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::ANTI_DEP));
-				REQUIRE(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
-				REQUIRE(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
-				REQUIRE_FALSE(n0.has_dependency(&n2, dependency_kind::ANTI_DEP));
-				REQUIRE_FALSE(n2.has_dependent(&n0, dependency_kind::ANTI_DEP));
+				n0.add_dependency({&n1, dependency_kind::anti_dep, dependency_origin::dataflow});
+				n0.add_dependency({&n2, dependency_kind::true_dep, dependency_origin::dataflow});
+				CHECK(n0.has_dependency(&n1, dependency_kind::anti_dep));
+				CHECK(n1.has_dependent(&n0, dependency_kind::anti_dep));
+				n0.add_dependency({&n1, dependency_kind::true_dep, dependency_origin::dataflow});
+				n0.add_dependency({&n2, dependency_kind::anti_dep, dependency_origin::dataflow});
+				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::anti_dep));
+				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::anti_dep));
+				REQUIRE(n0.has_dependency(&n1, dependency_kind::true_dep));
+				REQUIRE(n1.has_dependent(&n0, dependency_kind::true_dep));
+				REQUIRE_FALSE(n0.has_dependency(&n2, dependency_kind::anti_dep));
+				REQUIRE_FALSE(n2.has_dependent(&n0, dependency_kind::anti_dep));
 			}
 		}
 
@@ -41,19 +41,19 @@ namespace detail {
 			// True dependency cannot be downgraded to anti-dependency
 			{
 				my_graph_node n0, n1;
-				n0.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
-				CHECK(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
-				CHECK(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
-				n0.add_dependency({&n1, dependency_kind::ANTI_DEP, dependency_origin::dataflow});
-				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::ANTI_DEP));
-				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::ANTI_DEP));
-				REQUIRE(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
-				REQUIRE(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
-				n0.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
-				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::ANTI_DEP));
-				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::ANTI_DEP));
-				REQUIRE(n0.has_dependency(&n1, dependency_kind::TRUE_DEP));
-				REQUIRE(n1.has_dependent(&n0, dependency_kind::TRUE_DEP));
+				n0.add_dependency({&n1, dependency_kind::true_dep, dependency_origin::dataflow});
+				CHECK(n0.has_dependency(&n1, dependency_kind::true_dep));
+				CHECK(n1.has_dependent(&n0, dependency_kind::true_dep));
+				n0.add_dependency({&n1, dependency_kind::anti_dep, dependency_origin::dataflow});
+				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::anti_dep));
+				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::anti_dep));
+				REQUIRE(n0.has_dependency(&n1, dependency_kind::true_dep));
+				REQUIRE(n1.has_dependent(&n0, dependency_kind::true_dep));
+				n0.add_dependency({&n1, dependency_kind::true_dep, dependency_origin::dataflow});
+				REQUIRE_FALSE(n0.has_dependency(&n1, dependency_kind::anti_dep));
+				REQUIRE_FALSE(n1.has_dependent(&n0, dependency_kind::anti_dep));
+				REQUIRE(n0.has_dependency(&n1, dependency_kind::true_dep));
+				REQUIRE(n1.has_dependent(&n0, dependency_kind::true_dep));
 			}
 		}
 	}
@@ -61,10 +61,10 @@ namespace detail {
 	TEST_CASE("intrusive_graph_node removes itself from all connected nodes upon destruction", "[intrusive_graph_node]") {
 		my_graph_node n0, n2;
 		auto n1 = std::make_unique<my_graph_node>();
-		n0.add_dependency({n1.get(), dependency_kind::TRUE_DEP, dependency_origin::dataflow});
-		n1->add_dependency({&n2, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
-		CHECK(n0.has_dependency(n1.get(), dependency_kind::TRUE_DEP));
-		CHECK(n2.has_dependent(n1.get(), dependency_kind::TRUE_DEP));
+		n0.add_dependency({n1.get(), dependency_kind::true_dep, dependency_origin::dataflow});
+		n1->add_dependency({&n2, dependency_kind::true_dep, dependency_origin::dataflow});
+		CHECK(n0.has_dependency(n1.get(), dependency_kind::true_dep));
+		CHECK(n2.has_dependent(n1.get(), dependency_kind::true_dep));
 		n1.reset();
 		REQUIRE(std::distance(n0.get_dependencies().begin(), n0.get_dependencies().end()) == 0);
 		REQUIRE(std::distance(n2.get_dependents().begin(), n2.get_dependents().end()) == 0);
@@ -73,12 +73,12 @@ namespace detail {
 	TEST_CASE("intrusive_graph_node keeps track of the pseudo critical path length", "[intrusive_graph_node]") {
 		my_graph_node n0, n1, n2, n3;
 		REQUIRE(n3.get_pseudo_critical_path_length() == 0);
-		n3.add_dependency({&n2, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+		n3.add_dependency({&n2, dependency_kind::true_dep, dependency_origin::dataflow});
 		REQUIRE(n3.get_pseudo_critical_path_length() == 1);
-		n3.add_dependency({&n0, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+		n3.add_dependency({&n0, dependency_kind::true_dep, dependency_origin::dataflow});
 		REQUIRE(n3.get_pseudo_critical_path_length() == 1);
-		n1.add_dependency({&n0, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
-		n3.add_dependency({&n1, dependency_kind::TRUE_DEP, dependency_origin::dataflow});
+		n1.add_dependency({&n0, dependency_kind::true_dep, dependency_origin::dataflow});
+		n3.add_dependency({&n1, dependency_kind::true_dep, dependency_origin::dataflow});
 		REQUIRE(n3.get_pseudo_critical_path_length() == 2);
 	}
 

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -267,7 +267,7 @@ namespace detail {
 		    },
 		    cl::sycl::range<2>{32, 128}, cl::sycl::id<2>{32, 24});
 		const auto tsk = tm.get_task(tid);
-		REQUIRE(tsk->get_type() == task_type::DEVICE_COMPUTE);
+		REQUIRE(tsk->get_type() == task_type::device_compute);
 		REQUIRE(tsk->get_dimensions() == 2);
 		REQUIRE(tsk->get_global_size() == cl::sycl::range<3>{32, 128, 1});
 		REQUIRE(tsk->get_global_offset() == cl::sycl::id<3>{32, 24, 0});
@@ -316,7 +316,7 @@ namespace detail {
 	template <typename T>
 	class MyThirdKernel;
 
-	TEST_CASE("DEVICE_COMPUTE tasks derive debug name from kernel name", "[task][!mayfail]") {
+	TEST_CASE("device_compute tasks derive debug name from kernel name", "[task][!mayfail]") {
 		auto tm = std::make_unique<detail::task_manager>(1, nullptr, nullptr);
 		auto t1 =
 		    tm->get_task(tm->submit_command_group([](handler& cgh) { cgh.parallel_for<class MyFirstKernel>(cl::sycl::range<1>{1}, [](cl::sycl::id<1>) {}); }));

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -37,24 +37,24 @@ namespace detail {
 	struct buffer_manager_testspy {
 		template <typename DataT, int Dims>
 		static buffer_manager::access_info<DataT, Dims, device_buffer> get_device_buffer(buffer_manager& bm, buffer_id bid) {
-			std::unique_lock lock(bm.mutex);
-			auto& buf = bm.buffers.at(bid).device_buf;
+			std::unique_lock lock(bm.m_mutex);
+			auto& buf = bm.m_buffers.at(bid).device_buf;
 			return {dynamic_cast<device_buffer_storage<DataT, Dims>*>(buf.storage.get())->get_device_buffer(), id_cast<Dims>(buf.offset)};
 		}
 	};
 
 	struct runtime_testspy {
-		static scheduler& get_schdlr(runtime& rt) { return *rt.schdlr; }
+		static scheduler& get_schdlr(runtime& rt) { return *rt.m_schdlr; }
 
-		static executor& get_exec(runtime& rt) { return *rt.exec; }
+		static executor& get_exec(runtime& rt) { return *rt.m_exec; }
 	};
 
 	struct scheduler_testspy {
-		static std::thread& get_worker_thread(scheduler& schdlr) { return schdlr.worker_thread; }
+		static std::thread& get_worker_thread(scheduler& schdlr) { return schdlr.m_worker_thread; }
 	};
 
 	struct executor_testspy {
-		static std::thread& get_exec_thrd(executor& exec) { return exec.exec_thrd; }
+		static std::thread& get_exec_thrd(executor& exec) { return exec.m_exec_thrd; }
 	};
 
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "only a single distr_queue can be created", "[distr_queue][lifetime][dx]") {
@@ -892,17 +892,17 @@ namespace detail {
 		DWORD_PTR process_mask;
 #else
 		restore_process_affinity_fixture() {
-			const auto ret = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &process_mask);
+			const auto ret = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &m_process_mask);
 			REQUIRE(ret == 0);
 		}
 
 		~restore_process_affinity_fixture() {
-			const auto ret = pthread_setaffinity_np(pthread_self(), sizeof(process_mask), &process_mask);
+			const auto ret = pthread_setaffinity_np(pthread_self(), sizeof(m_process_mask), &m_process_mask);
 			REQUIRE(ret == 0);
 		}
 
 	  private:
-		cpu_set_t process_mask;
+		cpu_set_t m_process_mask;
 #endif
 	};
 

--- a/test/test_main.cc
+++ b/test/test_main.cc
@@ -24,7 +24,7 @@ int main(int argc, char* argv[]) {
 	return returnCode;
 }
 
-struct GlobalSetupAndTeardown : Catch::EventListenerBase {
+struct global_setup_and_teardown : Catch::EventListenerBase {
 	using EventListenerBase::EventListenerBase;
 	void testCasePartialEnded(const Catch::TestCaseStats&, uint64_t) override {
 		// Reset REQUIRE_LOOP after each test case, section or generator value.
@@ -32,4 +32,4 @@ struct GlobalSetupAndTeardown : Catch::EventListenerBase {
 	}
 };
 
-CATCH_REGISTER_LISTENER(GlobalSetupAndTeardown);
+CATCH_REGISTER_LISTENER(global_setup_and_teardown);

--- a/test/test_main.cc
+++ b/test/test_main.cc
@@ -15,13 +15,13 @@ int main(int argc, char* argv[]) {
 
 	session.cli(cli);
 
-	int returnCode = session.applyCommandLine(argc, argv);
-	if(returnCode != 0) { return returnCode; }
+	int return_code = session.applyCommandLine(argc, argv);
+	if(return_code != 0) { return return_code; }
 
 	celerity::detail::runtime::test_mode_enter();
-	returnCode = session.run();
+	return_code = session.run();
 	celerity::detail::runtime::test_mode_exit();
-	return returnCode;
+	return return_code;
 }
 
 struct global_setup_and_teardown : Catch::EventListenerBase {

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -41,27 +41,27 @@ namespace celerity {
 namespace detail {
 
 	struct task_ring_buffer_testspy {
-		static void create_task_slot(task_ring_buffer& trb) { trb.number_of_deleted_tasks += 1; }
+		static void create_task_slot(task_ring_buffer& trb) { trb.m_number_of_deleted_tasks += 1; }
 	};
 
 	struct task_manager_testspy {
-		static std::optional<task_id> get_current_horizon(task_manager& tm) { return tm.current_horizon; }
+		static std::optional<task_id> get_current_horizon(task_manager& tm) { return tm.m_current_horizon; }
 
 		static int get_num_horizons(task_manager& tm) {
 			int horizon_counter = 0;
-			for(auto task_ptr : tm.task_buffer) {
+			for(auto task_ptr : tm.m_task_buffer) {
 				if(task_ptr->get_type() == task_type::horizon) { horizon_counter++; }
 			}
 			return horizon_counter;
 		}
 
-		static region_map<std::optional<task_id>> get_last_writer(task_manager& tm, const buffer_id bid) { return tm.buffers_last_writers.at(bid); }
+		static region_map<std::optional<task_id>> get_last_writer(task_manager& tm, const buffer_id bid) { return tm.m_buffers_last_writers.at(bid); }
 
 		static int get_max_pseudo_critical_path_length(task_manager& tm) { return tm.get_max_pseudo_critical_path_length(); }
 
 		static auto get_execution_front(task_manager& tm) { return tm.get_execution_front(); }
 
-		static void create_task_slot(task_manager& tm) { task_ring_buffer_testspy::create_task_slot(tm.task_buffer); }
+		static void create_task_slot(task_manager& tm) { task_ring_buffer_testspy::create_task_slot(tm.m_task_buffer); }
 	};
 
 	inline bool has_dependency(const task_manager& tm, task_id dependent, task_id dependency, dependency_kind kind = dependency_kind::true_dep) {

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -50,7 +50,7 @@ namespace detail {
 		static int get_num_horizons(task_manager& tm) {
 			int horizon_counter = 0;
 			for(auto task_ptr : tm.task_buffer) {
-				if(task_ptr->get_type() == task_type::HORIZON) { horizon_counter++; }
+				if(task_ptr->get_type() == task_type::horizon) { horizon_counter++; }
 			}
 			return horizon_counter;
 		}
@@ -64,7 +64,7 @@ namespace detail {
 		static void create_task_slot(task_manager& tm) { task_ring_buffer_testspy::create_task_slot(tm.task_buffer); }
 	};
 
-	inline bool has_dependency(const task_manager& tm, task_id dependent, task_id dependency, dependency_kind kind = dependency_kind::TRUE_DEP) {
+	inline bool has_dependency(const task_manager& tm, task_id dependent, task_id dependency, dependency_kind kind = dependency_kind::true_dep) {
 		for(auto dep : tm.get_task(dependent)->get_dependencies()) {
 			if(dep.node->get_id() == dependency && dep.kind == kind) return true;
 		}
@@ -191,8 +191,8 @@ namespace test_utils {
 		    std::optional<detail::task_id> tid, std::optional<detail::node_id> nid, std::optional<detail::command_type> cmd) const {
 			// Sanity check: Not all commands have an associated task id
 			assert(tid == std::nullopt
-			       || (cmd == std::nullopt || cmd == detail::command_type::EXECUTION || cmd == detail::command_type::HORIZON
-			           || cmd == detail::command_type::EPOCH));
+			       || (cmd == std::nullopt || cmd == detail::command_type::execution || cmd == detail::command_type::horizon
+			           || cmd == detail::command_type::epoch));
 
 			std::set<detail::command_id> result;
 			std::transform(commands.cbegin(), commands.cend(), std::inserter(result, result.begin()), [](auto p) { return p.first; });


### PR DESCRIPTION
This change is based on #120, so that one should be merged first.

This adds a clang-tidy configuration with customized settings for (hopefully) all of our naming conventions, including the newly agreed upon `m_` prefix for private class members. I've also enabled all `readability-`, `performance-`, `cppcoreguidelines-` and `mpi-` checks. We'll have to see if we need to disable / configure some of those if they are too annoying (in particular the cppcore guidelines seem to be quite opinionated).

CI now also runs clang-tidy on the lines that have been changed in a PR, with a bot adding code comments (including quick-fixes, where possible) for all warnings. Obviously this is a last resort and ideally you should update your IDE to use the new config file so you can catch those diagnostics while writing the code.

In an ideal world our entire codebase would pass the clang-tidy checks, but we're not there yet (by a long shot), so I think doing it incrementally when changing existing code is a decent approach for now.