### PR TITLE
Fix: Generate intra-task anti-dependencies for reduction pushes

### DIFF
--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -472,6 +472,8 @@ namespace detail {
 							add_dependencies_for_box(m_cdag, reduce_cmd, m_node_data.at(source_nid).buffer_last_writer.at(bid), box);
 						} else {
 							auto push_cmd = m_cdag.create<push_command>(source_nid, bid, reduction.rid, nid, sr);
+							generated_pushes.push_back(push_cmd);
+
 							m_command_buffer_reads[push_cmd->get_cid()][bid] = GridRegion<3>::merge(m_command_buffer_reads[push_cmd->get_cid()][bid], box);
 							add_dependencies_for_box(m_cdag, push_cmd, m_node_data.at(source_nid).buffer_last_writer.at(bid), box);
 


### PR DESCRIPTION
`graph_generator` must generate anti-dependencies between push- and execution commands arising from the same task (known as _intra-task race conditions_ in the code). This works as intended when the push is generated from a buffer in `distributed_state` (the common case), but not when that buffer is in `pending_reduction_state` following a kernel that wrote (partial) reduction results.

![missing-anti-dep](https://user-images.githubusercontent.com/5698527/191505602-25b8022b-d105-43c9-9a8b-8f89c259ad73.png)

This PR fixes the bug by considering pushes arising from reductions for intra-task dependency analysis.

The bug surfaced in `distr_tests` (_multiple chained reductions produce correct results_) when testing #142 , although it is entirely unrelated to the contents of that PR.