### PR TITLE
Add buffer debug names

### DIFF
--- a/examples/matmul/matmul.cc
+++ b/examples/matmul/matmul.cc
@@ -78,6 +78,9 @@ int main() {
 	celerity::buffer<float, 2> mat_b_buf(range);
 	celerity::buffer<float, 2> mat_c_buf(range);
 
+	celerity::debug::set_buffer_name(mat_a_buf, "mat_a");
+	celerity::debug::set_buffer_name(mat_b_buf, "mat_b");
+
 	set_identity(queue, mat_a_buf);
 	set_identity(queue, mat_b_buf);
 

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -93,6 +93,7 @@ namespace detail {
 			cl::sycl::range<3> range = {1, 1, 1};
 			size_t element_size = 0;
 			bool is_host_initialized;
+			std::string debug_name = {};
 		};
 
 		/**
@@ -163,7 +164,8 @@ namespace detail {
 			return !m_buffer_infos.empty();
 		}
 
-		const buffer_info& get_buffer_info(buffer_id bid) const {
+		// returning copy of struct because FOR NOW it is not called in any performance critical section.
+		buffer_info get_buffer_info(buffer_id bid) const {
 			std::shared_lock lock(m_mutex);
 			assert(m_buffer_infos.find(bid) != m_buffer_infos.end());
 			return m_buffer_infos.at(bid);
@@ -311,6 +313,16 @@ namespace detail {
 		void unlock(buffer_lock_id id);
 
 		bool is_locked(buffer_id bid) const;
+
+		void set_debug_name(const buffer_id bid, const std::string& debug_name) {
+			std::lock_guard lock(m_mutex);
+			m_buffer_infos.at(bid).debug_name = debug_name;
+		}
+
+		std::string get_debug_name(const buffer_id bid) const {
+			std::lock_guard lock(m_mutex);
+			return m_buffer_infos.at(bid).debug_name;
+		}
 
 	  private:
 		struct backing_buffer {

--- a/include/celerity.h
+++ b/include/celerity.h
@@ -6,6 +6,7 @@
 
 #include "accessor.h"
 #include "buffer.h"
+#include "debug.h"
 #include "distr_queue.h"
 #include "side_effect.h"
 #include "user_bench.h"

--- a/include/command_graph.h
+++ b/include/command_graph.h
@@ -14,6 +14,7 @@
 namespace celerity {
 namespace detail {
 
+	class buffer_manager;
 	class reduction_manager;
 	class task_manager;
 
@@ -128,7 +129,7 @@ namespace detail {
 
 		auto& task_commands(task_id tid) { return m_by_task.at(tid); }
 
-		std::optional<std::string> print_graph(size_t max_nodes, const task_manager& tm, const reduction_manager& rm) const;
+		std::optional<std::string> print_graph(size_t max_nodes, const task_manager& tm, const reduction_manager& rm, const buffer_manager* bm) const;
 
 		// TODO unify dependency terminology to this
 		void add_dependency(abstract_command* depender, abstract_command* dependee, dependency_kind kind, dependency_origin origin) {

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,0 +1,18 @@
+#include <string>
+
+#include "buffer.h"
+
+namespace celerity {
+namespace debug {
+	template <typename DataT, int Dims>
+	void set_buffer_name(const celerity::buffer<DataT, Dims>& buff, const std::string& debug_name) {
+		detail::set_buffer_name(buff, debug_name);
+		detail::runtime::get_instance().get_buffer_manager().set_debug_name(detail::get_buffer_id(buff), debug_name);
+	}
+	template <typename DataT, int Dims>
+	std::string get_buffer_name(const celerity::buffer<DataT, Dims>& buff) {
+		return detail::get_buffer_name(buff);
+	}
+
+} // namespace debug
+} // namespace celerity

--- a/include/print_graph.h
+++ b/include/print_graph.h
@@ -9,12 +9,13 @@
 namespace celerity {
 namespace detail {
 
+	class buffer_manager;
 	class command_graph;
 	class reduction_manager;
 	class task_manager;
 
-	std::string print_task_graph(const task_ring_buffer& tdag, const reduction_manager& rm);
-	std::string print_command_graph(const command_graph& cdag, const task_manager& tm, const reduction_manager& rm);
+	std::string print_task_graph(const task_ring_buffer& tdag, const reduction_manager& rm, const buffer_manager* bm);
+	std::string print_command_graph(const command_graph& cdag, const task_manager& tm, const reduction_manager& rm, const buffer_manager* bm);
 
 } // namespace detail
 } // namespace celerity

--- a/src/command_graph.cc
+++ b/src/command_graph.cc
@@ -25,8 +25,9 @@ namespace detail {
 		}
 	}
 
-	std::optional<std::string> command_graph::print_graph(size_t max_nodes, const task_manager& tm, const reduction_manager& rm) const {
-		if(command_count() <= max_nodes) { return detail::print_command_graph(*this, tm, rm); }
+	std::optional<std::string> command_graph::print_graph(
+	    size_t max_nodes, const task_manager& tm, const reduction_manager& rm, const buffer_manager* bm) const {
+		if(command_count() <= max_nodes) { return detail::print_command_graph(*this, tm, rm, bm); }
 		return std::nullopt;
 	}
 

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -214,7 +214,7 @@ namespace detail {
 				}
 			}
 			{
-				const auto graph_str = m_cdag->print_graph(print_max_nodes, *m_task_mngr, *m_reduction_mngr);
+				const auto graph_str = m_cdag->print_graph(print_max_nodes, *m_task_mngr, *m_reduction_mngr, m_buffer_mngr.get());
 				if(graph_str.has_value()) {
 					CELERITY_TRACE("Command graph:\n\n{}\n", *graph_str);
 				} else {

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -27,7 +27,7 @@ namespace detail {
 	const task* task_manager::get_task(task_id tid) const { return m_task_buffer.get_task(tid); }
 
 	std::optional<std::string> task_manager::print_graph(size_t max_nodes) const {
-		if(m_task_buffer.get_current_task_count() <= max_nodes) { return detail::print_task_graph(m_task_buffer, *m_reduction_mngr); }
+		if(m_task_buffer.get_current_task_count() <= max_nodes) { return detail::print_task_graph(m_task_buffer, *m_reduction_mngr, nullptr); }
 		return std::nullopt;
 	}
 

--- a/test/buffer_manager_tests.cc
+++ b/test/buffer_manager_tests.cc
@@ -1098,6 +1098,13 @@ namespace detail {
 		}
 	}
 
+	TEST_CASE_METHOD(test_utils::runtime_fixture, "buffer_manager allows to set buffer debug names on  buffers", "[buffer_manager]") {
+		celerity::buffer<int, 1> buff_a(16);
+		std::string buff_name{"my_buffer"};
+		detail::runtime::get_instance().get_buffer_manager().set_debug_name(detail::get_buffer_id(buff_a), buff_name);
+		CHECK(detail::runtime::get_instance().get_buffer_manager().get_debug_name(detail::get_buffer_id(buff_a)) == buff_name);
+	}
+
 #endif // CELERITY_DETAIL_IS_OLD_COMPUTECPP_COMPILER
 
 } // namespace detail

--- a/test/print_graph_tests.cc
+++ b/test/print_graph_tests.cc
@@ -1,4 +1,7 @@
+#include <catch2/catch_test_macros.hpp>
+
 #include "test_utils.h"
+
 
 namespace celerity::detail {
 
@@ -72,7 +75,8 @@ TEST_CASE("command graph printing is unchanged", "[print_graph][command-graph]")
 	// replace the `expected` value with the new dot graph.
 	const auto expected =
 	    "digraph G{label=\"Command Graph\" subgraph cluster_2{label=<<font color=\"#606060\">T2 (master-node host)</font>>;color=darkgray;9[label=<C9 on "
-	    "N0<br/><b>execution</b> [[0,0,0] - [0,0,0]]<br/><i>read</i> B0 {[[0,0,0] - [1,1,1]]}<br/><i>read_write</i> B0 {[[0,0,0] - [1,1,1]]}<br/><i>write</i> "
+	    "N0<br/><b>execution</b> [[0,0,0] - [0,0,0]]<br/><i>read</i> B0 {[[0,0,0] - [1,1,1]]}<br/><i>read_write</i> B0 {[[0,0,0] - "
+	    "[1,1,1]]}<br/><i>write</i> "
 	    "B0 {[[0,0,0] - [1,1,1]]}> fontcolor=black shape=box];}subgraph cluster_1{label=<<font color=\"#606060\">T1 \"task_reduction_8\" "
 	    "(device-compute)</font>>;color=darkgray;5[label=<C5 on N0<br/><b>execution</b> [[0,0,0] - [1,1,1]]<br/>(R1) <i>discard_write</i> B0 {[[0,0,0] - "
 	    "[1,1,1]]}> fontcolor=black shape=box];6[label=<C6 on N1<br/><b>execution</b> [[1,0,0] - [2,1,1]]<br/>(R1) <i>discard_write</i> B0 {[[0,0,0] - "
@@ -81,16 +85,46 @@ TEST_CASE("command graph printing is unchanged", "[print_graph][command-graph]")
 	    "[1,1,1]]}> fontcolor=goldenrod shape=box];}subgraph cluster_0{label=<<font color=\"#606060\">T0 (epoch)</font>>;color=darkgray;0[label=<C0 on "
 	    "N0<br/><b>epoch</b>> fontcolor=black shape=box];1[label=<C1 on N1<br/><b>epoch</b>> fontcolor=crimson shape=box];2[label=<C2 on N2<br/><b>epoch</b>> "
 	    "fontcolor=dodgerblue4 shape=box];3[label=<C3 on N3<br/><b>epoch</b>> fontcolor=goldenrod shape=box];}16[label=<C16 on N0<br/>(R1) <b>await push</b> "
-	    "from N3<br/>B0 [[0,0,0] - [1,1,1]]> fontcolor=black shape=ellipse];0->16[color=orchid];15->16[style=dashed color=gray40];15[label=<C15 on N3<br/>(R1) "
-	    "<b>push</b> to N0<br/>B0 [[0,0,0] - [1,1,1]]> fontcolor=goldenrod shape=ellipse];8->15[];14[label=<C14 on N0<br/>(R1) <b>await push</b> from "
-	    "N2<br/>B0 [[0,0,0] - [1,1,1]]> fontcolor=black shape=ellipse];0->14[color=orchid];13->14[style=dashed color=gray40];13[label=<C13 on N2<br/>(R1) "
-	    "<b>push</b> to N0<br/>B0 [[0,0,0] - [1,1,1]]> fontcolor=dodgerblue4 "
+	    "from N3<br/> B0 [[0,0,0] - [1,1,1]]> fontcolor=black shape=ellipse];0->16[color=orchid];15->16[style=dashed color=gray40];15[label=<C15 on "
+	    "N3<br/>(R1) "
+	    "<b>push</b> to N0<br/> B0 [[0,0,0] - [1,1,1]]> fontcolor=goldenrod shape=ellipse];8->15[];14[label=<C14 on N0<br/>(R1) <b>await push</b> from "
+	    "N2<br/> B0 [[0,0,0] - [1,1,1]]> fontcolor=black shape=ellipse];0->14[color=orchid];13->14[style=dashed color=gray40];13[label=<C13 on N2<br/>(R1) "
+	    "<b>push</b> to N0<br/> B0 [[0,0,0] - [1,1,1]]> fontcolor=dodgerblue4 "
 	    "shape=ellipse];7->13[];0->5[color=orchid];1->6[color=orchid];2->7[color=orchid];3->8[color=orchid];10->9[];10[label=<C10 on N0<br/><b>reduction</b> "
-	    "R1<br/>B0 {[[0,0,0] - [1,1,1]]}> fontcolor=black shape=ellipse];5->10[];12->10[];14->10[];16->10[];11[label=<C11 on N1<br/>(R1) <b>push</b> to "
-	    "N0<br/>B0 [[0,0,0] - [1,1,1]]> fontcolor=crimson shape=ellipse];6->11[];12[label=<C12 on N0<br/>(R1) <b>await push</b> from N1<br/>B0 [[0,0,0] - "
+	    "R1<br/> B0 {[[0,0,0] - [1,1,1]]}> fontcolor=black shape=ellipse];5->10[];12->10[];14->10[];16->10[];11[label=<C11 on N1<br/>(R1) <b>push</b> to "
+	    "N0<br/> B0 [[0,0,0] - [1,1,1]]> fontcolor=crimson shape=ellipse];6->11[];12[label=<C12 on N0<br/>(R1) <b>await push</b> from N1<br/> B0 [[0,0,0] - "
 	    "[1,1,1]]> fontcolor=black shape=ellipse];0->12[color=orchid];11->12[style=dashed color=gray40];}";
 
-	const auto dot = ctx.get_command_graph().print_graph(std::numeric_limits<size_t>::max(), tm, rm).value();
+	const auto dot = ctx.get_command_graph().print_graph(std::numeric_limits<size_t>::max(), tm, rm, {}).value();
+	CHECK(dot == expected);
+}
+
+TEST_CASE_METHOD(test_utils::runtime_fixture, "Buffer debug names show up in the generated graph", "[print_graph][buffer_names]") {
+	distr_queue q;
+	celerity::range<1> range(16);
+	celerity::buffer<int, 1> buff_a(range);
+	std::string buff_name{"my_buffer"};
+	celerity::debug::set_buffer_name(buff_a, buff_name);
+	CHECK(celerity::debug::get_buffer_name(buff_a) == buff_name);
+
+	q.submit([=](handler& cgh) {
+		celerity::accessor acc{buff_a, cgh, celerity::access::all{}, celerity::write_only};
+		cgh.parallel_for<class UKN(print_graph_buffer_name)>(range, [=](item<1> item) {});
+	});
+
+	// wait for commands to be generated in the scheduler thread
+	q.slow_full_sync();
+
+	// Smoke test: It is valid for the dot output to change with updates to graph generation. If this test fails, verify that the printed graph is sane and
+	// replace the `expected` value with the new dot graph.
+	const auto expected =
+	    "digraph G{label=\"Command Graph\" subgraph cluster_0{label=<<font color=\"#606060\">T0 (epoch)</font>>;color=darkgray;0[label=<C0 on "
+	    "N0<br/><b>epoch</b>> fontcolor=black shape=box];}subgraph cluster_1{label=<<font color=\"#606060\">T1 \"print_graph_buffer_name_11\" "
+	    "(device-compute)</font>>;color=darkgray;2[label=<C2 on N0<br/><b>execution</b> [[0,0,0] - [16,1,1]]<br/><i>write</i> B0 \"my_buffer\" {[[0,0,0] - "
+	    "[16,1,1]]}> fontcolor=black shape=box];}subgraph cluster_2{label=<<font color=\"#606060\">T2 (epoch)</font>>;color=darkgray;3[label=<C3 on "
+	    "N0<br/><b>epoch</b> (barrier)> fontcolor=black shape=box];}2->3[color=orange];0->2[];}";
+
+	const auto dot = runtime_testspy::print_graph(runtime::get_instance());
 	CHECK(dot == expected);
 }
 } // namespace celerity::detail

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -44,14 +44,6 @@ namespace detail {
 		}
 	};
 
-	struct runtime_testspy {
-		static scheduler& get_schdlr(runtime& rt) { return *rt.m_schdlr; }
-
-		static executor& get_exec(runtime& rt) { return *rt.m_exec; }
-
-		static size_t get_command_count(runtime& rt) { return rt.m_cdag->command_count(); }
-	};
-
 	struct scheduler_testspy {
 		static std::thread& get_worker_thread(scheduler& schdlr) { return schdlr.m_worker_thread; }
 	};

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -46,6 +46,16 @@
 namespace celerity {
 namespace detail {
 
+	struct runtime_testspy {
+		static scheduler& get_schdlr(runtime& rt) { return *rt.m_schdlr; }
+		static executor& get_exec(runtime& rt) { return *rt.m_exec; }
+		static size_t get_command_count(runtime& rt) { return rt.m_cdag->command_count(); }
+		static command_graph& get_cdag(runtime& rt) { return *rt.m_cdag; }
+		static std::string print_graph(runtime& rt) {
+			return rt.m_cdag.get()->print_graph(std::numeric_limits<size_t>::max(), *rt.m_task_mngr, *rt.m_reduction_mngr, rt.m_buffer_mngr.get()).value();
+		}
+	};
+
 	struct task_ring_buffer_testspy {
 		static void create_task_slot(task_ring_buffer& trb) { trb.m_number_of_deleted_tasks += 1; }
 	};
@@ -426,7 +436,7 @@ namespace test_utils {
 	inline void maybe_print_graph(
 	    celerity::detail::command_graph& cdag, const celerity::detail::task_manager& tm, const celerity::detail::reduction_manager& rm) {
 		if(print_graphs) {
-			const auto graph_str = cdag.print_graph(std::numeric_limits<size_t>::max(), tm, rm);
+			const auto graph_str = cdag.print_graph(std::numeric_limits<size_t>::max(), tm, rm, {});
 			assert(graph_str.has_value());
 			CELERITY_INFO("Command graph:\n\n{}\n", *graph_str);
 		}


### PR DESCRIPTION
For now this only shows the buffer names plus ids instead of just ids when printing the command graph, but in a future it could also be used for instrumenting with some tracer/profiler and facilitate getting a more relevant name than just the buffer id. 

Also it is the first of hopefully more debug functionalities. 