### PR TITLE
clang-tidy: Enable more checks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,6 +26,7 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: Inner
 PointerAlignment: Left
+QualifierAlignment: Left
 SpaceAfterCStyleCast: false
 SpaceBeforeParens: Never
 SpaceInEmptyParentheses: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,9 @@ Checks:
   -bugprone-easily-swappable-parameters,
   -bugprone-lambda-function-name,
   -bugprone-macro-parentheses,
+  misc-*,
+  -misc-no-recursion
+  -misc-non-private-member-variables-in-classes,
   # TODO: Figure out which ones we want to (at least partially) enable
   # clang-analyzer-*,
   # clang-diagnostic-*,
@@ -29,7 +32,9 @@ Checks:
   # -readability-uppercase-literal-suffix
 
 CheckOptions:
+  ####################
   # Naming conventions
+  ####################
   - key: readability-identifier-naming.ClassCase
     value: lower_case
   - key: readability-identifier-naming.ClassMethodCase
@@ -60,12 +65,21 @@ CheckOptions:
     value: m_
   - key: readability-identifier-naming.TemplateParameterCase
     value: CamelCase
+  ##########################
   # Other coding conventions
+  ##########################
   - key: readability-braces-around-statements.ShortStatementLines
     # Allow control-flow statements w/o braces when on a single line
     value: 1
+  ##########################
+  # Various check options
+  ##########################
+  - key: misc-const-correctness.TransformPointersAsValues
+    value: true
 
 # Treat naming violations as errors
+# TODO: Also add misc-const-correctness here once that's become more reliable (check again for Clang > 15)
 WarningsAsErrors: "readability-identifier-naming"
+
 # Use .clang-format configuration for fixes
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,7 +30,7 @@ Checks: -*,
   mpi-*,
   performance-*,
   readability-*,
-  -readability-avoid-const-params-in-decls
+  -readability-avoid-const-params-in-decls,
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-uppercase-literal-suffix,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,9 +12,7 @@
 #
 InheritParentConfig: false
 # See https://clang.llvm.org/extra/clang-tidy/checks/list.html for a full list of available checks.
-Checks:
-  -*,
-  readability-identifier-naming,
+Checks: -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-lambda-function-name,
@@ -22,14 +20,20 @@ Checks:
   misc-*,
   -misc-no-recursion
   -misc-non-private-member-variables-in-classes,
-  # TODO: Figure out which ones we want to (at least partially) enable
-  # clang-analyzer-*,
-  # clang-diagnostic-*,
-  # cppcoreguidelines-*,
-  # mpi-*,
-  # performance-*,
-  # readability-*,
-  # -readability-uppercase-literal-suffix
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  mpi-*,
+  performance-*,
+  readability-*,
+  -readability-avoid-const-params-in-decls
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-uppercase-literal-suffix,
 
 CheckOptions:
   ####################

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@
 # 1. Automatic checks through an IDE (CLion, VsCode, ...)
 # 2. Running manually on select files (not recommended)
 #    `clang-tidy -p path/to/compile_commands.json file1 [file2, ...]`
+#    Note: A script for running clang-tidy on all Celerity sources is provided in `ci/run-clang-tidy.sh`
 # 3. Running on a diff (also done during CI)
 #    `git diff -U0 --no-color | clang-tidy-diff.py -p1 -path path/to/compile_commands.json`
 #
@@ -14,8 +15,11 @@ InheritParentConfig: false
 Checks:
   -*,
   readability-identifier-naming,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-lambda-function-name,
+  -bugprone-macro-parentheses,
   # TODO: Figure out which ones we want to (at least partially) enable
-  # bugprone-*,
   # clang-analyzer-*,
   # clang-diagnostic-*,
   # cppcoreguidelines-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,6 +46,10 @@ CheckOptions:
   - key: readability-identifier-naming.ParameterIgnoredRegexp
     # Allow single-letter uppercase function parameters
     value: "[A-Z]"
+  - key: readability-identifier-naming.ProtectedMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.ProtectedMemberPrefix
+    value: m_
   - key: readability-identifier-naming.PrivateMemberCase
     value: lower_case
   - key: readability-identifier-naming.PrivateMemberPrefix

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,7 @@ Checks: -*,
   -bugprone-lambda-function-name,
   -bugprone-macro-parentheses,
   misc-*,
-  -misc-no-recursion
+  -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   clang-analyzer-*,
   clang-diagnostic-*,

--- a/ci/run-clang-tidy.sh
+++ b/ci/run-clang-tidy.sh
@@ -17,7 +17,7 @@ if [[ ! -d src ]]; then
 fi
 
 CLANG_TIDY=${CLANG_TIDY:-clang-tidy}
-if [[ ! -x "$CLANG_TIDY" ]]; then
+if [[ ! -x "$(which $CLANG_TIDY)" ]]; then
     echo "Clang tidy executable \`$CLANG_TIDY\` does not exist. Set CLANG_TIDY environment variable to override."
     exit 1
 fi

--- a/examples/distr_io/distr_io.cc
+++ b/examples/distr_io/distr_io.cc
@@ -54,7 +54,7 @@ static void read_hdf5_file(celerity::distr_queue& q, const celerity::buffer<floa
 }
 
 
-static void write_hdf5_file(celerity::distr_queue& q, const celerity::buffer<float, 2>& buffer, const char* file_name) {
+static void write_hdf5_file(celerity::distr_queue& q, celerity::buffer<float, 2> buffer, const char* file_name) {
 	q.submit([=](celerity::handler& cgh) {
 		celerity::accessor a{buffer, cgh, celerity::experimental::access::even_split<2>{}, celerity::read_only_host_task};
 		cgh.host_task(celerity::experimental::collective, [=](celerity::experimental::collective_partition part) {

--- a/examples/reduction/reduction.cc
+++ b/examples/reduction/reduction.cc
@@ -63,7 +63,8 @@ int main(int argc, char* argv[]) {
 	}
 
 	int image_width = 0, image_height = 0, image_channels = 0;
-	std::unique_ptr<uint8_t, decltype((stbi_image_free))> srgb_255_data{stbi_load(argv[1], &image_width, &image_height, &image_channels, 4), stbi_image_free};
+	const std::unique_ptr<uint8_t, decltype((stbi_image_free))> srgb_255_data{
+	    stbi_load(argv[1], &image_width, &image_height, &image_channels, 4), stbi_image_free};
 	assert(srgb_255_data != nullptr);
 
 	celerity::distr_queue q;

--- a/examples/syncing/syncing.cc
+++ b/examples/syncing/syncing.cc
@@ -2,7 +2,7 @@
 
 #include <celerity.h>
 
-int main(int argc, char* argv[]) {
+int main() {
 	constexpr size_t buf_size = 512;
 
 	celerity::distr_queue queue;

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -10,6 +10,7 @@
 #include "ranges.h"
 #include "runtime.h"
 #include "sycl_wrappers.h"
+#include "utils.h"
 
 namespace celerity {
 
@@ -39,6 +40,8 @@ template <typename DataT, int Dims>
 class buffer {
   public:
 	static_assert(Dims > 0, "0-dimensional buffers NYI");
+
+	CELERITY_DETAIL_HACK_CLANG_TIDY_ALLOW_NON_CONST(buffer)
 
 	buffer(const DataT* host_ptr, celerity::range<Dims> range) {
 		if(!detail::runtime::is_initialized()) { detail::runtime::init(nullptr, nullptr); }

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -123,7 +123,7 @@ namespace detail {
 			buffer_id bid;
 			const bool is_host_initialized = host_init_ptr != nullptr;
 			{
-				std::unique_lock lock(m_mutex);
+				const std::unique_lock lock(m_mutex);
 				bid = m_buffer_count++;
 				m_buffer_infos[bid] = buffer_info{range, sizeof(DataT), is_host_initialized};
 				m_newest_data_location.emplace(bid, region_map<data_location>(range, data_location::nowhere));
@@ -155,18 +155,18 @@ namespace detail {
 		 * This is useful in rare situations where worker nodes might receive data for buffers they haven't registered yet.
 		 */
 		bool has_buffer(buffer_id bid) const {
-			std::shared_lock lock(m_mutex);
+			const std::shared_lock lock(m_mutex);
 			return m_buffer_infos.count(bid) == 1;
 		}
 
 		bool has_active_buffers() const {
-			std::shared_lock lock(m_mutex);
+			const std::shared_lock lock(m_mutex);
 			return !m_buffer_infos.empty();
 		}
 
 		// returning copy of struct because FOR NOW it is not called in any performance critical section.
 		buffer_info get_buffer_info(buffer_id bid) const {
-			std::shared_lock lock(m_mutex);
+			const std::shared_lock lock(m_mutex);
 			assert(m_buffer_infos.find(bid) != m_buffer_infos.end());
 			return m_buffer_infos.at(bid);
 		}
@@ -198,7 +198,7 @@ namespace detail {
 		template <typename DataT, int Dims>
 		access_info<DataT, Dims, device_buffer> get_device_buffer(
 		    buffer_id bid, cl::sycl::access::mode mode, const cl::sycl::range<3>& range, const cl::sycl::id<3>& offset) {
-			std::unique_lock lock(m_mutex);
+			const std::unique_lock lock(m_mutex);
 #if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 			assert((m_buffer_types.at(bid)->has_type<DataT, Dims>()));
 #endif
@@ -258,7 +258,7 @@ namespace detail {
 		template <typename DataT, int Dims>
 		access_info<DataT, Dims, host_buffer> get_host_buffer(
 		    buffer_id bid, cl::sycl::access::mode mode, const cl::sycl::range<3>& range, const cl::sycl::id<3>& offset) {
-			std::unique_lock lock(m_mutex);
+			const std::unique_lock lock(m_mutex);
 #if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 			assert((m_buffer_types.at(bid)->has_type<DataT, Dims>()));
 #endif
@@ -315,12 +315,12 @@ namespace detail {
 		bool is_locked(buffer_id bid) const;
 
 		void set_debug_name(const buffer_id bid, const std::string& debug_name) {
-			std::lock_guard lock(m_mutex);
+			const std::lock_guard lock(m_mutex);
 			m_buffer_infos.at(bid).debug_name = debug_name;
 		}
 
 		std::string get_debug_name(const buffer_id bid) const {
-			std::lock_guard lock(m_mutex);
+			const std::lock_guard lock(m_mutex);
 			return m_buffer_infos.at(bid).debug_name;
 		}
 

--- a/include/buffer_storage.h
+++ b/include/buffer_storage.h
@@ -232,8 +232,9 @@ namespace detail {
 		host_buffer<DataT, Dims> m_host_buf;
 	};
 
-	inline void assert_copy_is_in_range(const cl::sycl::range<3>& source_range, const cl::sycl::range<3>& target_range, const cl::sycl::id<3>& source_offset,
-	    const cl::sycl::id<3>& target_offset, const cl::sycl::range<3>& copy_range) {
+	inline void assert_copy_is_in_range([[maybe_unused]] const cl::sycl::range<3>& source_range, [[maybe_unused]] const cl::sycl::range<3>& target_range,
+	    [[maybe_unused]] const cl::sycl::id<3>& source_offset, [[maybe_unused]] const cl::sycl::id<3>& target_offset,
+	    [[maybe_unused]] const cl::sycl::range<3>& copy_range) {
 		assert(max_range(source_range, range_cast<3>(source_offset + copy_range)) == source_range);
 		assert(max_range(target_range, range_cast<3>(target_offset + copy_range)) == target_range);
 	}

--- a/include/device_queue.h
+++ b/include/device_queue.h
@@ -149,7 +149,7 @@ namespace detail {
 
 	template <typename DeviceT, typename PlatformT, typename SelectorT>
 	bool try_find_one_device(
-	    std::string& how_selected, DeviceT& device, const std::vector<PlatformT>& platforms, const host_config& host_cfg, SelectorT selector) {
+	    std::string& /*how_selected*/, DeviceT& device, const std::vector<PlatformT>& platforms, const host_config& /*host_cfg*/, SelectorT selector) {
 		std::vector<DeviceT> platform_devices;
 		for(auto& p : platforms) {
 			auto p_devices = p.get_devices();
@@ -167,8 +167,8 @@ namespace detail {
 	};
 
 	template <typename DeviceT, typename PlatformT>
-	bool try_find_one_device(
-	    std::string& how_selected, DeviceT& device, const std::vector<PlatformT>& platforms, const host_config& host_cfg, sycl::info::device_type type) {
+	bool try_find_one_device(std::string& /*how_selected*/, DeviceT& device, const std::vector<PlatformT>& platforms, const host_config& /*host_cfg*/,
+	    sycl::info::device_type type) {
 		for(auto& p : platforms) {
 			for(auto& d : p.get_devices(type)) {
 				device = d;

--- a/include/handler.h
+++ b/include/handler.h
@@ -41,7 +41,7 @@ namespace detail {
 #if !defined(_MSC_VER)
 		const std::unique_ptr<char, void (*)(void*)> demangled(abi::__cxa_demangle(name.c_str(), nullptr, nullptr, nullptr), std::free);
 		const std::string demangled_s(demangled.get());
-		if(size_t lastc; (lastc = demangled_s.rfind(":")) != std::string::npos) {
+		if(size_t lastc = demangled_s.rfind(":"); lastc != std::string::npos) {
 			name = demangled_s.substr(lastc + 1, demangled_s.length() - lastc - 1);
 		} else {
 			name = demangled_s;

--- a/include/handler.h
+++ b/include/handler.h
@@ -41,7 +41,7 @@ namespace detail {
 #if !defined(_MSC_VER)
 		const std::unique_ptr<char, void (*)(void*)> demangled(abi::__cxa_demangle(name.c_str(), nullptr, nullptr, nullptr), std::free);
 		const std::string demangled_s(demangled.get());
-		if(size_t lastc = demangled_s.rfind(":"); lastc != std::string::npos) {
+		if(const size_t lastc = demangled_s.rfind(":"); lastc != std::string::npos) {
 			name = demangled_s.substr(lastc + 1, demangled_s.length() - lastc - 1);
 		} else {
 			name = demangled_s;
@@ -262,7 +262,7 @@ class handler {
   private:
 	template <typename KernelFlavor, typename KernelName, int Dims, typename... ReductionsAndKernel, size_t... ReductionIndices>
 	void parallel_for_reductions_and_kernel(range<Dims> global_range, id<Dims> global_offset,
-	    typename detail::kernel_flavor_traits<KernelFlavor, Dims>::local_size_type local_size, std::index_sequence<ReductionIndices...> indices,
+	    typename detail::kernel_flavor_traits<KernelFlavor, Dims>::local_size_type local_size, std::index_sequence<ReductionIndices...> /*indices*/,
 	    ReductionsAndKernel&... kernel_and_reductions) {
 		auto args_tuple = std::forward_as_tuple(kernel_and_reductions...);
 		auto& kernel = std::get<sizeof...(kernel_and_reductions) - 1>(args_tuple);
@@ -511,7 +511,8 @@ namespace detail {
 	class reduction_descriptor;
 
 	template <typename DataT, int Dims, typename BinaryOperation, bool WithExplicitIdentity>
-	auto make_sycl_reduction(cl::sycl::handler& sycl_cgh, const reduction_descriptor<DataT, Dims, BinaryOperation, WithExplicitIdentity>& d) {
+	auto make_sycl_reduction(
+	    [[maybe_unused]] cl::sycl::handler& sycl_cgh, [[maybe_unused]] const reduction_descriptor<DataT, Dims, BinaryOperation, WithExplicitIdentity>& d) {
 #if !CELERITY_FEATURE_SIMPLE_SCALAR_REDUCTIONS
 		static_assert(detail::constexpr_false<BinaryOperation>, "Reductions are not supported by your SYCL implementation");
 #else
@@ -559,7 +560,8 @@ namespace detail {
 	};
 
 	template <bool WithExplicitIdentity, typename DataT, int Dims, typename BinaryOperation>
-	auto make_reduction(const buffer<DataT, Dims>& vars, handler& cgh, BinaryOperation op, DataT identity, const cl::sycl::property_list& prop_list) {
+	auto make_reduction([[maybe_unused]] const buffer<DataT, Dims>& vars, [[maybe_unused]] handler& cgh, [[maybe_unused]] const BinaryOperation op,
+	    [[maybe_unused]] const DataT identity, [[maybe_unused]] const cl::sycl::property_list& prop_list) {
 #if !CELERITY_FEATURE_SIMPLE_SCALAR_REDUCTIONS
 		static_assert(detail::constexpr_false<BinaryOperation>, "Reductions are not supported by your SYCL implementation");
 #else
@@ -657,7 +659,8 @@ void handler::host_task(range<Dims> global_range, id<Dims> global_offset, Functo
 }
 
 template <typename DataT, int Dims, typename BinaryOperation>
-auto reduction(const buffer<DataT, Dims>& vars, handler& cgh, BinaryOperation combiner, const cl::sycl::property_list& prop_list = {}) {
+auto reduction([[maybe_unused]] const buffer<DataT, Dims>& vars, [[maybe_unused]] handler& cgh, [[maybe_unused]] const BinaryOperation combiner,
+    [[maybe_unused]] const cl::sycl::property_list& prop_list = {}) {
 #if !CELERITY_FEATURE_SIMPLE_SCALAR_REDUCTIONS
 	static_assert(detail::constexpr_false<BinaryOperation>, "Reductions are not supported by your SYCL implementation");
 #else
@@ -672,7 +675,8 @@ auto reduction(const buffer<DataT, Dims>& vars, handler& cgh, BinaryOperation co
 }
 
 template <typename DataT, int Dims, typename BinaryOperation>
-auto reduction(const buffer<DataT, Dims>& vars, handler& cgh, const DataT identity, BinaryOperation combiner, const cl::sycl::property_list& prop_list = {}) {
+auto reduction([[maybe_unused]] const buffer<DataT, Dims>& vars, [[maybe_unused]] handler& cgh, [[maybe_unused]] const DataT identity,
+    [[maybe_unused]] const BinaryOperation combiner, [[maybe_unused]] const cl::sycl::property_list& prop_list = {}) {
 #if !CELERITY_FEATURE_SIMPLE_SCALAR_REDUCTIONS
 	static_assert(detail::constexpr_false<BinaryOperation>, "Reductions are not supported by your SYCL implementation");
 #else

--- a/include/host_object.h
+++ b/include/host_object.h
@@ -7,7 +7,7 @@
 #include <utility>
 
 #include "runtime.h"
-
+#include "utils.h"
 
 namespace celerity::experimental {
 
@@ -91,6 +91,12 @@ class host_object {
   public:
 	using object_type = T;
 
+	CELERITY_DETAIL_HACK_CLANG_TIDY_ALLOW_NON_CONST(host_object)
+	host_object(const host_object&) = default;
+	host_object(host_object&&) noexcept = default;
+	host_object& operator=(const host_object&) = default;
+	host_object& operator=(host_object&&) noexcept = default;
+
 	host_object() : m_shared_state{std::make_shared<state>(std::in_place)} {}
 
 	explicit host_object(const T& obj) : m_shared_state{std::make_shared<state>(std::in_place, obj)} {}
@@ -124,6 +130,12 @@ class host_object<T&> {
   public:
 	using object_type = T;
 
+	CELERITY_DETAIL_HACK_CLANG_TIDY_ALLOW_NON_CONST(host_object)
+	host_object(const host_object&) = default;
+	host_object(host_object&&) noexcept = default;
+	host_object& operator=(const host_object&) = default;
+	host_object& operator=(host_object&&) noexcept = default;
+
 	explicit host_object(T& obj) : m_shared_state{std::make_shared<state>(obj)} {}
 
 	explicit host_object(const std::reference_wrapper<T> ref) : m_shared_state{std::make_shared<state>(ref.get())} {}
@@ -148,6 +160,12 @@ template <>
 class host_object<void> {
   public:
 	using object_type = void;
+
+	CELERITY_DETAIL_HACK_CLANG_TIDY_ALLOW_NON_CONST(host_object)
+	host_object(const host_object&) = default;
+	host_object(host_object&&) noexcept = default;
+	host_object& operator=(const host_object&) = default;
+	host_object& operator=(host_object&&) noexcept = default;
 
 	explicit host_object() : m_shared_state{std::make_shared<state>()} {}
 

--- a/include/host_queue.h
+++ b/include/host_queue.h
@@ -69,7 +69,7 @@ class partition : public detail::sized_partition_base<Dims> {
  */
 class experimental::collective_partition : public partition<1> {
   public:
-	MPI_Comm get_collective_mpi_comm() const { return comm; }
+	MPI_Comm get_collective_mpi_comm() const { return m_comm; }
 
 	size_t get_node_index() const { return get_subrange().offset[0]; }
 
@@ -78,9 +78,9 @@ class experimental::collective_partition : public partition<1> {
   protected:
 	friend collective_partition detail::make_collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm);
 
-	MPI_Comm comm;
+	MPI_Comm m_comm;
 
-	collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm) : partition<1>(global_size, range), comm(comm) {}
+	collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm) : partition<1>(global_size, range), m_comm(comm) {}
 };
 
 template <>

--- a/include/log.h
+++ b/include/log.h
@@ -56,7 +56,7 @@ namespace detail {
 	};
 
 #define CELERITY_DETAIL_LOG_SET_SCOPED_CTX(ctx)                                                                                                                \
-	log_ctx_setter _set_log_ctx_##__COUNTER__ { ctx }
+	const log_ctx_setter _set_log_ctx_##__COUNTER__ { ctx }
 
 	template <typename Tuple, typename Callback>
 	constexpr void tuple_for_each_pair_impl(const Tuple&, Callback&&, std::index_sequence<>) {}

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -5,7 +5,7 @@
 namespace celerity {
 namespace detail {
 
-	inline size_t get_linear_index(const cl::sycl::range<1>& range, const cl::sycl::id<1>& index) { return index[0]; }
+	inline size_t get_linear_index(const cl::sycl::range<1>& /*range*/, const cl::sycl::id<1>& index) { return index[0]; }
 
 	inline size_t get_linear_index(const cl::sycl::range<2>& range, const cl::sycl::id<2>& index) { return index[0] * range[1] + index[1]; }
 

--- a/include/reduction_manager.h
+++ b/include/reduction_manager.h
@@ -50,24 +50,24 @@ namespace detail {
 	  public:
 		template <typename DataT, int Dims, typename BinaryOperation>
 		reduction_id create_reduction(const buffer_id bid, BinaryOperation op, DataT identity) {
-			std::lock_guard lock{m_mutex};
+			const std::lock_guard lock{m_mutex};
 			const auto rid = m_next_rid++;
 			m_reductions.emplace(rid, std::make_unique<buffer_reduction<DataT, Dims, BinaryOperation>>(bid, op, identity));
 			return rid;
 		}
 
 		bool has_reduction(reduction_id rid) const {
-			std::lock_guard lock{m_mutex};
+			const std::lock_guard lock{m_mutex};
 			return m_reductions.count(rid) != 0;
 		}
 
 		void push_overlapping_reduction_data(reduction_id rid, node_id source_nid, unique_payload_ptr data) {
-			std::lock_guard lock{m_mutex};
+			const std::lock_guard lock{m_mutex};
 			m_reductions.at(rid)->push_overlapping_data(source_nid, std::move(data));
 		}
 
 		void finish_reduction(reduction_id rid) {
-			std::lock_guard lock{m_mutex};
+			const std::lock_guard lock{m_mutex};
 			m_reductions.at(rid)->reduce_to_buffer();
 			m_reductions.erase(rid);
 		}

--- a/include/side_effect.h
+++ b/include/side_effect.h
@@ -4,7 +4,7 @@
 
 #include "handler.h"
 #include "host_object.h"
-
+#include "utils.h"
 
 namespace celerity::experimental {
 
@@ -17,6 +17,12 @@ class side_effect {
   public:
 	using object_type = typename host_object<T>::object_type;
 	constexpr static inline side_effect_order order = Order;
+
+	CELERITY_DETAIL_HACK_CLANG_TIDY_ALLOW_NON_CONST(side_effect)
+	side_effect(const side_effect&) = default;
+	side_effect(side_effect&&) noexcept = default;
+	side_effect& operator=(const side_effect&) = default;
+	side_effect& operator=(side_effect&&) noexcept = default;
 
 	explicit side_effect(const host_object<T>& object, handler& cgh) : m_object{object} {
 		if(detail::is_prepass_handler(cgh)) {

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -26,7 +26,7 @@ namespace detail {
 		explicit epoch_monitor(const task_id epoch) : m_this_epoch(epoch) {}
 
 		task_id get() const {
-			std::lock_guard lock{m_mutex};
+			const std::lock_guard lock{m_mutex};
 			return m_this_epoch;
 		}
 
@@ -38,7 +38,7 @@ namespace detail {
 
 		void set(const task_id epoch) {
 			{
-				std::lock_guard lock{m_mutex};
+				const std::lock_guard lock{m_mutex};
 				assert(epoch >= m_this_epoch);
 				m_this_epoch = epoch;
 			}
@@ -63,7 +63,7 @@ namespace detail {
 		virtual ~task_manager() = default;
 
 		template <typename CGF, typename... Hints>
-		task_id submit_command_group(CGF cgf, Hints... hints) {
+		task_id submit_command_group(CGF cgf, Hints... /*hints*/) {
 			auto reservation = m_task_buffer.reserve_task_entry(await_free_task_slot_callback());
 			const auto tid = reservation.get_tid();
 

--- a/include/types.h
+++ b/include/types.h
@@ -18,7 +18,7 @@ namespace detail {
 		using underlying_t = T;
 
 		constexpr PhantomType() = default;
-		constexpr PhantomType(T const& value) : m_value(value) {}
+		constexpr PhantomType(const T& value) : m_value(value) {}
 		constexpr PhantomType(T&& value) : m_value(std::move(value)) {}
 
 		// Allow implicit conversion to underlying type, otherwise it becomes too annoying to use.

--- a/include/user_bench.h
+++ b/include/user_bench.h
@@ -45,7 +45,7 @@ namespace experimental {
 
 				template <typename... Args>
 				void event(const std::string& format_string, Args&&... args) {
-					std::lock_guard lk{m_mutex};
+					const std::lock_guard lk{m_mutex};
 					const auto now = bench_clock::now();
 					const auto dt = (m_last_event_tp != bench_clock::time_point{})
 					                    ? std::chrono::duration_cast<std::chrono::microseconds>(now - m_last_event_tp).count()

--- a/include/user_bench.h
+++ b/include/user_bench.h
@@ -26,7 +26,7 @@ namespace experimental {
 				user_benchmarker(config& cfg, node_id this_nid);
 				user_benchmarker(const user_benchmarker&) = delete;
 				user_benchmarker(user_benchmarker&&) = delete;
-				~user_benchmarker();
+				~user_benchmarker() noexcept(false);
 
 				template <typename... Args>
 				void log_once(const std::string& format_string, Args&&... args) const {

--- a/include/utils.h
+++ b/include/utils.h
@@ -3,7 +3,16 @@
 #include <cstdint>
 #include <functional>
 #include <type_traits>
+#include <utility>
 #include <variant>
+
+// Certain types such as buffers and accessors could technically be declared const in most
+// situations, as they are being captured by-value into the inner lambda, however we don't want
+// that as it gives the wrong semantic impression.
+// To work around this, we define a copy constructor that receives a non-const argument,
+// which tricks clang-tidy into thinking that the declaration cannot be made const.
+#define CELERITY_DETAIL_HACK_CLANG_TIDY_ALLOW_NON_CONST(type)                                                                                                  \
+	type(type& other) : type(std::as_const(other)) {}
 
 namespace celerity::detail::utils {
 

--- a/src/buffer_manager.cc
+++ b/src/buffer_manager.cc
@@ -11,7 +11,7 @@ namespace detail {
 
 	void buffer_manager::unregister_buffer(buffer_id bid) noexcept {
 		{
-			std::unique_lock lock(m_mutex);
+			const std::unique_lock lock(m_mutex);
 			assert(m_buffer_infos.find(bid) != m_buffer_infos.end());
 
 			// Log the allocation size for host and device
@@ -31,7 +31,7 @@ namespace detail {
 	}
 
 	void buffer_manager::get_buffer_data(buffer_id bid, const subrange<3>& sr, void* out_linearized) {
-		std::unique_lock lock(m_mutex);
+		const std::unique_lock lock(m_mutex);
 		assert(m_buffers.count(bid) == 1 && (m_buffers.at(bid).device_buf.is_allocated() || m_buffers.at(bid).host_buf.is_allocated()));
 		auto data_locations = m_newest_data_location.at(bid).get_region_values(subrange_to_grid_box(sr));
 
@@ -66,7 +66,7 @@ namespace detail {
 	}
 
 	void buffer_manager::set_buffer_data(buffer_id bid, const subrange<3>& sr, unique_payload_ptr in_linearized) {
-		std::unique_lock lock(m_mutex);
+		const std::unique_lock lock(m_mutex);
 		assert(m_buffer_infos.count(bid) == 1);
 		m_scheduled_transfers[bid].push_back({std::move(in_linearized), sr});
 	}

--- a/src/config.cc
+++ b/src/config.cc
@@ -49,7 +49,7 @@ std::pair<bool, size_t> parse_uint(const char* str) {
 
 namespace celerity {
 namespace detail {
-	config::config(int* argc, char** argv[]) {
+	config::config(int* /*argc*/, char** /*argv*/[]) {
 		// TODO: At some point we might want to parse arguments from argv as well
 
 		{

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -100,7 +100,7 @@ namespace detail {
 				// also reading it from within a kernel is not supported. To avoid stalling other nodes, we thus perform the push first.
 				std::sort(ready_jobs.begin(), ready_jobs.end(),
 				    [this](command_id a, command_id b) { return m_jobs[a].cmd == command_type::push && m_jobs[b].cmd != command_type::push; });
-				for(command_id cid : ready_jobs) {
+				for(const command_id cid : ready_jobs) {
 					auto* job = m_jobs.at(cid).job.get();
 					job->start();
 					job->update();

--- a/src/graph_generator.cc
+++ b/src/graph_generator.cc
@@ -500,7 +500,7 @@ namespace detail {
 		}
 
 		for(auto [bid, nids] : buffer_reduction_resolve_list) {
-			GridBox<3> box{GridPoint<3>{1, 1, 1}};
+			const GridBox<3> box{GridPoint<3>{1, 1, 1}};
 			distributed_state state_after_reduction{cl::sycl::range<3>{1, 1, 1}};
 			state_after_reduction.region_sources.update_region(box, nids);
 			m_buffer_states.at(bid) = distributed_state{std::move(state_after_reduction)};

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -251,7 +251,7 @@ namespace detail {
 		if(is_master_node()) m_schdlr->notify_buffer_registered(bid, info.range);
 	}
 
-	void runtime::handle_buffer_unregistered(buffer_id bid) { maybe_destroy_runtime(); }
+	void runtime::handle_buffer_unregistered(buffer_id /*bid*/) { maybe_destroy_runtime(); }
 
 	void runtime::maybe_destroy_runtime() const {
 		if(m_test_active) return;

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -52,7 +52,7 @@ namespace detail {
 
 	void abstract_scheduler::notify(const event& evt) {
 		{
-			std::lock_guard lk(m_events_mutex);
+			const std::lock_guard lk(m_events_mutex);
 			m_available_events.push(evt);
 		}
 		m_events_cv.notify_one();

--- a/src/task.cc
+++ b/src/task.cc
@@ -22,7 +22,7 @@ namespace detail {
 	}
 
 	template <int KernelDims>
-	subrange<3> apply_range_mapper(range_mapper_base const* rm, const chunk<KernelDims>& chnk) {
+	subrange<3> apply_range_mapper(const range_mapper_base* rm, const chunk<KernelDims>& chnk) {
 		switch(rm->get_buffer_dimensions()) {
 		case 1: return subrange_cast<3>(rm->map_1(chnk));
 		case 2: return subrange_cast<3>(rm->map_2(chnk));
@@ -42,7 +42,7 @@ namespace detail {
 			auto rm = iter->second.get();
 			if(rm->get_access_mode() != mode) continue;
 
-			chunk<3> chnk{sr.offset, sr.range, global_size};
+			const chunk<3> chnk{sr.offset, sr.range, global_size};
 			subrange<3> req;
 			switch(kernel_dims) {
 			case 0:

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -55,7 +55,7 @@ namespace detail {
 
 	void task_manager::await_epoch(task_id epoch) { m_latest_epoch_reached.await(epoch); }
 
-	GridRegion<3> get_requirements(task const& tsk, buffer_id bid, const std::vector<cl::sycl::access::mode> modes) {
+	GridRegion<3> get_requirements(const task& tsk, buffer_id bid, const std::vector<cl::sycl::access::mode> modes) {
 		const auto& access_map = tsk.get_buffer_access_map();
 		const subrange<3> full_range{tsk.get_global_offset(), tsk.get_global_size()};
 		GridRegion<3> result;
@@ -230,7 +230,7 @@ namespace detail {
 		const auto previous_horizon = m_current_horizon;
 		m_current_horizon = tid;
 
-		task& new_horizon = reduce_execution_front(std::move(reserve), task::make_horizon_task(*m_current_horizon));
+		const task& new_horizon = reduce_execution_front(std::move(reserve), task::make_horizon_task(*m_current_horizon));
 		if(previous_horizon) { set_epoch_for_new_tasks(*previous_horizon); }
 
 		invoke_callbacks(&new_horizon);
@@ -278,7 +278,7 @@ namespace detail {
 					                         "\nLikely due to generating a very large number of tasks with no dependencies.");
 				}
 			}
-			task_id reached_epoch = m_latest_epoch_reached.await(previous_free_tid + 1);
+			const task_id reached_epoch = m_latest_epoch_reached.await(previous_free_tid + 1);
 			m_task_buffer.delete_up_to(reached_epoch);
 		};
 	}

--- a/src/transformers/naive_split.cc
+++ b/src/transformers/naive_split.cc
@@ -11,7 +11,8 @@ namespace celerity {
 namespace detail {
 
 	// We simply split in the first dimension for now
-	static std::vector<chunk<3>> split_equal(const chunk<3>& full_chunk, const cl::sycl::range<3>& granularity, const size_t num_chunks, const int dims) {
+	static std::vector<chunk<3>> split_equal(
+	    const chunk<3>& full_chunk, const cl::sycl::range<3>& granularity, const size_t num_chunks, [[maybe_unused]] const int dims) {
 #ifndef NDEBUG
 		assert(num_chunks > 0);
 		for(int d = 0; d < dims; ++d) {
@@ -74,7 +75,7 @@ namespace detail {
 		assert(std::distance(original->get_dependencies().begin(), original->get_dependencies().end()) == 0);
 		assert(std::distance(original->get_dependents().begin(), original->get_dependents().end()) == 0);
 
-		chunk<3> full_chunk{tsk.get_global_offset(), tsk.get_global_size(), tsk.get_global_size()};
+		const chunk<3> full_chunk{tsk.get_global_offset(), tsk.get_global_size(), tsk.get_global_size()};
 		const auto chunks = split_equal(full_chunk, tsk.get_granularity(), m_num_chunks, tsk.get_dimensions());
 		assert(chunks.size() <= m_num_chunks); // We may have created less than requested
 		assert(!chunks.empty());

--- a/src/user_bench.cc
+++ b/src/user_bench.cc
@@ -17,7 +17,7 @@ namespace experimental {
 				}
 			}
 
-			user_benchmarker::user_benchmarker(config& cfg, node_id this_nid) : m_this_nid(this_nid) {
+			user_benchmarker::user_benchmarker(config& /*cfg*/, node_id this_nid) : m_this_nid(this_nid) {
 				if(static_cast<double>(bench_clock::period::num) / bench_clock::period::den > static_cast<double>(std::micro::num) / std::micro::den) {
 					CELERITY_WARN("Available clock does not have sufficient precision");
 				}
@@ -26,14 +26,14 @@ namespace experimental {
 			user_benchmarker& get_user_benchmarker() { return celerity::detail::runtime::get_instance().get_user_benchmarker(); }
 
 			void user_benchmarker::begin_section(std::string name) {
-				std::lock_guard lk{m_mutex};
+				const std::lock_guard lk{m_mutex};
 				section sec = {m_next_section_id++, std::move(name), bench_clock::now()};
 				log("Begin section {} \"{}\"", sec.id, sec.name);
 				m_sections.push(std::move(sec));
 			}
 
 			void user_benchmarker::end_section(const std::string& name) {
-				std::lock_guard lk{m_mutex};
+				const std::lock_guard lk{m_mutex};
 				const auto sec = m_sections.top();
 				m_sections.pop();
 				if(sec.name != name) { throw std::runtime_error(fmt::format("Section name '{}' does not match last section '{}'", name, sec.name)); }

--- a/src/user_bench.cc
+++ b/src/user_bench.cc
@@ -10,7 +10,7 @@ namespace celerity {
 namespace experimental {
 	namespace bench {
 		namespace detail {
-			user_benchmarker::~user_benchmarker() {
+			user_benchmarker::~user_benchmarker() noexcept(false) {
 				while(!m_sections.empty()) {
 					const auto sec = m_sections.top();
 					end_section(sec.name);

--- a/src/worker_job.cc
+++ b/src/worker_job.cc
@@ -51,7 +51,7 @@ namespace detail {
 	// --------------------------------------------------- HORIZON --------------------------------------------------------
 	// --------------------------------------------------------------------------------------------------------------------
 
-	std::string horizon_job::get_description(const command_pkg& pkg) { return "horizon"; }
+	std::string horizon_job::get_description(const command_pkg& /*pkg*/) { return "horizon"; }
 
 	bool horizon_job::execute(const command_pkg& pkg) {
 		const auto data = std::get<horizon_data>(pkg.data);
@@ -63,7 +63,7 @@ namespace detail {
 	// ---------------------------------------------------- EPOCH ---------------------------------------------------------
 	// --------------------------------------------------------------------------------------------------------------------
 
-	std::string epoch_job::get_description(const command_pkg& pkg) { return "epoch"; }
+	std::string epoch_job::get_description(const command_pkg& /*pkg*/) { return "epoch"; }
 
 	bool epoch_job::execute(const command_pkg& pkg) {
 		const auto data = std::get<epoch_data>(pkg.data);
@@ -128,7 +128,7 @@ namespace detail {
 		return true;
 	}
 
-	std::string reduction_job::get_description(const command_pkg& pkg) { return "reduction"; }
+	std::string reduction_job::get_description(const command_pkg& /*pkg*/) { return "reduction"; }
 
 	// --------------------------------------------------------------------------------------------------------------------
 	// --------------------------------------------------- HOST_EXECUTE ---------------------------------------------------

--- a/test/accessor_tests.cc
+++ b/test/accessor_tests.cc
@@ -26,8 +26,8 @@ namespace detail {
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "SYCL accessors receive correct backing-buffer relative ranges and offsets", "[accessor]") {
 		distr_queue q;
 		buffer<int, 3> virtual_buf{cl::sycl::range<3>{1000, 1000, 1000}};
-		subrange<3> large_accessor_sr{{117, 118, 119}, {301, 302, 303}};
-		subrange<3> small_accessor_sr{{207, 206, 205}, {101, 102, 103}};
+		const subrange<3> large_accessor_sr{{117, 118, 119}, {301, 302, 303}};
+		const subrange<3> small_accessor_sr{{207, 206, 205}, {101, 102, 103}};
 
 		q.submit([=](handler& cgh) {
 			accessor large_celerity_acc{virtual_buf, cgh, celerity::access::fixed{large_accessor_sr}, celerity::read_write};
@@ -35,7 +35,7 @@ namespace detail {
 			if(!is_prepass_handler(cgh)) {
 				auto& bm = runtime::get_instance().get_buffer_manager();
 				auto info = buffer_manager_testspy::get_device_buffer<int, 3>(bm, get_buffer_id(virtual_buf));
-				subrange<3> backing_buffer_sr{info.offset, info.buffer.get_range()};
+				const subrange<3> backing_buffer_sr{info.offset, info.buffer.get_range()};
 
 				auto& large_sycl_acc = accessor_testspy::get_sycl_accessor(large_celerity_acc);
 				auto& small_sycl_acc = accessor_testspy::get_sycl_accessor(small_celerity_acc);
@@ -76,20 +76,20 @@ namespace detail {
 			tid = test_utils::add_compute_task<class get_access_with_tag>(
 			    tm,
 			    [&](handler& cgh) {
-				    accessor acc1{buf_a, cgh, one_to_one{}, celerity::write_only};
-				    static_assert(std::is_same_v<accessor<int, 1, access_mode::write, target::device>, decltype(acc1)>);
+				    const accessor acc1{buf_a, cgh, one_to_one{}, celerity::write_only};
+				    static_assert(std::is_same_v<accessor<int, 1, access_mode::write, target::device>, std::remove_cv_t<decltype(acc1)>>);
 
-				    accessor acc2{buf_a, cgh, one_to_one{}, celerity::read_only};
-				    static_assert(std::is_same_v<accessor<int, 1, access_mode::read, target::device>, decltype(acc2)>);
+				    const accessor acc2{buf_a, cgh, one_to_one{}, celerity::read_only};
+				    static_assert(std::is_same_v<accessor<int, 1, access_mode::read, target::device>, std::remove_cv_t<decltype(acc2)>>);
 
-				    accessor acc3{buf_a, cgh, one_to_one{}, celerity::read_write};
-				    static_assert(std::is_same_v<accessor<int, 1, access_mode::read_write, target::device>, decltype(acc3)>);
+				    const accessor acc3{buf_a, cgh, one_to_one{}, celerity::read_write};
+				    static_assert(std::is_same_v<accessor<int, 1, access_mode::read_write, target::device>, std::remove_cv_t<decltype(acc3)>>);
 
-				    accessor acc4{buf_a, cgh, one_to_one{}, celerity::write_only, celerity::no_init};
-				    static_assert(std::is_same_v<accessor<int, 1, access_mode::discard_write, target::device>, decltype(acc4)>);
+				    const accessor acc4{buf_a, cgh, one_to_one{}, celerity::write_only, celerity::no_init};
+				    static_assert(std::is_same_v<accessor<int, 1, access_mode::discard_write, target::device>, std::remove_cv_t<decltype(acc4)>>);
 
-				    accessor acc5{buf_a, cgh, one_to_one{}, celerity::read_write, celerity::no_init};
-				    static_assert(std::is_same_v<accessor<int, 1, access_mode::discard_read_write, target::device>, decltype(acc5)>);
+				    const accessor acc5{buf_a, cgh, one_to_one{}, celerity::read_write, celerity::no_init};
+				    static_assert(std::is_same_v<accessor<int, 1, access_mode::discard_read_write, target::device>, std::remove_cv_t<decltype(acc5)>>);
 			    },
 			    buf_a.get_range());
 		}
@@ -102,20 +102,20 @@ namespace detail {
 				//   celerity::no_init or nothing.
 				// accessor acc0{buf_a, cgh, one_to_one{}, cl::sycl::write_only_host_task, celerity::property_list{celerity::no_init}};
 
-				accessor acc1{buf_a, cgh, one_to_one{}, celerity::write_only_host_task};
-				static_assert(std::is_same_v<accessor<int, 1, access_mode::write, target::host_task>, decltype(acc1)>);
+				const accessor acc1{buf_a, cgh, one_to_one{}, celerity::write_only_host_task};
+				static_assert(std::is_same_v<accessor<int, 1, access_mode::write, target::host_task>, std::remove_cv_t<decltype(acc1)>>);
 
-				accessor acc2{buf_a, cgh, one_to_one{}, celerity::read_only_host_task};
-				static_assert(std::is_same_v<accessor<int, 1, access_mode::read, target::host_task>, decltype(acc2)>);
+				const accessor acc2{buf_a, cgh, one_to_one{}, celerity::read_only_host_task};
+				static_assert(std::is_same_v<accessor<int, 1, access_mode::read, target::host_task>, std::remove_cv_t<decltype(acc2)>>);
 
-				accessor acc3{buf_a, cgh, fixed<1>{{0, 1}}, celerity::read_write_host_task};
-				static_assert(std::is_same_v<accessor<int, 1, access_mode::read_write, target::host_task>, decltype(acc3)>);
+				const accessor acc3{buf_a, cgh, fixed<1>{{0, 1}}, celerity::read_write_host_task};
+				static_assert(std::is_same_v<accessor<int, 1, access_mode::read_write, target::host_task>, std::remove_cv_t<decltype(acc3)>>);
 
-				accessor acc4{buf_a, cgh, one_to_one{}, celerity::write_only_host_task, celerity::no_init};
-				static_assert(std::is_same_v<accessor<int, 1, access_mode::discard_write, target::host_task>, decltype(acc4)>);
+				const accessor acc4{buf_a, cgh, one_to_one{}, celerity::write_only_host_task, celerity::no_init};
+				static_assert(std::is_same_v<accessor<int, 1, access_mode::discard_write, target::host_task>, std::remove_cv_t<decltype(acc4)>>);
 
-				accessor acc5{buf_a, cgh, one_to_one{}, celerity::read_write_host_task, celerity::no_init};
-				static_assert(std::is_same_v<accessor<int, 1, access_mode::discard_read_write, target::host_task>, decltype(acc5)>);
+				const accessor acc5{buf_a, cgh, one_to_one{}, celerity::read_write_host_task, celerity::no_init};
+				static_assert(std::is_same_v<accessor<int, 1, access_mode::discard_read_write, target::host_task>, std::remove_cv_t<decltype(acc5)>>);
 			});
 		}
 
@@ -174,12 +174,12 @@ namespace detail {
 			auto acc = accessor_fixture<Dims>::template get_device_accessor<size_t, Dims, cl::sycl::access::mode::discard_write>(
 			    cgh, bid, range_cast<Dims>(range), {});
 			cgh.parallel_for<class kernel_multi_dim_accessor_read_<Dims>>(range_cast<Dims>(range), [=](celerity::item<Dims> item) {
-				size_t i = item[0];
-				size_t j = item[1];
+				const size_t i = item[0];
+				const size_t j = item[1];
 				if constexpr(Dims == 2) {
 					acc[i][j] = acc_read[i][j];
 				} else {
-					size_t k = item[2];
+					const size_t k = item[2];
 					acc[i][j][k] = acc_read[i][j][k];
 				}
 			});
@@ -203,9 +203,9 @@ namespace detail {
 			}
 		}
 
-		typename accessor_fixture<Dims>::access_target tgt = accessor_fixture<Dims>::access_target::host;
-		bool acc_check = accessor_fixture<Dims>::template buffer_reduce<size_t, Dims, class check_multi_dim_accessor<Dims>>(bid, tgt, range_cast<Dims>(range),
-		    {}, true,
+		const typename accessor_fixture<Dims>::access_target tgt = accessor_fixture<Dims>::access_target::host;
+		const bool acc_check = accessor_fixture<Dims>::template buffer_reduce<size_t, Dims, class check_multi_dim_accessor<Dims>>(bid, tgt,
+		    range_cast<Dims>(range), {}, true,
 		    [range = range_cast<Dims>(range)](cl::sycl::id<Dims> idx, bool current, size_t value) { return current && value == get_linear_index(range, idx); });
 
 		REQUIRE(acc_check);
@@ -284,7 +284,7 @@ namespace detail {
 		distr_queue q;
 		std::optional<buffer<int>> buf;
 
-		int init = 0;
+		const int init = 0;
 		SECTION("when the buffer is uninitialized") { buf = buffer<int>{1}; };
 		SECTION("when the buffer is host-initialized") { buf = buffer<int>{&init, 1}; };
 

--- a/test/benchmark_reporters.cc
+++ b/test/benchmark_reporters.cc
@@ -51,19 +51,19 @@ class benchmark_reporter_base : public Catch::StreamingReporterBase {
 	// TODO: Do we want to somehow report this?
 	void benchmarkFailed(Catch::StringRef benchmark_name) override { StreamingReporterBase::benchmarkFailed(benchmark_name); }
 
-	void sectionStarting(Catch::SectionInfo const& section_info) override {
+	void sectionStarting(const Catch::SectionInfo& section_info) override {
 		StreamingReporterBase::sectionStarting(section_info);
 		// Each test case has an implicit section with the name of the test case itself,
 		// so there is no need to capture that separately.
 		m_active_sections.push_back(section_info.name);
 	}
 
-	void testCasePartialEnded(Catch::TestCaseStats const& test_case_stats, uint64_t part_number) override {
+	void testCasePartialEnded(const Catch::TestCaseStats& test_case_stats, uint64_t part_number) override {
 		StreamingReporterBase::testCasePartialEnded(test_case_stats, part_number);
 		m_active_sections.clear();
 	}
 
-	void testRunEnded(Catch::TestRunStats const& test_run_stats) override {
+	void testRunEnded(const Catch::TestRunStats& test_run_stats) override {
 		StreamingReporterBase::testRunEnded(test_run_stats);
 		bool warning_printed = false;
 		for(auto it = m_test_case_benchmark_combinations.cbegin(); it != m_test_case_benchmark_combinations.cend(); ++it) {
@@ -104,12 +104,12 @@ class benchmark_csv_reporter : public benchmark_reporter_base {
 
 	static std::string getDescription() { return "Reporter for benchmarks in CSV format"; } // NOLINT(readability-identifier-naming)
 
-	void testRunStarting(Catch::TestRunInfo const& test_run_info) override {
+	void testRunStarting(const Catch::TestRunInfo& test_run_info) override {
 		benchmark_reporter_base::testRunStarting(test_run_info);
 		fmt::print(m_stream, "test case,benchmark name,samples,iterations,estimated,mean,low mean,high mean,std dev,low std dev,high std dev,raw\n");
 	}
 
-	void benchmarkEnded(Catch::BenchmarkStats<> const& benchmark_stats) override {
+	void benchmarkEnded(const Catch::BenchmarkStats<>& benchmark_stats) override {
 		benchmark_reporter_base::benchmarkEnded(benchmark_stats);
 		auto& info = benchmark_stats.info;
 		fmt::print(m_stream, "{},{},{},{},{},", escape_csv(get_test_case_name()), escape_csv(info.name), info.samples, info.iterations, info.estimatedDuration);
@@ -199,7 +199,7 @@ class benchmark_md_reporter : public benchmark_reporter_base {
 
 	static std::string getDescription() { return "Generates a Markdown report for benchmark results"; } // NOLINT(readability-identifier-naming)
 
-	void testRunStarting(Catch::TestRunInfo const& test_run_info) override {
+	void testRunStarting(const Catch::TestRunInfo& test_run_info) override {
 		benchmark_reporter_base::testRunStarting(test_run_info);
 
 		fmt::print(m_stream, "# Benchmark Results\n\n");
@@ -212,14 +212,14 @@ class benchmark_md_reporter : public benchmark_reporter_base {
 		meta_printer.print(m_stream);
 	}
 
-	void testRunEnded(Catch::TestRunStats const& test_run_stats) override {
+	void testRunEnded(const Catch::TestRunStats& test_run_stats) override {
 		benchmark_reporter_base::testRunEnded(test_run_stats);
 		fmt::print(m_stream, "\n\n");
 		m_results_printer.print(m_stream);
 		fmt::print(m_stream, "\nAll numbers are in nanoseconds.\n");
 	}
 
-	void benchmarkEnded(Catch::BenchmarkStats<> const& benchmark_stats) override {
+	void benchmarkEnded(const Catch::BenchmarkStats<>& benchmark_stats) override {
 		benchmark_reporter_base::benchmarkEnded(benchmark_stats);
 
 		const auto min = std::reduce(benchmark_stats.samples.cbegin(), benchmark_stats.samples.cend(),

--- a/test/benchmarks.cc
+++ b/test/benchmarks.cc
@@ -20,7 +20,7 @@ TEMPLATE_TEST_CASE_SIG("benchmark intrusive graph dependency handling with N nod
 	// existing nodes -- this is intentional; both cases are relevant in practise
 
 	BENCHMARK("creating nodes") {
-		bench_graph_node nodes[N];
+		const bench_graph_node nodes[N];
 		return nodes[N - 1].get_pseudo_critical_path_length(); // trick the compiler
 	};
 
@@ -376,7 +376,6 @@ template <typename BenchmarkContext>
 	step(up, u);
 
 	auto t = 0.0;
-	size_t i = 0;
 	while(t < T) {
 		step(up, u);
 		std::swap(u, up);

--- a/test/buffer_manager_test_utils.h
+++ b/test/buffer_manager_test_utils.h
@@ -8,7 +8,7 @@ namespace detail {
 	struct buffer_manager_testspy {
 		template <typename DataT, int Dims>
 		static buffer_manager::access_info<DataT, Dims, device_buffer> get_device_buffer(buffer_manager& bm, buffer_id bid) {
-			std::unique_lock lock(bm.m_mutex);
+			const std::unique_lock lock(bm.m_mutex);
 			auto& buf = bm.m_buffers.at(bid).device_buf;
 			return {dynamic_cast<device_buffer_storage<DataT, Dims>*>(buf.storage.get())->get_device_buffer(), id_cast<Dims>(buf.offset)};
 		}

--- a/test/device_selection_tests.cc
+++ b/test/device_selection_tests.cc
@@ -102,7 +102,7 @@ struct config_testspy {
 } // namespace celerity::detail
 
 TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prefers user specified device pointer", "[device-selection]") {
-	celerity::detail::config cfg(nullptr, nullptr);
+	const celerity::detail::config cfg(nullptr, nullptr);
 	mock_platform_factory mpf;
 
 	auto [mp] = mpf.create_platforms(std::nullopt);
@@ -114,7 +114,7 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prefers user sp
 
 TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
     "pick_device automatically selects a gpu device if available, otherwise falls back to the first device available", "[device-selection]") {
-	celerity::detail::config cfg(nullptr, nullptr);
+	const celerity::detail::config cfg(nullptr, nullptr);
 	mock_platform_factory mpf;
 
 	auto dv_type_1 = GENERATE(as<dt>(), dt::gpu, dt::accelerator, dt::cpu, dt::custom, dt::host);
@@ -144,7 +144,7 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device selects device 
 	mp_0.create_devices(dt::cpu, dt::gpu);
 	auto md = mp_1.create_devices(dt::gpu, dt::gpu, dt::cpu)[1];
 
-	celerity::detail::device_config d_cfg{1, 1};
+	const celerity::detail::device_config d_cfg{1, 1};
 	celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
 
 	auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1});
@@ -166,7 +166,7 @@ TEST_CASE_METHOD(
 		auto md = mp_1.create_devices(dt::gpu, dt::gpu, dt::gpu, dt::gpu)[local_rank];
 		mp_2.create_devices(dt::accelerator, dt::accelerator, dt::accelerator, dt::accelerator);
 
-		celerity::detail::host_config h_cfg{node_count, local_rank};
+		const celerity::detail::host_config h_cfg{node_count, local_rank};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
 		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1, mp_2});
@@ -184,7 +184,7 @@ TEST_CASE_METHOD(
 		mp_1.create_devices(dt::gpu, dt::gpu, dt::gpu);
 		auto md = mp_2.create_devices(dt::accelerator, dt::accelerator, dt::accelerator, dt::accelerator)[local_rank];
 
-		celerity::detail::host_config h_cfg{node_count, local_rank};
+		const celerity::detail::host_config h_cfg{node_count, local_rank};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
 		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1, mp_2});
@@ -202,7 +202,7 @@ TEST_CASE_METHOD(
 		const size_t node_count = 4;
 		const size_t local_rank = GENERATE(0, 3);
 
-		celerity::detail::host_config h_cfg{node_count, local_rank};
+		const celerity::detail::host_config h_cfg{node_count, local_rank};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
 		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1, mp_2});
@@ -219,7 +219,7 @@ TEST_CASE_METHOD(
 		const size_t node_count = 4;
 		const size_t local_rank = GENERATE(0, 3);
 
-		celerity::detail::host_config h_cfg{node_count, local_rank};
+		const celerity::detail::host_config h_cfg{node_count, local_rank};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
 		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1});
@@ -245,7 +245,7 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected
 		mp_0.create_devices(dt::cpu);
 		mp_1.create_devices(dt::gpu, type_and_name{dt::gpu, "My device"});
 
-		celerity::detail::device_config d_cfg{1, 1};
+		celerity::detail::device_config const d_cfg{1, 1};
 		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
 
 		celerity::test_utils::log_capture lc;
@@ -278,7 +278,7 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected
 		const size_t node_count = 4;
 		const size_t local_rank = 3;
 
-		celerity::detail::host_config h_cfg{node_count, local_rank};
+		const celerity::detail::host_config h_cfg{node_count, local_rank};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
 		celerity::test_utils::log_capture lc(spdlog::level::warn);
@@ -297,7 +297,7 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected
 		const size_t node_count = 4;
 		const size_t local_rank = 3;
 
-		celerity::detail::host_config h_cfg{node_count, local_rank};
+		const celerity::detail::host_config h_cfg{node_count, local_rank};
 		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
 		celerity::test_utils::log_capture lc(spdlog::level::warn);
@@ -312,7 +312,7 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected
 		mp_0.create_devices(dt::cpu);
 		mp_1.create_devices(dt::gpu, dt::gpu);
 
-		celerity::detail::device_config d_cfg{3, 0};
+		celerity::detail::device_config const d_cfg{3, 0};
 		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
 		CHECK_THROWS_WITH(pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1}),
 		    "Invalid platform id 3: Only 2 platforms available");
@@ -325,7 +325,7 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected
 		mp_0.create_devices(dt::cpu);
 		mp_1.create_devices(dt::gpu, dt::gpu);
 
-		celerity::detail::device_config d_cfg{1, 5};
+		celerity::detail::device_config const d_cfg{1, 5};
 		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
 
 		CHECK_THROWS_WITH(pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1}),
@@ -354,7 +354,7 @@ TEST_CASE_METHOD(celerity::test_utils::runtime_fixture, "pick_device supports pa
 
 	auto device_selector = [device](const sycl::device& d) -> int { return d == device ? 2 : 1; };
 
-	celerity::distr_queue q(device_selector);
+	const celerity::distr_queue q(device_selector);
 
 	auto& dq = celerity::detail::runtime::get_instance().get_device_queue();
 	CHECK(dq.get_sycl_queue().get_device() == device);
@@ -371,7 +371,7 @@ TEST_CASE("pick_device correctly selects according to device selector score", "[
 
 	auto device_selector = [md](const mock_device& d) -> int { return d == md ? 2 : 1; };
 
-	celerity::detail::config cfg(nullptr, nullptr);
+	const celerity::detail::config cfg(nullptr, nullptr);
 	auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{mp_0, mp_1, mp_2});
 	CHECK(device == md);
 }
@@ -389,7 +389,7 @@ TEST_CASE("pick_device selects a unique device for each local node according to 
 	const size_t node_count = 4;
 	const size_t local_rank = 3;
 
-	celerity::detail::host_config h_cfg{node_count, local_rank};
+	const celerity::detail::host_config h_cfg{node_count, local_rank};
 	celerity::detail::config cfg(nullptr, nullptr);
 	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
@@ -413,7 +413,7 @@ TEST_CASE("pick_device selects the highest scoring device for all nodes if an in
 	const size_t node_count = 4;
 	const size_t local_rank = 3;
 
-	celerity::detail::host_config h_cfg{node_count, local_rank};
+	const celerity::detail::host_config h_cfg{node_count, local_rank};
 	celerity::detail::config cfg(nullptr, nullptr);
 	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 	auto device_selector = [md](const mock_device& d) -> int { return d == md ? 2 : 1; };
@@ -436,7 +436,7 @@ TEST_CASE("pick_device warns when highest scoring devices span multiple platform
 	const size_t node_count = 4;
 	const size_t local_rank = GENERATE(0, 3);
 
-	celerity::detail::host_config h_cfg{node_count, local_rank};
+	const celerity::detail::host_config h_cfg{node_count, local_rank};
 	celerity::detail::config cfg(nullptr, nullptr);
 	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
@@ -465,7 +465,7 @@ TEST_CASE("pick_device warns when highest scoring devices are of different types
 	const size_t node_count = 4;
 	const size_t local_rank = 0;
 
-	celerity::detail::host_config h_cfg{node_count, local_rank};
+	const celerity::detail::host_config h_cfg{node_count, local_rank};
 	celerity::detail::config cfg(nullptr, nullptr);
 	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
@@ -490,7 +490,7 @@ TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device does not consid
 	const size_t node_count = 4;
 	const size_t local_rank = 2;
 
-	celerity::detail::host_config h_cfg{node_count, local_rank};
+	const celerity::detail::host_config h_cfg{node_count, local_rank};
 	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
 
 	auto device_selector = [](const mock_device& d) -> int { return d.get_type() == dt::accelerator ? 1 : -1; };

--- a/test/graph_gen_reduction_tests.cc
+++ b/test/graph_gen_reduction_tests.cc
@@ -17,7 +17,7 @@ namespace detail {
 
 	TEST_CASE("graph_generator generates reduction command trees", "[graph_generator][command-graph][reductions]") {
 		using namespace cl::sycl::access;
-		size_t num_nodes = 2;
+		const size_t num_nodes = 2;
 		test_utils::cdag_test_context ctx(num_nodes);
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
@@ -105,7 +105,7 @@ namespace detail {
 
 	TEST_CASE("single-node configurations do not generate reduction commands", "[graph_generator][command-graph][reductions]") {
 		using namespace cl::sycl::access;
-		size_t num_nodes = 1;
+		const size_t num_nodes = 1;
 		test_utils::cdag_test_context ctx(num_nodes);
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
@@ -134,7 +134,7 @@ namespace detail {
 	    "discarding the reduction result from a execution_command will not generate a reduction command", "[graph_generator][command-graph][reductions]") {
 		using namespace cl::sycl::access;
 
-		size_t num_nodes = 2;
+		const size_t num_nodes = 2;
 		test_utils::cdag_test_context ctx(num_nodes);
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
@@ -158,7 +158,7 @@ namespace detail {
 	TEST_CASE("graph_generator does not generate multiple reduction commands for redundant requirements", "[graph_generator][command-graph][reductions]") {
 		using namespace cl::sycl::access;
 
-		size_t num_nodes = 4;
+		const size_t num_nodes = 4;
 		test_utils::cdag_test_context ctx(num_nodes);
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
@@ -185,7 +185,7 @@ namespace detail {
 	TEST_CASE("graph_generator does not generate unnecessary anti-dependencies around reduction commands", "[graph_generator][command-graph][reductions]") {
 		using namespace cl::sycl::access;
 
-		size_t num_nodes = 2;
+		const size_t num_nodes = 2;
 		test_utils::cdag_test_context ctx(num_nodes);
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
@@ -215,7 +215,7 @@ namespace detail {
 	TEST_CASE("graph_generator designates a reduction initializer command that does not require transfers", "[graph_generator][command-graph][reductions]") {
 		using namespace cl::sycl::access;
 
-		size_t num_nodes = 2;
+		const size_t num_nodes = 2;
 		test_utils::cdag_test_context ctx(num_nodes);
 		auto& tm = ctx.get_task_manager();
 		auto& ggen = ctx.get_graph_generator();
@@ -250,7 +250,7 @@ namespace detail {
 	TEST_CASE("commands overwriting a buffer generate anti-dependencies on preceding reduction pushes", "[graph_generator][command-graph][reductions]") {
 		// regression test - this reproduces the essence of distr_tests "multiple chained reductions produce correct results"
 
-		size_t num_nodes = 2;
+		const size_t num_nodes = 2;
 		test_utils::cdag_test_context ctx(num_nodes);
 		auto& tm = ctx.get_task_manager();
 		test_utils::mock_buffer_factory mbf(ctx);

--- a/test/graph_generation_tests.cc
+++ b/test/graph_generation_tests.cc
@@ -520,7 +520,7 @@ namespace detail {
 			    depender, dependency, [](auto depender_cmd, auto dependency_cmd) { return !depender_cmd->has_dependency(dependency_cmd); });
 		};
 
-		experimental::collective_group group;
+		const experimental::collective_group group;
 		auto tid_master = test_utils::build_and_flush(ctx, 2, test_utils::add_host_task(ctx.get_task_manager(), on_master_node, [&](handler&) {}));
 		auto tid_collective_implicit_1 =
 		    test_utils::build_and_flush(ctx, 2, test_utils::add_host_task(ctx.get_task_manager(), experimental::collective, [&](handler&) {}));

--- a/test/print_graph_tests.cc
+++ b/test/print_graph_tests.cc
@@ -52,7 +52,7 @@ TEST_CASE("task-graph printing is unchanged", "[print_graph][task-graph]") {
 }
 
 TEST_CASE("command graph printing is unchanged", "[print_graph][command-graph]") {
-	size_t num_nodes = 4;
+	const size_t num_nodes = 4;
 	test_utils::cdag_test_context ctx(num_nodes);
 	auto& tm = ctx.get_task_manager();
 	auto& ggen = ctx.get_graph_generator();
@@ -101,7 +101,7 @@ TEST_CASE("command graph printing is unchanged", "[print_graph][command-graph]")
 
 TEST_CASE_METHOD(test_utils::runtime_fixture, "Buffer debug names show up in the generated graph", "[print_graph][buffer_names]") {
 	distr_queue q;
-	celerity::range<1> range(16);
+	const celerity::range<1> range(16);
 	celerity::buffer<int, 1> buff_a(range);
 	std::string buff_name{"my_buffer"};
 	celerity::debug::set_buffer_name(buff_a, buff_name);
@@ -109,7 +109,7 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "Buffer debug names show up in the
 
 	q.submit([=](handler& cgh) {
 		celerity::accessor acc{buff_a, cgh, celerity::access::all{}, celerity::write_only};
-		cgh.parallel_for<class UKN(print_graph_buffer_name)>(range, [=](item<1> item) {});
+		cgh.parallel_for<class UKN(print_graph_buffer_name)>(range, [=](item<1>) { (void)acc; });
 	});
 
 	// wait for commands to be generated in the scheduler thread

--- a/test/runtime_deprecation_tests.cc
+++ b/test/runtime_deprecation_tests.cc
@@ -53,7 +53,7 @@ namespace detail {
 	TEST_CASE_METHOD(test_utils::buffer_manager_fixture, "device accessor supports atomic access", "[accessor][deprecated]") {
 		auto& bm = get_buffer_manager();
 		auto& dq = get_device_queue();
-		int host_data = 0;
+		const int host_data = 0;
 		auto bid = bm.register_buffer<int, 1>(cl::sycl::range<3>(1, 1, 1), &host_data);
 
 		auto range = cl::sycl::range<1>(2048);
@@ -61,7 +61,7 @@ namespace detail {
 		live_pass_device_handler cgh(nullptr, sr, true, dq);
 
 		auto device_acc = get_device_accessor<int, 1, cl::sycl::access::mode::atomic>(cgh, bid, {1}, {0});
-		cgh.parallel_for<class UKN(atomic_increment)>(range, [=](cl::sycl::id<1> id) { device_acc[0].fetch_add(2); });
+		cgh.parallel_for<class UKN(atomic_increment)>(range, [=](cl::sycl::id<1> /*id*/) { device_acc[0].fetch_add(2); });
 		cgh.get_submission_event().wait();
 
 		auto host_acc = get_host_accessor<int, 1, cl::sycl::access::mode::read>(bid, {1}, {0});

--- a/test/sycl_tests.cc
+++ b/test/sycl_tests.cc
@@ -81,7 +81,7 @@ constexpr auto sycl_target_device = cl::sycl::access::target::device;
 template <access_mode AccessMode, bool UsingPlaceholderAccessor>
 static auto make_device_accessor(sycl::buffer<int, 1>& buf, sycl::handler& cgh, const subrange<1>& sr) {
 	if constexpr(UsingPlaceholderAccessor) {
-		sycl::accessor<int, 1, AccessMode, sycl_target_device, sycl::access::placeholder::true_t> acc{buf, sr.range, sr.offset};
+		const sycl::accessor<int, 1, AccessMode, sycl_target_device, sycl::access::placeholder::true_t> acc{buf, sr.range, sr.offset};
 		cgh.require(acc);
 		return acc;
 	} else {
@@ -104,7 +104,7 @@ static void test_access(sycl::queue& q, sycl::buffer<int, 1>& test_buf, const su
 		 });
 	 }).wait_and_throw();
 
-	sycl::host_accessor verify_acc{verify_buf};
+	sycl::host_accessor const verify_acc{verify_buf};
 	CHECK(verify_acc[0]);
 };
 

--- a/test/system/distr_tests.cc
+++ b/test/system/distr_tests.cc
@@ -231,7 +231,7 @@ namespace detail {
 					{
 						size_t relative = global_linear_id;
 						for(int nd = 0; nd < Dims; ++nd) {
-							int d = Dims - 1 - nd;
+							int const d = Dims - 1 - nd;
 							global_id[d] = relative % global_range[d];
 							relative /= global_range[d];
 						}
@@ -269,29 +269,32 @@ namespace detail {
 		buffer<int, 1> buff_a(cl::sycl::range<1>{1});
 		q.submit([=](handler& cgh) {
 			accessor write_a{buff_a, cgh, celerity::access::all{}, celerity::write_only, celerity::no_init};
-			cgh.parallel_for<class UKN(write_a)>(cl::sycl::range<1>{N}, [=](celerity::item<1> item) {});
+			cgh.parallel_for<class UKN(write_a)>(cl::sycl::range<1>{N}, [=](celerity::item<1>) { (void)write_a; });
 		});
 
 		buffer<int, 1> buff_b(cl::sycl::range<1>{1});
 		q.submit([=](handler& cgh) {
 			accessor write_b{buff_b, cgh, celerity::access::all{}, celerity::write_only, celerity::no_init};
-			cgh.parallel_for<class UKN(write_b)>(cl::sycl::range<1>{N}, [=](celerity::item<1> item) {});
+			cgh.parallel_for<class UKN(write_b)>(cl::sycl::range<1>{N}, [=](celerity::item<1>) { (void)write_b; });
 		});
 
 		q.submit([=](handler& cgh) {
 			accessor read_write_a{buff_a, cgh, celerity::access::all{}, celerity::read_write};
-			cgh.parallel_for<class UKN(read_write_a)>(cl::sycl::range<1>{N}, [=](celerity::item<1> item) {});
+			cgh.parallel_for<class UKN(read_write_a)>(cl::sycl::range<1>{N}, [=](celerity::item<1>) { (void)read_write_a; });
 		});
 
 		q.submit([=](handler& cgh) {
 			accessor read_write_a{buff_a, cgh, celerity::access::all{}, celerity::read_write};
 			accessor read_write_b{buff_b, cgh, celerity::access::all{}, celerity::read_write};
-			cgh.parallel_for<class UKN(read_write_a_b)>(cl::sycl::range<1>{N}, [=](celerity::item<1> item) {});
+			cgh.parallel_for<class UKN(read_write_a_b)>(cl::sycl::range<1>{N}, [=](celerity::item<1>) {
+				(void)read_write_a;
+				(void)read_write_b;
+			});
 		});
 
 		q.submit([=](handler& cgh) {
 			accessor write_a{buff_a, cgh, celerity::access::all{}, celerity::write_only, celerity::no_init};
-			cgh.parallel_for<class UKN(write_a_again)>(cl::sycl::range<1>{N}, [=](celerity::item<1> item) {});
+			cgh.parallel_for<class UKN(write_a_again)>(cl::sycl::range<1>{N}, [=](celerity::item<1>) { (void)write_a; });
 		});
 
 		q.slow_full_sync();

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -249,7 +249,7 @@ namespace detail {
 
 	TEST_CASE("task_manager generates pseudo-dependencies for collective host tasks", "[task_manager][task-graph]") {
 		task_manager tm{1, nullptr};
-		experimental::collective_group group;
+		const experimental::collective_group group;
 		auto tid_master = test_utils::add_host_task(tm, on_master_node, [](handler&) {});
 		auto tid_collective_implicit_1 = test_utils::add_host_task(tm, experimental::collective, [](handler&) {});
 		auto tid_collective_implicit_2 = test_utils::add_host_task(tm, experimental::collective, [](handler&) {});
@@ -384,17 +384,17 @@ namespace detail {
 		auto buf_a = mbf.create_buffer(cl::sycl::range<1>(128));
 		auto buf_b = mbf.create_buffer(cl::sycl::range<1>(128));
 
-		task_id tid_1 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
+		const task_id tid_1 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
 			buf_a.get_access<access_mode::discard_write>(cgh, fixed<1>({0, 64}));
 			buf_b.get_access<access_mode::discard_write>(cgh, fixed<1>({0, 128}));
 		});
-		task_id tid_2 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
+		const task_id tid_2 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
 			buf_a.get_access<access_mode::discard_write>(cgh, fixed<1>({64, 64}));
 		});
-		task_id tid_3 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
+		const task_id tid_3 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
 			buf_a.get_access<access_mode::read_write>(cgh, fixed<1>({32, 64}));
 		});
-		task_id tid_4 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
+		const task_id tid_4 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
 			buf_a.get_access<access_mode::read_write>(cgh, fixed<1>({32, 64}));
 		});
 
@@ -402,10 +402,10 @@ namespace detail {
 		CHECK(task_manager_testspy::get_num_horizons(tm) == 1);
 		CHECK(horizon.has_value());
 
-		task_id tid_6 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
+		const task_id tid_6 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
 			buf_b.get_access<access_mode::read_write>(cgh, fixed<1>({0, 128}));
 		});
-		task_id tid_7 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
+		const task_id tid_7 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
 			buf_b.get_access<access_mode::read_write>(cgh, fixed<1>({0, 128}));
 		});
 
@@ -417,7 +417,7 @@ namespace detail {
 			CHECK(region_map_a.get_region_values(make_region(32, 96)).front().second.value() == tid_4);
 		}
 
-		task_id tid_8 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
+		const task_id tid_8 = test_utils::add_host_task(tm, on_master_node, [&](handler& cgh) {
 			buf_b.get_access<access_mode::read_write>(cgh, fixed<1>({0, 128}));
 		});
 

--- a/test/task_ring_buffer_tests.cc
+++ b/test/task_ring_buffer_tests.cc
@@ -27,6 +27,7 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "freeing task ring buffer capacity
 		q.submit(celerity::allow_by_ref, [=, &reached_ringbuffer_capacity](celerity::handler& cgh) {
 			celerity::accessor acc{dependency, cgh, celerity::access::all{}, celerity::read_write_host_task};
 			cgh.host_task(celerity::on_master_node, [=, &reached_ringbuffer_capacity] {
+				(void)acc;
 				while(!reached_ringbuffer_capacity.load())
 					; // we wait in all tasks so that we can make sure to fill the ring buffer completely
 					  // and therefore test that execution re-starts correctly once an epoch is reached

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -27,6 +27,11 @@
 #include "transformers/naive_split.h"
 #include "types.h"
 
+// Clang-tidy doesn't like that Catch2's RAII helper for scoped INFO messages isn't qualified as `const`.
+// TODO: Fix in Catch2
+#undef INFO
+#define INFO(msg) const INTERNAL_CATCH_INFO("INFO", msg)
+
 // To avoid having to come up with tons of unique kernel names, we simply use the CPP counter.
 // This is non-standard but widely supported.
 #define _UKN_CONCAT2(x, y) x##_##y


### PR DESCRIPTION
So far we've used clang-tidy only to enforce naming conventions. This PR enables a whole set of additional checks as suggested in #127.

Notably this includes [`misc-const-correctness`](https://clang.llvm.org/extra/clang-tidy/checks/misc/const-correctness.html), a check that was recently added in clang-tidy 15. While we don't yet use clang-tidy 15 in CI, this patch includes a (semi-automatic) fixup pass that was done for all const-correctness violations found through that check. Unfortunately the check seems to be a little buggy still (producing false positives in certain situations) which is why I've decided to not turn it into an error for now.

Here's a summary of the remaining clang-tidy warnings we produce with the set of checks enabled in this patch:
```
Found 465 diagnostics (out of 2880 parsed; 2415 were duplicates).
   96: readability-qualified-auto
   51: readability-function-cognitive-complexity
   46: bugprone-unchecked-optional-access
   33: cppcoreguidelines-special-member-functions
   21: cppcoreguidelines-init-variables
   18: readability-implicit-bool-conversion
   16: bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions
   16: readability-named-parameter
   15: performance-unnecessary-value-param
   14: cppcoreguidelines-avoid-non-const-global-variables
   13: cppcoreguidelines-pro-bounds-constant-array-index
   12: clang-analyzer-deadcode.DeadStores
   12: cppcoreguidelines-pro-bounds-array-to-pointer-decay
   11: readability-isolate-declaration
   10: cppcoreguidelines-pro-type-member-init
    9: cppcoreguidelines-pro-type-static-cast-downcast
    8: bugprone-exception-escape
    6: cppcoreguidelines-pro-type-vararg
    6: readability-else-after-return
    6: cppcoreguidelines-non-private-member-variables-in-classes
    5: cppcoreguidelines-pro-type-reinterpret-cast
    4: readability-redundant-access-specifiers
    3: performance-faster-string-find
    3: cppcoreguidelines-pro-type-const-cast
    3: cppcoreguidelines-owning-memory
    3: clang-diagnostic-error
    2: bugprone-implicit-widening-of-multiplication-result
    2: bugprone-reserved-identifier
    2: readability-inconsistent-declaration-parameter-name
    2: misc-const-correctness
    2: readability-static-accessed-through-instance
    2: performance-noexcept-move-constructor
    2: clang-analyzer-optin.mpi.MPI-Checker
    2: cppcoreguidelines-prefer-member-initializer
    2: readability-convert-member-functions-to-static
    1: readability-redundant-smartptr-get
    1: readability-suspicious-call-argument
    1: clang-analyzer-core.NonNullParamChecker
    1: performance-move-const-arg
    1: performance-for-range-copy
    1: clang-analyzer-core.CallAndMessage
    1: readability-make-member-function-const
```

Remember that our CI setup only runs checks on diffs, so I think it is reasonable to address these whenever we touch those respective parts of the code.

Resolves #127.