### PR TITLE
Update authoritative version of clang-format to 14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,8 @@
+# Clang-format coding style definitions for Celerity
+#
+# Due to some inconsistencies between releases we currently
+# use clang-format 14 as the authoritative version.
+
 BasedOnStyle: llvm
 
 AlignAfterOpenBracket: DontAlign
@@ -5,7 +10,7 @@ AlignOperands: true
 AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Unfortunately Clang Format frequently has breaking changes with major
 releases (which are tied to the Clang release cycle), which means we have to
 settle on a specific version.
 
-We currently use `clang-format-10`. Please make sure to use the correct
+We currently use `clang-format-14`. Please make sure to use the correct
 version to avoid cluttering your diffs with unrelated format changes.
 
 You can automatically determine whether you've correctly formatted all of

--- a/include/host_object.h
+++ b/include/host_object.h
@@ -165,7 +165,7 @@ class host_object<void> {
 // The universal reference parameter T&& matches U& as well as U&& for object types U, but we don't want to implicitly invoke a copy constructor: the user
 // might have intended to either create a host_object<T&> (which requires a std::reference_wrapper parameter) or move-construct the interior.
 template <typename T>
-explicit host_object(T &&) -> host_object<detail::assert_host_object_ctor_param_is_rvalue_t<T>>;
+explicit host_object(T&&) -> host_object<detail::assert_host_object_ctor_param_is_rvalue_t<T>>;
 
 template <typename T>
 explicit host_object(std::reference_wrapper<T>) -> host_object<T&>;

--- a/src/platform_specific/named_threads.unix.cc
+++ b/src/platform_specific/named_threads.unix.cc
@@ -11,9 +11,7 @@ static_assert(std::is_same_v<std::thread::native_handle_type, pthread_t>, "Unexp
 
 constexpr auto PTHREAD_MAX_THREAD_NAME_LEN = 16;
 
-std::thread::native_handle_type get_current_thread_handle() {
-	return pthread_self();
-}
+std::thread::native_handle_type get_current_thread_handle() { return pthread_self(); }
 
 void set_thread_name(const std::thread::native_handle_type thread_handle, const std::string& name) {
 	auto truncated_name = name;

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -28,9 +28,7 @@ static inline std::wstring convert_string(const std::string& str) {
 	return dst;
 }
 
-std::thread::native_handle_type get_current_thread_handle() {
-	return GetCurrentThread();
-}
+std::thread::native_handle_type get_current_thread_handle() { return GetCurrentThread(); }
 
 void set_thread_name(const std::thread::native_handle_type thread_handle, const std::string& name) {
 	const auto wname = convert_string(name);

--- a/test/accessor_tests.cc
+++ b/test/accessor_tests.cc
@@ -164,9 +164,8 @@ namespace detail {
 		// this kernel initializes the buffer what will be read after.
 		auto acc_write =
 		    accessor_fixture<Dims>::template get_device_accessor<size_t, Dims, cl::sycl::access::mode::discard_write>(cgh, bid, range_cast<Dims>(range), {});
-		cgh.parallel_for<class kernel_multi_dim_accessor_write_<Dims>>(range_cast<Dims>(range), [=](celerity::item<Dims> item) {
-			acc_write[item] = item.get_linear_id();
-		});
+		cgh.parallel_for<class kernel_multi_dim_accessor_write_<Dims>>(
+		    range_cast<Dims>(range), [=](celerity::item<Dims> item) { acc_write[item] = item.get_linear_id(); });
 		cgh.get_submission_event().wait();
 
 		SECTION("for device buffers") {
@@ -205,9 +204,9 @@ namespace detail {
 		}
 
 		typename accessor_fixture<Dims>::access_target tgt = accessor_fixture<Dims>::access_target::HOST;
-		bool acc_check = accessor_fixture<Dims>::template buffer_reduce<size_t, Dims, class check_multi_dim_accessor<Dims>>(bid, tgt,
-		    range_cast<Dims>(range), {}, true, [range=range_cast<Dims>(range)](cl::sycl::id<Dims> idx, bool current, size_t value) {
-			return current && value == get_linear_index(range, idx); });
+		bool acc_check = accessor_fixture<Dims>::template buffer_reduce<size_t, Dims, class check_multi_dim_accessor<Dims>>(bid, tgt, range_cast<Dims>(range),
+		    {}, true,
+		    [range = range_cast<Dims>(range)](cl::sycl::id<Dims> idx, bool current, size_t value) { return current && value == get_linear_index(range, idx); });
 
 		REQUIRE(acc_check);
 	}


### PR DESCRIPTION
This thankfully is mostly a documentation change, except for one bug fix in connection with deduction guides.

Also change the `AllowShortFunctionsOnASingleLine` rule from `Inline` to `true`. This rule seems to be extremely buggy, and clang-format's behavior for `Inline` starting with version 13 does not make any sense. Earlier versions also didn't treat the rule correctly (basically all short functions were put on a single line, regardless of their position in the code), which is what `true` is supposed to do (at least to my understanding).