### PR TITLE
Run Celerity microbenchmarks via CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,36 @@
+name: Celerity Benchmarks
+
+on:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: [ self-hosted, "slurm-nvidia-benchmark" ]
+    env:
+      container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
+      build-dir: /root/build
+    container:
+      image: celerity-build/hipsycl:ubuntu22.04-latest
+      volumes:
+        - ccache:/ccache
+    steps:
+      - name: Print exact SYCL revision used for this CI run
+        run: cat /VERSION
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Build Celerity
+        run: bash /root/build-celerity.sh ${{ env.container-workspace }} --build-type Release --target benchmarks
+      - name: Run benchmarks
+        timeout-minutes: 30
+        working-directory: ${{ env.build-dir }}
+        run: ${{ env.container-workspace }}/ci/run-benchmarks.sh
+      - name: Upload results or stack traces
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark Results
+          path: |
+            ${{ env.build-dir }}/gpuc2_bench.*
+            ${{ env.build-dir }}/*.trace
+          if-no-files-found: ignore

--- a/ci/run-benchmarks.sh
+++ b/ci/run-benchmarks.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o errexit -o pipefail -o nounset
+
+if [[ ! -d CMakeFiles ]]; then
+    echo "Warning: This script should be run from within a build directory" >&2
+fi
+
+if [[ $# -ne 0 ]]; then
+    echo "Usage: $0" >&2
+    exit 1
+fi
+
+bash /root/capture-backtrace.sh test/benchmarks \
+    --reporter celerity-benchmark-md::out=gpuc2_bench.md \
+    --reporter celerity-benchmark-csv::out=gpuc2_bench.csv


### PR DESCRIPTION
This adds a new CI workflow that runs the `benchmarks` binary and creates `gpuc2_bench.*` as artifacts. slurmactiond is configured such that the corresponding SLURM job uses `--exclusive --cpu-freq=high --nodelist=gpuc2` for optimal results.

While attempting to run the benchmarks inside Docker for the first time, it became apparent that our `benchmark_reporters` rely on system-specific locales for number formatting which was not available in our Docker images. For robustness, I have replaced this use of locales with a hand-rolled loop that inserts the thousands separators we need.

**Note:** GitHub does not allow us to trigger `workflow_dispatch` for workflows that do not exist on the default branch. As a workaround I've added a `push` trigger to the new workflow and removed the `push` trigger for the existing CI - I will drop these commits before merging.