### PR TITLE
Dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Celerity's runtime behavior:
   should be queried (currently not supported when using hipSYCL).
 - `CELERITY_GRAPH_PRINT_MAX_VERTS` sets the maximum number of vertices the
   task/command graphs can have above which their GraphViz output will be omitted.
+- `CELERITY_DRY_RUN_NODES` takes a number and simulates a run with that many nodes
+  without actually executing the commands.
 
 ## Disclaimer
 

--- a/include/config.h
+++ b/include/config.h
@@ -40,6 +40,8 @@ namespace detail {
 		 */
 		const std::optional<device_config>& get_device_config() const { return m_device_cfg; };
 		std::optional<bool> get_enable_device_profiling() const { return m_enable_device_profiling; };
+		bool is_dry_run() const { return m_dry_run_nodes > 0; };
+		int get_dry_run_nodes() const { return m_dry_run_nodes; }
 
 		size_t get_graph_print_max_verts() const { return m_graph_print_max_verts; };
 
@@ -49,6 +51,7 @@ namespace detail {
 		std::optional<device_config> m_device_cfg;
 		std::optional<bool> m_enable_device_profiling;
 		size_t m_graph_print_max_verts = 200;
+		int m_dry_run_nodes = 0;
 	};
 
 } // namespace detail

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -77,6 +77,8 @@ namespace detail {
 
 		host_object_manager& get_host_object_manager() const;
 
+		bool is_dry_run() const { return m_cfg->is_dry_run(); }
+
 	  private:
 		inline static bool m_mpi_initialized = false;
 		inline static bool m_mpi_finalized = false;

--- a/src/config.cc
+++ b/src/config.cc
@@ -180,6 +180,16 @@ namespace detail {
 			const auto result = get_env("CELERITY_FORCE_WG");
 			if(result.first) { CELERITY_WARN("Support for CELERITY_FORCE_WG has been removed with Celerity 0.3.0."); }
 		}
+
+		// -------------------------------- CELERITY_DRY_RUN_NODES ---------------------------------
+		{
+			const auto [is_set, value] = get_env("CELERITY_DRY_RUN_NODES");
+			if(is_set) {
+				const auto [is_valid, num_nodes] = parse_uint(value.c_str());
+				if(!is_valid) { CELERITY_WARN("CELERITY_DRY_RUN_NODES contains invalid value - will be ignored"); }
+				m_dry_run_nodes = num_nodes;
+			}
+		}
 	}
 } // namespace detail
 } // namespace celerity

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -6,6 +6,12 @@
 #include <string>
 #include <unordered_set>
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include <catch2/catch_test_macros.hpp>
 #include <celerity.h>
 
@@ -432,6 +438,55 @@ namespace test_utils {
 			maybe_print_graph(ctx.get_command_graph(), ctx.get_task_manager(), ctx.get_reduction_manager());
 		}
 	}
+
+	class set_test_env {
+	  public:
+#ifdef _WIN32
+		set_test_env(const std::string& env, const std::string& val) : m_env_var_name(env) {
+			//  We use the ANSI version of Get/Set, because it does not require type conversion of char to wchar_t, and we can safely do this
+			//  because we are not mutating the text and therefore can treat them as raw bytes without having to worry about the text encoding.
+			const auto name_size = GetEnvironmentVariableA(env.c_str(), nullptr, 0);
+			if(name_size > 0) {
+				m_original_value.resize(name_size);
+				const auto res = GetEnvironmentVariableA(env.c_str(), m_original_value.data(), name_size);
+				assert(res != 0 && "Failed to get celerity environment variable");
+			}
+			const auto res = SetEnvironmentVariableA(env.c_str(), val.c_str());
+			assert(res != 0 && "Failed to set celerity environment variable");
+		}
+
+		~set_test_env() {
+			if(m_original_value.empty()) {
+				const auto res = SetEnvironmentVariableA(m_env_var_name.c_str(), NULL);
+				assert(res != 0 && "Failed to delete celerity environment variable");
+			} else {
+				const auto res = SetEnvironmentVariableA(m_env_var_name.c_str(), m_original_value.c_str());
+				assert(res != 0 && "Failed to reset celerity environment variable");
+			}
+		}
+
+#else
+		set_test_env(const std::string& env, const std::string& val) {
+			const char* has_value = std::getenv(env.c_str());
+			if(has_value != nullptr) { m_original_value = has_value; }
+			const auto res = setenv(env.c_str(), val.c_str(), 1);
+			assert(res == 0 && "Failed to set celerity environment variable");
+			m_env_var_name = env;
+		}
+		~set_test_env() {
+			if(m_original_value.empty()) {
+				const auto res = unsetenv(m_env_var_name.c_str());
+				assert(res == 0 && "Failed to unset celerity environment variable");
+			} else {
+				const auto res = setenv(m_env_var_name.c_str(), m_original_value.c_str(), 1);
+				assert(res == 0 && "Failed to reset celerity environment variable");
+			}
+		}
+#endif
+	  private:
+		std::string m_env_var_name;
+		std::string m_original_value;
+	};
 
 } // namespace test_utils
 } // namespace celerity


### PR DESCRIPTION
The idea behind this is to able to simulate a run to analyze behavior and how would celerity scale to larger amounts nodes, without necessarily having those nodes.
For this we are not flushing commands unless they are epochs ( and this ones only to the master node).