### PR TITLE
Schedule CI jobs through SLURM

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -23,7 +23,7 @@ jobs:
   build-and-test:
     needs: find-duplicate-workflows
     if: ${{ needs.find-duplicate-workflows.outputs.should_skip != 'true' }}
-    runs-on: ${{ matrix.platform }}
+    runs-on: slurm-${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A lot of behind-the-scenes work has gone into scheduling CI jobs through SLURM on our Nvidia / Intel hardware. The new [slurmactiond](https://github.com/celerity/slurmactiond) service (currently still a private repository) provides the necessary glue to spawn Github Actions runners as SLURM jobs as new CI runs arrive.

~~Two issues still need to be resolved:~~

- [x] ~~ComputeCpp 2.6.0 through 2.8.0 versions seem unable to detect the Intel iGPU on the Core i9-12900 of our runner. If this is a true incompatibility, we should drop these legacy versions.~~ This was actually caused by the Ubuntu 20.04 image containing an Intel Compute Runtime version that was incompatible with the one installed on the host.
- [x] ~~Runner de-registration in slurmactiond is still brittle and occasionally needs manual intervention when jobs fail. The new CI should not enter production until it can run entirely unattended.~~ slurmactiond now has enough recovery features to survive common error conditions.

