### PR TITLE
Communicate buffer creation to graph generator through scheduler event

### DIFF
--- a/include/graph_generator.h
+++ b/include/graph_generator.h
@@ -117,9 +117,6 @@ namespace detail {
 
 		std::unordered_map<node_id, per_node_data> m_node_data;
 
-		// This mutex mainly serves to protect per-buffer data structures, as new buffers might be added at any time.
-		std::mutex m_buffer_mutex;
-
 		void set_epoch_for_new_commands(per_node_data& node_data, const command_id epoch);
 
 		void reduce_execution_front_to(abstract_command* new_front);

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -100,8 +100,6 @@ namespace detail {
 
 		// These management classes are only constructed on the master node.
 		std::unique_ptr<command_graph> m_cdag;
-		std::shared_ptr<graph_generator> m_ggen;
-		std::shared_ptr<graph_serializer> m_gsrlzr;
 		std::unique_ptr<scheduler> m_schdlr;
 
 		std::unique_ptr<buffer_manager> m_buffer_mngr;

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -20,7 +20,7 @@ namespace detail {
 	// Abstract base class to allow different threading implementation in tests
 	class abstract_scheduler {
 	  public:
-		abstract_scheduler(graph_generator& ggen, graph_serializer& gsrlzr, size_t num_nodes);
+		abstract_scheduler(std::unique_ptr<graph_generator> ggen, std::unique_ptr<graph_serializer> gsrlzr, size_t num_nodes);
 
 		virtual ~abstract_scheduler() = default;
 
@@ -52,8 +52,8 @@ namespace detail {
 		};
 		using event = std::variant<event_shutdown, event_task_available, event_buffer_registered>;
 
-		graph_generator& m_ggen;
-		graph_serializer& m_gsrlzr;
+		std::unique_ptr<graph_generator> m_ggen;
+		std::unique_ptr<graph_serializer> m_gsrlzr;
 
 		std::queue<event> m_available_events;
 		std::queue<event> m_in_flight_events;

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -20,7 +20,7 @@ namespace detail {
 	// Abstract base class to allow different threading implementation in tests
 	class abstract_scheduler {
 	  public:
-		abstract_scheduler(std::unique_ptr<graph_generator> ggen, std::unique_ptr<graph_serializer> gsrlzr, size_t num_nodes);
+		abstract_scheduler(std::unique_ptr<graph_generator> ggen, std::unique_ptr<graph_serializer> gser, size_t num_nodes);
 
 		virtual ~abstract_scheduler() = default;
 
@@ -53,7 +53,7 @@ namespace detail {
 		using event = std::variant<event_shutdown, event_task_available, event_buffer_registered>;
 
 		std::unique_ptr<graph_generator> m_ggen;
-		std::unique_ptr<graph_serializer> m_gsrlzr;
+		std::unique_ptr<graph_serializer> m_gser;
 
 		std::queue<event> m_available_events;
 		std::queue<event> m_in_flight_events;

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -25,7 +25,6 @@ namespace detail {
 	}
 
 	void graph_generator::add_buffer(buffer_id bid, const cl::sycl::range<3>& range) {
-		std::lock_guard<std::mutex> lock(m_buffer_mutex);
 		// Initialize the whole range to all nodes, so that we always use local buffer ranges when they haven't been written to (on any node) yet.
 		// TODO: Consider better handling for when buffers are not host initialized
 		std::vector<node_id> all_nodes(m_num_nodes);
@@ -39,7 +38,6 @@ namespace detail {
 	}
 
 	void graph_generator::build_task(const task& tsk, const std::vector<graph_transformer*>& transformers) {
-		std::lock_guard<std::mutex> lock(m_buffer_mutex);
 		// TODO: Maybe assert that this task hasn't been processed before
 
 		const auto tid = tsk.get_id();

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -244,7 +244,7 @@ namespace detail {
 	void runtime::handle_buffer_registered(buffer_id bid) {
 		const auto& info = m_buffer_mngr->get_buffer_info(bid);
 		m_task_mngr->add_buffer(bid, info.range, info.is_host_initialized);
-		if(is_master_node()) m_ggen->add_buffer(bid, info.range);
+		if(is_master_node()) m_schdlr->notify_buffer_registered(bid, info.range);
 	}
 
 	void runtime::handle_buffer_unregistered(buffer_id bid) { maybe_destroy_runtime(); }

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -137,9 +137,9 @@ namespace detail {
 		if(is_master_node()) {
 			m_cdag = std::make_unique<command_graph>();
 			auto ggen = std::make_unique<graph_generator>(m_num_nodes, *m_reduction_mngr, *m_cdag);
-			auto gsrlzr = std::make_unique<graph_serializer>(
+			auto gser = std::make_unique<graph_serializer>(
 			    *m_cdag, [this](node_id target, unique_frame_ptr<command_frame> frame) { flush_command(target, std::move(frame)); });
-			m_schdlr = std::make_unique<scheduler>(std::move(ggen), std::move(gsrlzr), m_num_nodes);
+			m_schdlr = std::make_unique<scheduler>(std::move(ggen), std::move(gser), m_num_nodes);
 			m_task_mngr->register_task_callback([this](const task* tsk) { m_schdlr->notify_task_created(tsk); });
 		}
 

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -9,10 +9,10 @@
 namespace celerity {
 namespace detail {
 
-	abstract_scheduler::abstract_scheduler(std::unique_ptr<graph_generator> ggen, std::unique_ptr<graph_serializer> gsrlzr, size_t num_nodes)
-	    : m_ggen(std::move(ggen)), m_gsrlzr(std::move(gsrlzr)), m_num_nodes(num_nodes) {
+	abstract_scheduler::abstract_scheduler(std::unique_ptr<graph_generator> ggen, std::unique_ptr<graph_serializer> gser, size_t num_nodes)
+	    : m_ggen(std::move(ggen)), m_gser(std::move(gser)), m_num_nodes(num_nodes) {
 		assert(m_ggen != nullptr);
-		assert(m_gsrlzr != nullptr);
+		assert(m_gser != nullptr);
 	}
 
 	void abstract_scheduler::shutdown() { notify(event_shutdown{}); }
@@ -37,7 +37,7 @@ namespace detail {
 					    assert(e.tsk != nullptr);
 					    naive_split_transformer naive_split(m_num_nodes, m_num_nodes);
 					    m_ggen->build_task(*e.tsk, {&naive_split});
-					    m_gsrlzr->flush(e.tsk->get_id());
+					    m_gser->flush(e.tsk->get_id());
 				    },
 				    [this](const event_buffer_registered& e) { //
 					    m_ggen->add_buffer(e.bid, e.range);

--- a/test/accessor_tests.cc
+++ b/test/accessor_tests.cc
@@ -215,7 +215,7 @@ namespace detail {
 		runtime::init(nullptr, nullptr);
 		auto& tm = runtime::get_instance().get_task_manager();
 		auto& rm = runtime::get_instance().get_reduction_manager();
-		test_utils::mock_buffer_factory mbf(&tm, nullptr);
+		test_utils::mock_buffer_factory mbf{tm};
 
 		auto buf_0 = mbf.create_buffer(cl::sycl::range<1>{1});
 

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -151,7 +151,7 @@ struct task_manager_benchmark_context {
 struct graph_generator_benchmark_context {
 	const size_t num_nodes;
 	command_graph cdag;
-	graph_serializer gsrlzr{cdag, [](node_id, unique_frame_ptr<command_frame>) {}};
+	graph_serializer gser{cdag, [](node_id, unique_frame_ptr<command_frame>) {}};
 	reduction_manager rm;
 	task_manager tm{num_nodes, nullptr, &rm};
 	graph_generator ggen{num_nodes, rm, cdag};
@@ -161,7 +161,7 @@ struct graph_generator_benchmark_context {
 		tm.register_task_callback([this](const task* tsk) {
 			naive_split_transformer transformer{this->num_nodes, this->num_nodes};
 			ggen.build_task(*tsk, {&transformer});
-			gsrlzr.flush(tsk->get_id());
+			gser.flush(tsk->get_id());
 		});
 	}
 
@@ -234,8 +234,8 @@ class restartable_thread {
 
 class benchmark_scheduler final : public abstract_scheduler {
   public:
-	benchmark_scheduler(restartable_thread& worker_thread, std::unique_ptr<graph_generator> ggen, std::unique_ptr<graph_serializer> gsrlzr, size_t num_nodes)
-	    : abstract_scheduler(std::move(ggen), std::move(gsrlzr), num_nodes), m_worker_thread(worker_thread) {}
+	benchmark_scheduler(restartable_thread& worker_thread, std::unique_ptr<graph_generator> ggen, std::unique_ptr<graph_serializer> gser, size_t num_nodes)
+	    : abstract_scheduler(std::move(ggen), std::move(gser), num_nodes), m_worker_thread(worker_thread) {}
 
 	void startup() override {
 		m_worker_thread.start([this] { schedule(); });

--- a/test/graph_compaction_tests.cc
+++ b/test/graph_compaction_tests.cc
@@ -345,7 +345,7 @@ namespace detail {
 
 		// generate exactly two horizons
 		auto& ggen = ctx.get_graph_generator();
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 		auto buf = mbf.create_buffer(range<1>(1));
 		for(int i = 0; i < 4; ++i) {
 			test_utils::build_and_flush(
@@ -394,7 +394,7 @@ namespace detail {
 
 		// generate exactly two horizons
 		auto& ggen = ctx.get_graph_generator();
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 		auto buf = mbf.create_buffer(range<1>(1));
 		for(int i = 0; i < 5; ++i) {
 			test_utils::build_and_flush(

--- a/test/graph_gen_granularity_tests.cc
+++ b/test/graph_gen_granularity_tests.cc
@@ -141,7 +141,7 @@ namespace detail {
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
 
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 		const range<1> buf_range{16};
 		auto buf = mbf.create_buffer(buf_range);
 

--- a/test/graph_gen_reduction_tests.cc
+++ b/test/graph_gen_reduction_tests.cc
@@ -22,7 +22,7 @@ namespace detail {
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
 		auto& rm = ctx.get_reduction_manager();
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 
 		auto range = cl::sycl::range<1>(64);
 		auto buf_0 = mbf.create_buffer(range);
@@ -110,7 +110,7 @@ namespace detail {
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
 		auto& rm = ctx.get_reduction_manager();
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 
 		auto range = cl::sycl::range<1>(64);
 		auto buf_0 = mbf.create_buffer(range);
@@ -139,7 +139,7 @@ namespace detail {
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
 		auto& rm = ctx.get_reduction_manager();
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 
 		auto buf_0 = mbf.create_buffer(cl::sycl::range<1>{1});
 
@@ -163,7 +163,7 @@ namespace detail {
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
 		auto& rm = ctx.get_reduction_manager();
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 
 		auto buf_0 = mbf.create_buffer(cl::sycl::range<1>{1});
 
@@ -190,7 +190,7 @@ namespace detail {
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
 		auto& rm = ctx.get_reduction_manager();
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 
 		auto buf_0 = mbf.create_buffer(cl::sycl::range<1>{1});
 
@@ -220,7 +220,7 @@ namespace detail {
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
 		auto& rm = ctx.get_reduction_manager();
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 
 		auto buf_0 = mbf.create_buffer(cl::sycl::range<1>{1});
 

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -629,7 +629,7 @@ namespace detail {
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
 
-		test_utils::mock_buffer_factory mbf(&tm, &ggen);
+		test_utils::mock_buffer_factory mbf(ctx);
 
 		auto& inspector = ctx.get_inspector();
 		auto& cdag = ctx.get_command_graph();

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -256,7 +256,7 @@ namespace detail {
 
 	TEST_CASE("task_manager correctly records compute task information", "[task_manager][task][device_compute_task]") {
 		task_manager tm{1, nullptr, nullptr};
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf_a = mbf.create_buffer(cl::sycl::range<2>(64, 152));
 		auto buf_b = mbf.create_buffer(cl::sycl::range<3>(7, 21, 99));
 		const auto tid = test_utils::add_compute_task(

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -22,7 +22,7 @@ namespace detail {
 		using namespace cl::sycl::access;
 
 		task_manager tm{1, nullptr, nullptr};
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf_a = mbf.create_buffer(cl::sycl::range<1>(128));
 		auto buf_b = mbf.create_buffer(cl::sycl::range<1>(128));
 
@@ -104,7 +104,7 @@ namespace detail {
 		using namespace cl::sycl::access;
 
 		task_manager tm{1, nullptr, nullptr};
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf = mbf.create_buffer(cl::sycl::range<1>(128));
 
 		const auto tid_a = test_utils::add_compute_task<class UKN(task_a)>(tm, [&](handler& cgh) {
@@ -122,7 +122,7 @@ namespace detail {
 	TEST_CASE("task_manager correctly generates anti-dependencies", "[task_manager][task-graph]") {
 		using namespace cl::sycl::access;
 		task_manager tm{1, nullptr, nullptr};
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf = mbf.create_buffer(cl::sycl::range<1>(128));
 
 		// Write to the full buffer
@@ -151,7 +151,7 @@ namespace detail {
 	TEST_CASE("task_manager correctly handles host-initialized buffers", "[task_manager][task-graph]") {
 		using namespace cl::sycl::access;
 		task_manager tm{1, nullptr, nullptr};
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto host_init_buf = mbf.create_buffer(cl::sycl::range<1>(128), true);
 		auto non_host_init_buf = mbf.create_buffer(cl::sycl::range<1>(128), false);
 		auto artificial_dependency_buf = mbf.create_buffer(cl::sycl::range<1>(1), false);
@@ -203,7 +203,7 @@ namespace detail {
 
 		for(const auto& mode_set : rw_mode_sets) {
 			task_manager tm{1, nullptr, nullptr};
-			test_utils::mock_buffer_factory mbf(&tm);
+			test_utils::mock_buffer_factory mbf(tm);
 			auto buf = mbf.create_buffer(cl::sycl::range<1>(128), true);
 
 			const auto tid_a = test_utils::add_compute_task<class UKN(task_a)>(tm, [&](handler& cgh) {
@@ -225,7 +225,7 @@ namespace detail {
 				CAPTURE(consumer_mode);
 				CAPTURE(producer_mode);
 				task_manager tm{1, nullptr, nullptr};
-				test_utils::mock_buffer_factory mbf(&tm);
+				test_utils::mock_buffer_factory mbf(tm);
 				auto buf = mbf.create_buffer(cl::sycl::range<1>(128), false);
 
 				const task_id tid_a = test_utils::add_compute_task<class UKN(task_a)>(tm, [&](handler& cgh) {
@@ -298,7 +298,7 @@ namespace detail {
 
 	TEST_CASE("task_manager keeps track of max pseudo critical path length and task front", "[task_manager][task-graph][task-front]") {
 		task_manager tm{1, nullptr, nullptr};
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf_a = mbf.create_buffer(cl::sycl::range<1>(128));
 
 		const auto tid_a = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
@@ -324,7 +324,7 @@ namespace detail {
 		task_manager tm{1, nullptr, nullptr};
 		tm.set_horizon_step(2);
 
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf_a = mbf.create_buffer(cl::sycl::range<1>(128));
 
 		test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf_a.get_access<access_mode::discard_write>(cgh, fixed<1>({0, 128})); });
@@ -380,7 +380,7 @@ namespace detail {
 		task_manager tm{1, nullptr, nullptr};
 		tm.set_horizon_step(2);
 
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf_a = mbf.create_buffer(cl::sycl::range<1>(128));
 		auto buf_b = mbf.create_buffer(cl::sycl::range<1>(128));
 
@@ -447,7 +447,7 @@ namespace detail {
 		task_manager tm{1, nullptr, nullptr};
 		tm.set_horizon_step(2);
 
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 
 		task_id initial_last_writer_id = -1;
 		{
@@ -503,7 +503,7 @@ namespace detail {
 		const auto first_collective = test_utils::add_host_task(tm, experimental::collective, [&](handler& cgh) {});
 
 		// generate exactly two horizons
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf = mbf.create_buffer(range<1>(1));
 		for(int i = 0; i < 4; ++i) {
 			test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); });
@@ -530,7 +530,7 @@ namespace detail {
 
 	TEST_CASE("buffer accesses with empty ranges do not generate data-flow dependencies", "[task_manager][task-graph]") {
 		task_manager tm{1, nullptr, nullptr};
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf = mbf.create_buffer(range<2>(32, 32));
 
 		const auto write_sr = GENERATE(values({subrange<2>{{16, 16}, {0, 0}}, subrange<2>{{16, 16}, {8, 8}}}));
@@ -601,7 +601,7 @@ namespace detail {
 		    test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { ho.add_side_effect(cgh, experimental::side_effect_order::sequential); });
 
 		// generate exactly two horizons
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf = mbf.create_buffer(range<1>(1));
 		for(int i = 0; i < 5; ++i) {
 			test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); });
@@ -624,7 +624,7 @@ namespace detail {
 
 	TEST_CASE("epochs create appropriate dependencies to predecessors and successors", "[task_manager][task-graph][epoch]") {
 		task_manager tm{1, nullptr, nullptr};
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 
 		auto buf_a = mbf.create_buffer(range<1>(1));
 		const auto tid_a = test_utils::add_compute_task<class UKN(task_a)>(tm, [&](handler& cgh) { buf_a.get_access<access_mode::discard_write>(cgh, all{}); });
@@ -659,7 +659,7 @@ namespace detail {
 		task_manager tm{1, nullptr, nullptr};
 		tm.set_horizon_step(2);
 
-		test_utils::mock_buffer_factory mbf(&tm);
+		test_utils::mock_buffer_factory mbf(tm);
 		auto buf = mbf.create_buffer(range<1>(1));
 		for(int i = 0; i < 3; ++i) {
 			test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, all{}); });

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -285,7 +285,10 @@ namespace test_utils {
 
 	class mock_buffer_factory {
 	  public:
-		explicit mock_buffer_factory(detail::task_manager* tm = nullptr, detail::graph_generator* ggen = nullptr) : m_task_mngr(tm), m_ggen(ggen) {}
+		explicit mock_buffer_factory() = default;
+		explicit mock_buffer_factory(detail::task_manager& tm) : m_task_mngr(&tm) {}
+		explicit mock_buffer_factory(detail::task_manager& tm, detail::graph_generator& ggen) : m_task_mngr(&tm), m_ggen(&ggen) {}
+		explicit mock_buffer_factory(detail::task_manager& tm, detail::abstract_scheduler& schdlr) : m_task_mngr(&tm), m_schdlr(&schdlr) {}
 		explicit mock_buffer_factory(cdag_test_context& ctx) : m_task_mngr(&ctx.get_task_manager()), m_ggen(&ctx.get_graph_generator()) {}
 
 		template <int Dims>
@@ -293,13 +296,15 @@ namespace test_utils {
 			const detail::buffer_id bid = m_next_buffer_id++;
 			const auto buf = mock_buffer<Dims>(bid, size);
 			if(m_task_mngr != nullptr) { m_task_mngr->add_buffer(bid, detail::range_cast<3>(size), mark_as_host_initialized); }
+			if(m_schdlr != nullptr) { m_schdlr->notify_buffer_registered(bid, detail::range_cast<3>(size)); }
 			if(m_ggen != nullptr) { m_ggen->add_buffer(bid, detail::range_cast<3>(size)); }
 			return buf;
 		}
 
 	  private:
-		detail::task_manager* m_task_mngr;
-		detail::graph_generator* m_ggen;
+		detail::task_manager* m_task_mngr = nullptr;
+		detail::abstract_scheduler* m_schdlr = nullptr;
+		detail::graph_generator* m_ggen = nullptr;
 		detail::buffer_id m_next_buffer_id = 0;
 	};
 

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -247,7 +247,7 @@ namespace test_utils {
 			m_tm = std::make_unique<detail::task_manager>(1 /* num_nodes */, nullptr /* host_queue */, m_rm.get());
 			m_cdag = std::make_unique<detail::command_graph>();
 			m_ggen = std::make_unique<detail::graph_generator>(num_nodes, *m_rm, *m_cdag);
-			m_gsrlzr = std::make_unique<detail::graph_serializer>(*m_cdag, m_inspector.get_cb());
+			m_gser = std::make_unique<detail::graph_serializer>(*m_cdag, m_inspector.get_cb());
 			this->m_num_nodes = num_nodes;
 		}
 
@@ -256,7 +256,7 @@ namespace test_utils {
 		detail::command_graph& get_command_graph() { return *m_cdag; }
 		detail::graph_generator& get_graph_generator() { return *m_ggen; }
 		cdag_inspector& get_inspector() { return m_inspector; }
-		detail::graph_serializer& get_graph_serializer() { return *m_gsrlzr; }
+		detail::graph_serializer& get_graph_serializer() { return *m_gser; }
 
 		detail::task_id build_task_horizons() {
 			const auto most_recently_generated_task_horizon = detail::task_manager_testspy::get_current_horizon(get_task_manager());
@@ -278,7 +278,7 @@ namespace test_utils {
 		std::unique_ptr<detail::command_graph> m_cdag;
 		std::unique_ptr<detail::graph_generator> m_ggen;
 		cdag_inspector m_inspector;
-		std::unique_ptr<detail::graph_serializer> m_gsrlzr;
+		std::unique_ptr<detail::graph_serializer> m_gser;
 		size_t m_num_nodes;
 		std::optional<detail::task_id> m_most_recently_built_task_horizon;
 	};


### PR DESCRIPTION
Currently the graph generator holds a `m_buffer_mutex` for the sole purpose of synchronizing buffer addition between main thread and scheduler thread. This is contrary to the otherwise thread-unaware design of the graph generator and could cause scheduler stalls if buffers are constructed while tasks are scheduled.

This PR introduces a new scheduler event for buffer addition which makes this mutex unnecessary. It also transfers ownership of graph generator and graph serializer to the scheduler in order to prevent accidental concurrent access from a non-scheduler thread.

`test_utils::mock_buffer_factory` also gets a richer constructor interface to be able to deal with either a non-threaded graph generator or a threaded scheduler.