### PR TITLE
Remove task mutex

### DIFF
--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -68,7 +68,6 @@ namespace detail {
 			task_id tid;
 			const task* tsk_ptr = nullptr;
 			{
-				std::lock_guard lock(m_task_mutex);
 				auto reservation = m_task_buffer.reserve_task_entry(await_free_task_slot_callback());
 				tid = reservation.get_tid();
 
@@ -190,9 +189,6 @@ namespace detail {
 
 		// Stores which host object was last affected by which task.
 		std::unordered_map<host_object_id, task_id> m_host_object_last_effects;
-
-		// For simplicity we use a single mutex to control access to all task-related (i.e. the task graph, ...) data structures.
-		mutable std::mutex m_task_mutex;
 
 		std::vector<task_callback> m_task_callbacks;
 


### PR DESCRIPTION
`task_manager` had a `m_task_mutex` left over from #112 that is now superfluous.

It was used in five places, all of which are only ever called from the main thread:
- task_manager::submit_command_group()
- task_manager::add_buffer()
- task_manager::generate_epoch_task()
- task_manager::generate_horizon_task()
- task_manager::print_graph()

All concurrency the task manager is involved in now is handled by the epoch monitor.