### PR TITLE
Fix compilation and runtime issues on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,11 @@ macro(add_submodule_directory RELPATH)
 endmacro()
 
 add_submodule_directory(vendor/spdlog)
+if(WIN32)
+  # Catch2 uses custom top-level exception filters that conflict with MSMPI, which also uses their own filters.
+  # Disabling Windows SEH prevents Catch2 from using their own top-level exception filters.
+  set(CATCH_CONFIG_NO_WINDOWS_SEH ON)
+endif()
 add_submodule_directory(vendor/Catch2)
 
 configure_file(include/version.h.in include/version.h @ONLY)

--- a/include/device_queue.h
+++ b/include/device_queue.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <algorithm>
 #include <memory>
-
-#include <CL/sycl.hpp>
 #include <type_traits>
 #include <variant>
+
+#include <CL/sycl.hpp>
 
 #include "config.h"
 #include "workaround.h"

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <type_traits>
+#include <variant>
 
 namespace celerity::detail::utils {
 

--- a/test/benchmark_reporters.cc
+++ b/test/benchmark_reporters.cc
@@ -236,7 +236,7 @@ class benchmark_md_reporter : public benchmark_reporter_base {
 		};
 
 		const auto min = std::reduce(benchmark_stats.samples.cbegin(), benchmark_stats.samples.cend(),
-		    std::chrono::duration<double, std::nano>(std::numeric_limits<double>::max()), [](auto& a, auto& b) { return std::min(a, b); });
+		    std::chrono::duration<double, std::nano>(std::numeric_limits<double>::max()), [](const auto& a, const auto& b) { return std::min(a, b); });
 
 		m_results_printer.add_row({fmt::format("{}", escape_md_partial(get_test_case_name())), // Test case
 		    escape_md_partial(benchmark_stats.info.name),                                      // Benchmark name

--- a/test/device_selection_tests.cc
+++ b/test/device_selection_tests.cc
@@ -456,7 +456,7 @@ TEST_CASE("pick_device warns when highest scoring devices span multiple platform
 	auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
 	mp_0.create_devices(dt::cpu);
 	mp_1.create_devices(dt::accelerator, dt::gpu, dt::gpu, dt::gpu);
-	mp_2.create_devices(dt::gpu, dt::accelerator, dt::accelerator, dt::accelerator)[2];
+	mp_2.create_devices(dt::gpu, dt::accelerator, dt::accelerator, dt::accelerator);
 
 	const size_t node_count = 4;
 	const size_t local_rank = GENERATE(0, 3);


### PR DESCRIPTION
This PR is based on #129, so that one must be merged first.

Some code changes in past PRs have introduced code that no longer compiles on windows, this PR remedies that by adding missing headers and some minor code tweaks.

Additionally, PR #106 refactored the unit tests, specifically changing when `MPI_Init` is called relative to when Catch2 is initialized. This surfaced an issue where MSMPI changes the top-level exception filter, after Catch2 has already changed it, resulting in a sanity check inside Catch2 failing, where it checks that the previous filter was restored correctly. This PR disables windows SEH for Catch2, mitigating the issue.