### PR TITLE
CI: Disable buggy skipping of duplicate runs

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -31,9 +31,8 @@ jobs:
       - id: skip-check
         uses: fkirc/skip-duplicate-actions@v3.4.1
         with:
-          concurrent_skipping: "same_content_newer"
-          skip_after_successful_duplicate: "true"
-          paths_ignore: '["**/*.md", "docs/**", "website/**"]'
+          concurrent_skipping: "never"
+          skip_after_successful_duplicate: "false"
           do_not_skip: '["workflow_dispatch", "schedule"]'
           cancel_others: "true"
 


### PR DESCRIPTION
Due to [a bug](https://github.com/fkirc/skip-duplicate-actions/issues/264), the fkirc/skip-duplicate-actions incorrectly identifies `pull_request` as duplicates to `push` triggers based on identical base branches, even though pull requests run will on an implicit merge commit.

This temporarily disables skipping of concurrent runs. We keep cancellation of known-outdated runs when a newer commit was pushed on the same branch. 