### PR TITLE
Coalesce command serialization into single MPI op per task and node

### DIFF
--- a/include/frame.h
+++ b/include/frame.h
@@ -3,6 +3,7 @@
 #include <cassert>
 
 #include "payload.h"
+#include "utils.h"
 
 namespace celerity::detail {
 
@@ -37,10 +38,13 @@ class unique_frame_ptr : private std::unique_ptr<Frame, unique_frame_delete<Fram
 
 	friend class unique_payload_ptr;
 
+	template <typename>
+	friend class shared_frame_ptr;
+
   public:
 	using payload_type = typename Frame::payload_type;
 
-	unique_frame_ptr() = default;
+	unique_frame_ptr() noexcept = default;
 
 	unique_frame_ptr(from_payload_count_tag, size_t payload_count) : unique_frame_ptr(from_size_bytes, sizeof(Frame) + sizeof(payload_type) * payload_count) {}
 
@@ -95,6 +99,270 @@ class unique_frame_ptr : private std::unique_ptr<Frame, unique_frame_delete<Fram
 		const auto frame = reinterpret_cast<Frame*>(payload) - 1; // frame header is located at -sizeof(Frame) bytes (-1 Frame object)
 		delete frame;
 	}
+};
+
+template <typename Frame>
+class shared_frame_ptr : private std::shared_ptr<Frame> {
+  private:
+	using impl = std::shared_ptr<Frame>;
+
+  public:
+	using payload_type = typename Frame::payload_type;
+
+	shared_frame_ptr() noexcept = default;
+
+	shared_frame_ptr(unique_frame_ptr<Frame>&& unique)
+	    : impl(static_cast<typename unique_frame_ptr<Frame>::impl&&>(unique)), m_size_bytes(unique.m_size_bytes) {}
+
+	template <typename T>
+	shared_frame_ptr(const std::shared_ptr<T>& alias, Frame* const frame, const size_t frame_size_bytes) : impl(alias, frame), m_size_bytes(frame_size_bytes) {}
+
+	shared_frame_ptr(const shared_frame_ptr&) = default;
+
+	shared_frame_ptr(shared_frame_ptr&& other) noexcept : impl(static_cast<impl&&>(other)) { std::swap(m_size_bytes, other.m_size_bytes); }
+
+	shared_frame_ptr& operator=(const shared_frame_ptr& other) = default;
+
+	shared_frame_ptr& operator=(shared_frame_ptr&& other) noexcept {
+		if(this == &other) return *this;                        // gracefully handle self-assignment
+		static_cast<impl&>(*this) = static_cast<impl&&>(other); // delegate to base class unique_ptr<Frame>::operator=() to delete previously held frame
+		m_size_bytes = other.m_size_bytes;
+		other.m_size_bytes = 0;
+		return *this;
+	}
+
+	Frame* get_pointer() { return impl::get(); }
+	const Frame* get_pointer() const { return impl::get(); }
+	size_t get_size_bytes() const { return m_size_bytes; }
+	size_t get_payload_count() const { return (m_size_bytes - sizeof(Frame)) / sizeof(payload_type); }
+
+	using impl::operator bool;
+	using impl::operator*;
+	using impl::operator->;
+
+  private:
+	size_t m_size_bytes = 0;
+};
+
+template <typename Frame>
+class frame_vector_layout {
+  public:
+	void reserve_back(from_size_bytes_tag, const size_t frame_size_bytes) {
+		assert(frame_size_bytes >= sizeof(Frame));
+		m_frame_count += 1;
+		m_aligned_frames_size = utils::ceil(m_aligned_frames_size, alignof(Frame)) + frame_size_bytes;
+	}
+
+	void reserve_back(from_payload_count_tag, const size_t payload_count) {
+		reserve_back(from_size_bytes, sizeof(Frame) + sizeof(typename Frame::payload_type) * payload_count);
+	}
+
+	size_t get_frame_count() const { return m_frame_count; }
+
+	size_t get_size_bytes() const { return utils::ceil(sizeof(size_t) * (1 + m_frame_count), alignof(Frame)) + m_aligned_frames_size; }
+
+  private:
+	size_t m_frame_count = 0;
+	size_t m_aligned_frames_size = 0;
+};
+
+template <typename Frame>
+class frame_vector : public std::enable_shared_from_this<frame_vector<Frame>> {
+  public:
+	class const_iterator;
+
+  private:
+	template <typename Iterator /* CRTP */, typename MaybeConstVector, typename MaybeConstFrame>
+	class iterator_impl {
+	  public:
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = MaybeConstFrame;
+		using reference = value_type&;
+		using pointer = value_type*;
+		using difference_type = std::ptrdiff_t;
+
+		explicit iterator_impl(MaybeConstVector& vector, const size_t index, MaybeConstFrame* const frame)
+		    : m_vector(&vector), m_index(index), m_frame(frame) {}
+
+		Iterator& operator++() {
+			const auto num_frames = m_vector->get_frame_count();
+			if(m_index + 1 < num_frames) {
+				const auto cur_frame_padded_size = utils::ceil(m_vector->get_frame_size_bytes(m_index), alignof(Frame));
+				m_frame = reinterpret_cast<MaybeConstFrame*>(reinterpret_cast<uintptr_t>(m_frame) + cur_frame_padded_size);
+				m_index += 1;
+			} else if(m_index + 1 == num_frames) {
+				m_frame = nullptr;
+				m_index = num_frames;
+			}
+			return *static_cast<Iterator*>(this);
+		}
+
+		Iterator operator++(const int) {
+			const auto prev = *static_cast<Iterator*>(this);
+			++*this;
+			return prev;
+		}
+
+		friend bool operator==(const Iterator lhs, const Iterator rhs) { return lhs.m_vector == rhs.m_vector && lhs.m_index == rhs.m_index; }
+
+		friend bool operator!=(const Iterator lhs, const Iterator rhs) { return !(lhs == rhs); }
+
+		reference operator*() const {
+			assert(m_frame != nullptr);
+			return *m_frame;
+		}
+
+		pointer operator->() const {
+			assert(m_frame != nullptr);
+			return m_frame;
+		}
+
+		size_t get_size_bytes() const { return m_vector->get_frame_size_bytes(m_index); }
+
+		size_t get_payload_count() const { return m_vector->get_frame_payload_count(m_index); }
+
+		shared_frame_ptr<value_type> get_shared_from_this() const {
+			assert(m_frame != nullptr);
+			return shared_frame_ptr<MaybeConstFrame>(m_vector->shared_from_this(), m_frame, m_vector->get_frame_size_bytes(m_index));
+		}
+
+	  private:
+		friend class const_iterator;
+
+		MaybeConstVector* m_vector;
+		size_t m_index;
+		MaybeConstFrame* m_frame;
+	};
+
+  public:
+	using value_type = Frame;
+	using payload_type = typename Frame::payload_type;
+
+	class iterator final : public iterator_impl<iterator, frame_vector, Frame> {
+	  public:
+		using iterator_impl<iterator, frame_vector, Frame>::iterator_impl;
+	};
+
+	class const_iterator final : public iterator_impl<const_iterator, const frame_vector, const Frame> {
+	  public:
+		using iterator_impl<const_iterator, const frame_vector, const Frame>::iterator_impl;
+
+		const_iterator(iterator non_const) : const_iterator(*non_const.m_vector, non_const.m_index, non_const.m_frame) {}
+	};
+
+	frame_vector() noexcept = default;
+
+	frame_vector(from_size_bytes_tag, size_t size_bytes) : m_alloc(operator new(size_bytes)), m_size_bytes(size_bytes) {}
+
+	frame_vector(frame_vector&& other) noexcept : m_alloc(other.m_alloc), m_size_bytes(other.m_size_bytes) {
+		other.m_alloc = nullptr;
+		other.m_size_bytes = 0;
+	}
+
+	~frame_vector() { reset(); }
+
+	frame_vector& operator=(frame_vector&& other) noexcept {
+		if(this == &other) return *this;
+		reset();
+		std::swap(m_alloc, other.m_alloc);
+		std::swap(m_size_bytes, other.m_size_bytes);
+		return *this;
+	}
+
+	iterator begin() { return iterator{*this, 0, get_first_frame()}; }
+	iterator end() { return iterator{*this, get_frame_count(), nullptr}; }
+	const_iterator cbegin() const { return const_iterator{*this, 0, get_first_frame()}; }
+	const_iterator cend() const { return const_iterator{*this, get_frame_count(), nullptr}; }
+	const_iterator begin() const { return cbegin(); }
+	const_iterator end() const { return cend(); }
+
+	void* get_pointer() { return m_alloc; }
+	const void* get_pointer() const { return m_alloc; }
+
+	size_t get_size_bytes() const { return m_size_bytes; }
+	size_t get_frame_count() const { return m_alloc ? get_header()[0] : 0; }
+
+	size_t get_frame_size_bytes(const size_t index) const {
+		assert(index < get_frame_count());
+		return get_header()[1 + index];
+	}
+
+	size_t get_frame_payload_count(const size_t index) const { return (get_frame_size_bytes(index) - sizeof(Frame)) / sizeof(payload_type); }
+
+	explicit operator bool() const { return m_alloc != nullptr; }
+
+  private:
+	template <typename F>
+	friend class frame_vector_builder;
+
+	void* m_alloc = nullptr;
+	size_t m_size_bytes = 0;
+
+	size_t* get_header() const {
+		assert(m_alloc != nullptr);
+		return static_cast<size_t*>(m_alloc);
+	}
+
+	void set_frame_count(const size_t count) { get_header()[0] = count; }
+
+	void set_frame_size_bytes(const size_t index, const size_t size_bytes) { get_header()[1 + index] = size_bytes; }
+
+	Frame* get_first_frame() const {
+		if(m_alloc != nullptr) {
+			const auto offset = utils::ceil((1 + get_frame_count()) * sizeof(size_t), alignof(Frame));
+			return reinterpret_cast<Frame*>(static_cast<std::byte*>(m_alloc) + offset);
+		} else {
+			return nullptr;
+		}
+	}
+
+	void reset() {
+		// TODO this cannot call Frame destructors because frame_vector_builder will leave the structure partially initialized.
+		// At the same time, unique/shared_frame_ptrs will call destructors. This should be made consistent.
+		operator delete(m_alloc);
+		m_alloc = nullptr;
+		m_size_bytes = 0;
+	}
+};
+
+template <typename Frame>
+class frame_vector_builder {
+  public:
+	explicit frame_vector_builder(frame_vector_layout<Frame> layout) : m_vector(from_size_bytes, layout.get_size_bytes()) {
+		m_vector.get_header()[0] = layout.get_frame_count();
+		m_next_frame = m_vector.get_first_frame();
+	}
+
+	Frame& emplace_back(from_size_bytes_tag, const size_t frame_size_bytes) {
+		assert(frame_size_bytes >= sizeof(Frame));
+		assert(m_vector);
+		assert(m_next_index < m_vector.get_frame_count());
+		assert(reinterpret_cast<std::byte*>(m_next_frame) - static_cast<std::byte*>(m_vector.get_pointer()) + frame_size_bytes <= m_vector.get_size_bytes());
+
+		m_vector.set_frame_size_bytes(m_next_index, frame_size_bytes);
+		new(m_next_frame) Frame;
+		const auto frame = m_next_frame;
+
+		const auto frame_padded_size = utils::ceil(frame_size_bytes, alignof(Frame));
+		m_next_frame = reinterpret_cast<Frame*>(reinterpret_cast<uintptr_t>(frame) + frame_padded_size);
+		m_next_index += 1;
+
+		return *frame;
+	}
+
+	Frame& emplace_back(from_payload_count_tag, const size_t payload_count) {
+		return emplace_back(from_size_bytes, sizeof(Frame) + sizeof(typename Frame::payload_type) * payload_count);
+	}
+
+	frame_vector<Frame> into_vector() && {
+		assert(m_next_index == m_vector.get_frame_count());
+		return std::move(m_vector);
+	}
+
+  private:
+	frame_vector<Frame> m_vector;
+	size_t m_next_index = 0;
+	Frame* m_next_frame;
 };
 
 } // namespace celerity::detail

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -111,7 +111,7 @@ namespace detail {
 		std::unique_ptr<executor> m_exec;
 
 		struct flush_handle {
-			unique_frame_ptr<command_frame> frame;
+			frame_vector<command_frame> frames;
 			MPI_Request req;
 		};
 		std::deque<flush_handle> m_active_flushes;
@@ -128,7 +128,7 @@ namespace detail {
 		 */
 		void maybe_destroy_runtime() const;
 
-		void flush_command(node_id target, unique_frame_ptr<command_frame> frame);
+		void flush_commands(node_id target, frame_vector<command_frame> frames);
 
 		// ------------------------------------------ TESTING UTILS ------------------------------------------
 		// We have to jump through some hoops to be able to re-initialize the runtime for unit testing.

--- a/include/utils.h
+++ b/include/utils.h
@@ -42,4 +42,9 @@ struct pair_hash {
 	}
 };
 
+template <typename T>
+inline T ceil(T min, T mult) {
+	return (min + mult - 1) / mult * mult;
+}
+
 } // namespace celerity::detail::utils

--- a/src/graph_serializer.cc
+++ b/src/graph_serializer.cc
@@ -6,114 +6,118 @@
 #include "command_graph.h"
 #include "task_manager.h"
 
-namespace celerity {
-namespace detail {
+namespace celerity::detail {
 
-	void graph_serializer::flush(task_id tid) { flush(m_cdag.task_commands(tid)); }
+graph_serializer::graph_serializer(const size_t num_nodes, command_graph& cdag, flush_callback flush_cb)
+    : m_num_nodes(num_nodes), m_cdag(cdag), m_flush_cb(std::move(flush_cb)) {}
 
-	bool is_virtual_dependency(const abstract_command* const cmd) {
-		// The initial epoch command is not flushed, so including it in dependencies is not useful
-		// TODO we might want to generate and flush init tasks explicitly to avoid this kind of special casing
-		const auto ecmd = dynamic_cast<const epoch_command*>(cmd);
-		return ecmd && ecmd->get_tid() == task_manager::initial_epoch_task;
+void graph_serializer::flush(const task_id tid) {
+	node_command_map pending_node_cmds(m_num_nodes);
+	for(const auto tcmd : m_cdag.task_commands(tid)) {
+		assert(tcmd->get_tid() == tid);
+		collect_task_command(tcmd, pending_node_cmds);
 	}
+	for(node_id nid = 0; nid < m_num_nodes; ++nid) {
+		if(!pending_node_cmds[nid].empty()) { m_flush_cb(nid, serialize(pending_node_cmds[nid])); }
+	}
+}
 
-	void graph_serializer::flush(const std::vector<task_command*>& cmds) {
+void graph_serializer::collect_task_command(task_command* const cmd, node_command_map& pending_node_cmds) const {
+	cmd->mark_as_flushed();
+
+	const auto nid = cmd->get_nid();
+	assert(nid <= m_num_nodes);
+
+	// Iterate over first level of dependencies.
+	// These might either be commands from other tasks that have been flushed previously or generated data transfer / reduction commands.
+	for(const auto& edge : cmd->get_dependencies()) {
+		const auto dep = edge.node;
+
+		// Sanity check: All dependencies must be on the same node.
+		assert(dep->get_nid() == nid);
+
 #if defined(CELERITY_DETAIL_ENABLE_DEBUG)
-		task_id check_tid = task_id(-1);
+		// Task command dependencies must be from a different task and have already been flushed.
+		if(auto* tdep = dynamic_cast<task_command*>(dep)) {
+			assert(tdep->get_tid() != cmd->get_tid());
+			assert(tdep->is_flushed());
+		}
 #endif
 
-		std::vector<std::pair<task_command*, std::vector<command_id>>> cmds_and_deps;
-		cmds_and_deps.reserve(cmds.size());
-		for(auto cmd : cmds) {
-#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
-			// Verify that all commands belong to the same task
-			assert(check_tid == task_id(-1) || check_tid == cmd->get_tid());
-			check_tid = cmd->get_tid();
-#endif
+		if(!dep->is_flushed()) collect_dependency(dep, pending_node_cmds);
+	}
 
-			cmds_and_deps.emplace_back();
-			auto& cad = *cmds_and_deps.rbegin();
-			cad.first = cmd;
+	pending_node_cmds[nid].emplace_back(cmd);
+}
 
-			// Iterate over first level of dependencies.
-			// These might either be commands from other tasks that have been flushed previously or generated data transfer / reduction commands.
-			for(auto d : cmd->get_dependencies()) {
-				if(!is_virtual_dependency(d.node)) { cad.second.push_back(d.node->get_cid()); }
+void graph_serializer::collect_dependency(abstract_command* const cmd, node_command_map& pending_node_cmds) const {
+	cmd->mark_as_flushed();
 
-				// Sanity check: All dependencies must be on the same node.
-				assert(d.node->get_nid() == cmd->get_nid());
+	const auto nid = cmd->get_nid();
+	assert(nid <= m_num_nodes);
 
-				if(auto* tcmd = dynamic_cast<task_command*>(d.node)) {
-					// Task command dependencies must be from a different task and have already been flushed.
-					assert(tcmd->get_tid() != cmd->get_tid());
-					assert(tcmd->is_flushed());
-					continue;
-				}
+	// Special casing for await_push commands: Also flush the corresponding push.
+	// This is necessary as we would otherwise not reach it when starting from task commands alone
+	// (unless there exists an anti-dependency, which is not true in most cases).
+	if(isa<await_push_command>(cmd)) {
+		const auto pcmd = static_cast<await_push_command*>(cmd)->get_source();
+		if(!pcmd->is_flushed()) collect_dependency(pcmd, pending_node_cmds);
+	}
 
-				// Flush dependency right away
-				if(!d.node->is_flushed()) flush_dependency(d.node);
-			}
-		}
+	// Iterate over second level of dependencies. These will usually be flushed already. One notable exception are reduction dependencies, which generate
+	// a tree of push_await_commands and reduction_commands as a dependency.
+	// TODO: We could probably do some pruning here (e.g. omit tasks we know are already finished)
+	for(const auto& edge : cmd->get_dependencies()) {
+		const auto dep = edge.node;
 
-		// Finally, flush all the task commands.
-		for(auto& cad : cmds_and_deps) {
-			serialize_and_flush(cad.first, cad.second);
+		// Sanity check: All dependencies must be on the same node.
+		assert(dep->get_nid() == nid);
+
+		if(!dep->is_flushed()) {
+			assert(isa<reduction_command>(cmd) || isa<await_push_command>(dep));
+			collect_dependency(dep, pending_node_cmds);
 		}
 	}
 
-	void graph_serializer::flush_dependency(abstract_command* dep) const {
-		// Special casing for await_push commands: Also flush the corresponding push.
-		// This is necessary as we would otherwise not reach it when starting from task commands alone
-		// (unless there exists an anti-dependency, which is not true in most cases).
-		if(isa<await_push_command>(dep)) {
-			const auto pcmd = static_cast<await_push_command*>(dep)->get_source();
-			if(!pcmd->is_flushed()) flush_dependency(pcmd);
-		}
+	pending_node_cmds[nid].emplace_back(cmd);
+}
 
-		std::vector<command_id> dep_deps;
-		// Iterate over second level of dependencies. These will usually be flushed already. One notable exception are reduction dependencies, which generate
-		// a tree of push_await_commands and reduction_commands as a dependency.
-		// TODO: We could probably do some pruning here (e.g. omit tasks we know are already finished)
-		for(auto dd : dep->get_dependencies()) {
-			if(!dd.node->is_flushed()) {
-				assert(isa<reduction_command>(dep) && isa<await_push_command>(dd.node));
-				flush_dependency(dd.node);
-			}
-			if(!is_virtual_dependency(dd.node)) { dep_deps.push_back(dd.node->get_cid()); }
-		}
-		serialize_and_flush(dep, dep_deps);
+frame_vector<command_frame> graph_serializer::serialize(const command_vector& cmds) const {
+	frame_vector_layout<command_frame> layout;
+	for(const auto cmd : cmds) {
+		const auto num_deps = std::distance(cmd->get_dependencies().begin(), cmd->get_dependencies().end());
+		layout.reserve_back(from_payload_count, num_deps);
 	}
 
-	void graph_serializer::serialize_and_flush(abstract_command* cmd, const std::vector<command_id>& dependencies) const {
-		assert(!cmd->is_flushed() && "Command has already been flushed.");
+	frame_vector_builder<command_frame> builder(layout);
+	for(const auto cmd : cmds) {
+		const auto num_deps = std::distance(cmd->get_dependencies().begin(), cmd->get_dependencies().end());
+		auto& frame = builder.emplace_back(from_payload_count, num_deps);
 
-		unique_frame_ptr<command_frame> frame(from_payload_count, dependencies.size());
-
-		frame->pkg.cid = cmd->get_cid();
-		if(const auto* ecmd = dynamic_cast<epoch_command*>(cmd)) {
-			frame->pkg.data = epoch_data{ecmd->get_tid(), ecmd->get_epoch_action()};
-		} else if(const auto* xcmd = dynamic_cast<execution_command*>(cmd)) {
-			frame->pkg.data = execution_data{xcmd->get_tid(), xcmd->get_execution_range(), xcmd->is_reduction_initializer()};
-		} else if(const auto* pcmd = dynamic_cast<push_command*>(cmd)) {
-			frame->pkg.data = push_data{pcmd->get_bid(), pcmd->get_rid(), pcmd->get_target(), pcmd->get_range()};
-		} else if(const auto* apcmd = dynamic_cast<await_push_command*>(cmd)) {
+		frame.pkg.cid = cmd->get_cid();
+		if(const auto* ecmd = dynamic_cast<const epoch_command*>(cmd)) {
+			frame.pkg.data = epoch_data{ecmd->get_tid(), ecmd->get_epoch_action()};
+		} else if(const auto* xcmd = dynamic_cast<const execution_command*>(cmd)) {
+			frame.pkg.data = execution_data{xcmd->get_tid(), xcmd->get_execution_range(), xcmd->is_reduction_initializer()};
+		} else if(const auto* pcmd = dynamic_cast<const push_command*>(cmd)) {
+			frame.pkg.data = push_data{pcmd->get_bid(), pcmd->get_rid(), pcmd->get_target(), pcmd->get_range()};
+		} else if(const auto* apcmd = dynamic_cast<const await_push_command*>(cmd)) {
 			auto* source = apcmd->get_source();
-			frame->pkg.data = await_push_data{source->get_bid(), source->get_rid(), source->get_nid(), source->get_cid(), source->get_range()};
-		} else if(const auto* rcmd = dynamic_cast<reduction_command*>(cmd)) {
-			frame->pkg.data = reduction_data{rcmd->get_reduction_info().rid};
-		} else if(const auto* hcmd = dynamic_cast<horizon_command*>(cmd)) {
-			frame->pkg.data = horizon_data{hcmd->get_tid()};
+			frame.pkg.data = await_push_data{source->get_bid(), source->get_rid(), source->get_nid(), source->get_cid(), source->get_range()};
+		} else if(const auto* rcmd = dynamic_cast<const reduction_command*>(cmd)) {
+			frame.pkg.data = reduction_data{rcmd->get_reduction_info().rid};
+		} else if(const auto* hcmd = dynamic_cast<const horizon_command*>(cmd)) {
+			frame.pkg.data = horizon_data{hcmd->get_tid()};
 		} else {
 			assert(false && "Unknown command");
 		}
 
-		frame->num_dependencies = dependencies.size();
-		std::copy(dependencies.begin(), dependencies.end(), frame->dependencies);
-
-		m_flush_cb(cmd->get_nid(), std::move(frame));
-		cmd->mark_as_flushed();
+		frame.num_dependencies = num_deps;
+		std::transform(cmd->get_dependencies().begin(), cmd->get_dependencies().end(), frame.dependencies,
+		    [](const abstract_command::dependency& edge) { return edge.node->get_cid(); });
 	}
 
-} // namespace detail
-} // namespace celerity
+	return std::move(builder).into_vector();
+}
+
+} // namespace celerity::detail

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_TARGETS
   region_map_tests
   runtime_tests
   runtime_deprecation_tests
+  serialization_tests
   sycl_tests
   task_graph_tests
   task_ring_buffer_tests

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -151,7 +151,7 @@ struct task_manager_benchmark_context {
 struct graph_generator_benchmark_context {
 	const size_t num_nodes;
 	command_graph cdag;
-	graph_serializer gser{cdag, [](node_id, unique_frame_ptr<command_frame>) {}};
+	graph_serializer gser{num_nodes, cdag, [](node_id, frame_vector<command_frame>) {}};
 	task_manager tm{num_nodes, nullptr};
 	graph_generator ggen{num_nodes, cdag};
 	test_utils::mock_buffer_factory mbf{tm, ggen};
@@ -259,7 +259,7 @@ struct scheduler_benchmark_context {
 	explicit scheduler_benchmark_context(restartable_thread& thrd, size_t num_nodes)
 	    : num_nodes{num_nodes}, //
 	      schdlr{thrd, std::make_unique<graph_generator>(num_nodes, cdag),
-	          std::make_unique<graph_serializer>(cdag, [](node_id, unique_frame_ptr<command_frame>) {}), num_nodes} {
+	          std::make_unique<graph_serializer>(num_nodes, cdag, [](node_id, frame_vector<command_frame>) {}), num_nodes} {
 		tm.register_task_callback([this](const task* tsk) { schdlr.notify_task_created(tsk); });
 		schdlr.startup();
 	}

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -462,7 +462,7 @@ namespace detail {
 
 		CHECK(inspector.get_commands(tid_a, std::nullopt, command_type::execution).size() == 1);
 		const auto computes_a = inspector.get_commands(tid_a, node_id(0), command_type::execution);
-		CHECK(computes_a.size() == 1);
+		REQUIRE(computes_a.size() == 1);
 
 		// task_b writes to the same buffer a
 		const auto tid_b = test_utils::build_and_flush(ctx, 1,
@@ -471,7 +471,7 @@ namespace detail {
 
 		CHECK(inspector.get_commands(tid_b, std::nullopt, command_type::execution).size() == 1);
 		const auto computes_b = inspector.get_commands(tid_b, node_id(0), command_type::execution);
-		CHECK(computes_b.size() == 1);
+		REQUIRE(computes_b.size() == 1);
 		// task_b should have an anti-dependency onto task_a
 		REQUIRE(inspector.has_dependency(*computes_b.cbegin(), *computes_a.cbegin()));
 
@@ -482,9 +482,11 @@ namespace detail {
 
 		CHECK(inspector.get_commands(tid_c, std::nullopt, command_type::execution).size() == 1);
 		const auto computes_c = inspector.get_commands(tid_c, node_id(0), command_type::execution);
-		CHECK(computes_c.size() == 1);
-		// task_c should not have any anti-dependencies at all
-		REQUIRE(inspector.get_dependency_count(*computes_c.cbegin()) == 0);
+		REQUIRE(computes_c.size() == 1);
+		// task_c should only have a dependency on epoch commands
+		REQUIRE(inspector.get_dependency_count(*computes_c.cbegin()) == 1);
+		const command_id epoch_cid = 0; // there is 1 node with nid = 0, and by definition the initial epoch commands are enumerated as cid = nid
+		CHECK(inspector.has_dependency(*computes_c.cbegin(), epoch_cid));
 
 		test_utils::maybe_print_graphs(ctx);
 	}

--- a/test/serialization_tests.cc
+++ b/test/serialization_tests.cc
@@ -1,0 +1,289 @@
+#include "test_utils.h"
+
+#include <catch2/generators/catch_generators_all.hpp>
+
+namespace celerity::detail {
+
+TEST_CASE("frame_vector iteration reproduces the emplaced values", "[frame_vector]") {
+	struct frame {
+		using payload_type = uint32_t;
+		enum { tag_a, tag_b } tag = tag_b; // non-trivial default ctor
+		size_t count;
+		payload_type payload[];
+	};
+
+	frame_vector_layout<frame> layout;
+	layout.reserve_back(from_payload_count, 2);
+	layout.reserve_back(from_payload_count, 3);
+	layout.reserve_back(from_payload_count, 1);
+	CHECK(layout.get_size_bytes()
+	      == utils::ceil(4 * sizeof(size_t), alignof(frame))                                    //
+	             + utils::ceil(sizeof(frame) + sizeof(frame::payload_type) * 2, alignof(frame)) //
+	             + utils::ceil(sizeof(frame) + sizeof(frame::payload_type) * 3, alignof(frame)) //
+	             + (sizeof(frame) + sizeof(frame::payload_type) * 1));
+
+	frame_vector_builder<frame> builder(layout);
+	{
+		auto& f = builder.emplace_back(from_payload_count, 2);
+		f.count = 2;
+		f.payload[0] = 8;
+		f.payload[1] = 9;
+	}
+	{
+		auto& f = builder.emplace_back(from_payload_count, 3);
+		f.tag = frame::tag_a;
+		f.count = 3;
+		f.payload[0] = 2;
+		f.payload[1] = 3;
+		f.payload[2] = 4;
+	}
+	{
+		auto& f = builder.emplace_back(from_payload_count, 1);
+		f.count = 1;
+		f.payload[0] = 10;
+	}
+
+	auto vector = std::move(builder).into_vector();
+	CHECK(std::distance(vector.cbegin(), vector.cend()) == 3);
+
+	auto it = vector.begin();
+	REQUIRE(it != vector.end());
+	CHECK(it.get_payload_count() == 2);
+	CHECK(it.get_size_bytes() == sizeof(frame) + 2 * sizeof(uint32_t));
+	CHECK(it->tag == frame::tag_b);
+	CHECK(it->count == 2);
+	CHECK(it->payload[0] == 8);
+	CHECK(it->payload[1] == 9);
+
+	const auto same_it = it++;
+	REQUIRE(same_it == vector.begin());
+	CHECK(&*same_it == &*vector.begin());
+
+	REQUIRE(it != vector.end());
+	CHECK(it.get_payload_count() == 3);
+	CHECK(it.get_size_bytes() == sizeof(frame) + 3 * sizeof(uint32_t));
+	CHECK(it->tag == frame::tag_a);
+	CHECK(it->count == 3);
+	CHECK(it->payload[0] == 2);
+	CHECK(it->payload[1] == 3);
+	CHECK(it->payload[2] == 4);
+
+	++it;
+	REQUIRE(it != vector.end());
+	CHECK(it.get_payload_count() == 1);
+	CHECK(it.get_size_bytes() == sizeof(frame) + 1 * sizeof(uint32_t));
+	CHECK(it->tag == frame::tag_b);
+	CHECK(it->count == 1);
+	CHECK(it->payload[0] == 10);
+
+	++it;
+	CHECK(it == vector.end());
+
+	CHECK(vector.begin() == vector.cbegin());
+	CHECK(vector.cend() == vector.end());
+	CHECK(vector.begin() != vector.cend());
+	CHECK(vector.cend() != vector.begin());
+}
+
+TEST_CASE("frame_vector correctly lays out frame types with small aligment", "[frame_vector]") {
+	struct frame {
+		using payload_type = uint16_t;
+		payload_type payload[];
+	};
+
+	frame_vector_layout<frame> layout;
+	layout.reserve_back(from_payload_count, 1);
+	layout.reserve_back(from_payload_count, 5);
+	layout.reserve_back(from_payload_count, 4);
+	CHECK(layout.get_size_bytes()
+	      == utils::ceil(4 * sizeof(size_t), alignof(frame))                                    //
+	             + utils::ceil(sizeof(frame) + sizeof(frame::payload_type) * 1, alignof(frame)) //
+	             + utils::ceil(sizeof(frame) + sizeof(frame::payload_type) * 5, alignof(frame)) //
+	             + (sizeof(frame) + sizeof(frame::payload_type) * 4));
+
+	frame_vector_builder<frame> builder(layout);
+	{
+		auto& f = builder.emplace_back(from_payload_count, 1);
+		f.payload[0] = 1;
+	}
+	{
+		auto& f = builder.emplace_back(from_payload_count, 5);
+		f.payload[0] = 4;
+		f.payload[1] = 5;
+		f.payload[2] = 6;
+		f.payload[3] = 7;
+		f.payload[4] = 8;
+	}
+	{
+		auto& f = builder.emplace_back(from_payload_count, 4);
+		f.payload[0] = 10;
+		f.payload[1] = 11;
+		f.payload[2] = 12;
+		f.payload[3] = 13;
+	}
+
+	auto vector = std::move(builder).into_vector();
+
+	auto it = vector.begin();
+	REQUIRE(it != vector.end());
+	CHECK(it.get_size_bytes() == 2);
+	CHECK(it.get_payload_count() == 1);
+	CHECK(it->payload[0] == 1);
+
+	++it;
+	REQUIRE(it != vector.end());
+	CHECK(it.get_size_bytes() == 10);
+	CHECK(it.get_payload_count() == 5);
+	CHECK(it->payload[0] == 4);
+	CHECK(it->payload[1] == 5);
+	CHECK(it->payload[2] == 6);
+	CHECK(it->payload[3] == 7);
+	CHECK(it->payload[4] == 8);
+
+	++it;
+	REQUIRE(it != vector.end());
+	CHECK(it.get_size_bytes() == 8);
+	CHECK(it.get_payload_count() == 4);
+	CHECK(it->payload[0] == 10);
+	CHECK(it->payload[1] == 11);
+	CHECK(it->payload[2] == 12);
+	CHECK(it->payload[3] == 13);
+
+	++it;
+	CHECK(it == vector.end());
+}
+
+TEST_CASE("frame_vector correctly lays out frame types with large aligment", "[frame_vector]") {
+	struct alignas(16) frame {
+		using payload_type = uint64_t;
+		int tag;
+		alignas(16) payload_type payload[];
+	};
+
+	frame_vector_layout<frame> layout;
+	layout.reserve_back(from_payload_count, 0);
+	layout.reserve_back(from_payload_count, 1);
+	layout.reserve_back(from_payload_count, 2);
+	layout.reserve_back(from_payload_count, 3);
+	layout.reserve_back(from_payload_count, 1);
+
+	CHECK(layout.get_size_bytes()
+	      == utils::ceil(6 * sizeof(size_t), alignof(frame))                                    //
+	             + utils::ceil(sizeof(frame) + sizeof(frame::payload_type) * 0, alignof(frame)) //
+	             + utils::ceil(sizeof(frame) + sizeof(frame::payload_type) * 1, alignof(frame)) //
+	             + utils::ceil(sizeof(frame) + sizeof(frame::payload_type) * 2, alignof(frame)) //
+	             + utils::ceil(sizeof(frame) + sizeof(frame::payload_type) * 3, alignof(frame)) //
+	             + (sizeof(frame) + sizeof(frame::payload_type) * 1));
+
+	frame_vector_builder<frame> builder(layout);
+	{
+		auto& f = builder.emplace_back(from_payload_count, 0);
+		REQUIRE(reinterpret_cast<uintptr_t>(&f) % 16 == 0);
+	}
+	{
+		auto& f = builder.emplace_back(from_payload_count, 1);
+		REQUIRE(reinterpret_cast<uintptr_t>(&f) % 16 == 0);
+		f.payload[0] = 4;
+	}
+	{
+		auto& f = builder.emplace_back(from_payload_count, 2);
+		REQUIRE(reinterpret_cast<uintptr_t>(&f) % 16 == 0);
+		f.payload[0] = 2;
+		f.payload[1] = 3;
+	}
+	{
+		auto& f = builder.emplace_back(from_payload_count, 3);
+		REQUIRE(reinterpret_cast<uintptr_t>(&f) % 16 == 0);
+		f.payload[0] = 7;
+		f.payload[1] = 8;
+		f.payload[2] = 9;
+	}
+	{
+		auto& f = builder.emplace_back(from_payload_count, 1);
+		REQUIRE(reinterpret_cast<uintptr_t>(&f) % 16 == 0);
+		f.payload[0] = 11;
+	}
+
+	auto vector = std::move(builder).into_vector();
+
+	auto it = vector.begin();
+	REQUIRE(it != vector.end());
+	CHECK(it.get_size_bytes() == sizeof(frame));
+	CHECK(it.get_payload_count() == 0);
+
+	++it;
+	REQUIRE(it != vector.end());
+	CHECK(it.get_size_bytes() == sizeof(frame) + sizeof(frame::payload_type));
+	CHECK(it.get_payload_count() == 1);
+	CHECK(it->payload[0] == 4);
+
+	++it;
+	REQUIRE(it != vector.end());
+	CHECK(it.get_size_bytes() == sizeof(frame) + 2 * sizeof(frame::payload_type));
+	CHECK(it.get_payload_count() == 2);
+	CHECK(it->payload[0] == 2);
+	CHECK(it->payload[1] == 3);
+
+	++it;
+	REQUIRE(it != vector.end());
+	CHECK(it.get_size_bytes() == sizeof(frame) + 3 * sizeof(frame::payload_type));
+	CHECK(it.get_payload_count() == 3);
+	CHECK(it->payload[0] == 7);
+	CHECK(it->payload[1] == 8);
+	CHECK(it->payload[2] == 9);
+
+	++it;
+	REQUIRE(it != vector.end());
+	CHECK(it.get_size_bytes() == sizeof(frame) + sizeof(frame::payload_type));
+	CHECK(it.get_payload_count() == 1);
+	CHECK(it->payload[0] == 11);
+
+	++it;
+	CHECK(it == vector.end());
+}
+
+
+TEST_CASE("can create shared_frame_ptrs from frame_vector iterators", "[frame-vector]") {
+	struct frame {
+		using payload_type = std::byte;
+		int tag;
+		payload_type payload[];
+	};
+
+	frame_vector_layout<frame> layout;
+	layout.reserve_back(from_payload_count, 0);
+	layout.reserve_back(from_payload_count, 1);
+	layout.reserve_back(from_payload_count, 2);
+
+	frame_vector_builder<frame> builder(layout);
+	builder.emplace_back(from_payload_count, 0).tag = 6;
+	builder.emplace_back(from_payload_count, 1).tag = 5;
+	builder.emplace_back(from_payload_count, 2).tag = 4;
+
+	auto vector = std::make_shared<frame_vector<frame>>(std::move(builder).into_vector());
+	CHECK(vector.use_count() == 1);
+
+	{
+		auto it = vector->begin();
+		auto b0 = it.get_shared_from_this();
+		CHECK(b0.get_payload_count() == 0);
+		CHECK(b0->tag == 6);
+
+		++it;
+		auto b1 = it.get_shared_from_this();
+		CHECK(b1.get_payload_count() == 1);
+		CHECK(b1->tag == 5);
+
+		++it;
+		auto b2 = it.get_shared_from_this();
+		CHECK(b2.get_payload_count() == 2);
+		CHECK(b2->tag == 4);
+
+		++it;
+		CHECK(it == vector->end());
+		CHECK(vector.use_count() == 4);
+	}
+	CHECK(vector.use_count() == 1);
+}
+
+} // namespace celerity::detail


### PR DESCRIPTION
In addition to execution commands, scheduling a task will generate push / await-push / reduction cascades on participating nodes. So far, all of these implicit commands are `MPI_Sent` to workers individually, initiating _O(N²)_ MPI ops in case of an all-to-all communication pattern. As we have investigated previously, this will overwhelm the management of asynchronous ops at least in OpenMPI and degrade network performance.

### Frame Vectors

This PR introduces `frame_vector`, a contiguous data structure for serializing multiple `command_frame`s as they exist today. The memory layout is as follows:
```
[size_t num_frames][size_t frame_0_size_bytes][size_t frame_k_size_bytes...][frame_0][frame_k...]
```
A `frame_vector` can be allocated in two different manners:
- By constructing it `from_size_bytes` and filling it with a byte-wise copy (aka, `MPI_Recv`)
- By assembling it from scratch:
    1. Create a `frame_vector_layout`, calling `reserve_back` to compute the required allocation size
    2. Create ` frame_vector_builder` from the `layout` and constructing frames in-place by calling `emplace_back`
    3. Obtaining the final `frame_vector` from the `builder` by calling `into_vector`

This three-step program appears somewhat convoluted, but is easier to implement than an auto-resizing vector and also allows us to build the entire structure with a single call to `malloc`.

### Shared Frame Pointers

Since we are packing together commands only based on their task-id and destination node-id but are otherwise unrelated from the perspective of the Executor, we need to entertain the question how the frame memory should be freed.

The most elegant solution I came up with so far is to introduce a `shared_frame_ptr` akin to `unique_frame_ptr`, and create _N_ `shared_frame_ptr`s in the executor that collectively own the allocation of the receiving `frame_vector` that contained _N_ commands.

### Good Bye Virtual Dependencies

The `graph_serializer` has almost been re-written entirely to move from a _flush-as-you-go_ model to a _collect-and-flush-once_ aproach. This has the added benefit of requiring only around _2N_ allocations for _N_ nodes.

So far, we had the concept of a _virtual depencency_, aka an in-CDAG dependency to a command that exists implicitly and has not actually been flushed to its worker. This only applies to the initial epoch, which is created implicitly in TDAG and CDAG, and parts of the code (especially tests) weren't able to deal with a dependency to a command they did not receive. This _virtual dependency_ special casing became a nuisance when trying to compute command payload sizes in advance.

As a solution, this PR moves to serialize dependencies to init-epoch commands like any other dependency, and equips the (test) code in question to deal with those implicit commands. Technically this means we are inflating each affected command frame by one `size_t`, but I would argue the performance impact of this will not be measurable.

### What is Left to Figure Out

- [ ] This PR adds even more _frame_ management types than we already have. We could simplify this, e.g. by
   - getting rid of `unique_frame_ptr` and only ever transmitting `frame_vector`s (which would then have size 1 for `data_frames` and waste one `size_t` of bandwidth)
   - making shared-pointer semantics the default and getting rid of `unique_*_ptr` types
- [ ] Benchmark this PR against master to figure out if we have addressed the OpenMPI bottleneck
- [ ] Bikeshed terminology - does `frame_vector` make sense, or is the vector the actual _frame_ (because its being transmitted over the network) and its elements should have a different name?
- [x] ~~This PR seems to introduce a bug around reductions that is sometimes observable on DPC++ (see the [most recent CI failure](https://github.com/celerity/celerity-runtime/actions/runs/3081442005/jobs/4979998874)). See if this is caused by the modified transitive-dependency handling logic in `graph_serializer`, or if we depend on the order of commands being sent in an incorrect manner.~~ Was unrelated to this PR after all, and is fixed by #146.