### PR TITLE
Update DPC++ to the newest compatible version

### DIFF
--- a/.github/workflows/build_matrix.json
+++ b/.github/workflows/build_matrix.json
@@ -9,7 +9,7 @@
         { "sycl": "computecpp", "sycl-version": "2.10.0", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
         { "sycl": "computecpp", "sycl-version": "2.10.0-experimental", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "computecpp", "sycl-version": "2.10.0-experimental", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
-        { "sycl": "dpcpp", "sycl-version": "7735139b", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
+        { "sycl": "dpcpp", "sycl-version": "3fd08509", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
         { "sycl": "hipsycl", "sycl-version": "7b00e2ef", "ubuntu-version": "20.04", "platform": "nvidia", "build-type": "Debug" },

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,8 +248,8 @@ target_include_directories(celerity_runtime PUBLIC
 # because they are not ABI compatible.
 if(WIN32 AND CELERITY_SYCL_IMPL STREQUAL "DPC++")
   set(SYCL_LIB
-    $<$<CONFIG:Debug>:sycld>
-    $<$<CONFIG:Release>:sycl>
+    $<$<CONFIG:Debug>:sycl6d>
+    $<$<CONFIG:Release>:sycl6>
   )
 endif()
 

--- a/cmake/AddToTarget.cmake
+++ b/cmake/AddToTarget.cmake
@@ -8,8 +8,14 @@ if(CELERITY_SYCL_IMPL STREQUAL "DPC++")
         "${one_value_args}"
         "${multi_value_args}"
         ${ARGN}
-        )
-    set(DPCPP_FLAGS "-fsycl;-sycl-std=2020;-fsycl-targets=${CELERITY_DPCPP_TARGETS};-DCELERITY_DPCPP=1;${DPCPP_FLAGS}")
+    )
+    list(PREPEND DPCPP_FLAGS
+      -fsycl
+      -sycl-std=2020
+      "-fsycl-targets=${CELERITY_DPCPP_TARGETS}"
+      -DCELERITY_DPCPP=1
+      -Wno-sycl-strict  # -Wsycl-strict produces false-positive warnings in DPC++'s own SYCL headers as of 2022-10-06
+    )
     target_compile_options(${ADD_SYCL_TARGET} PUBLIC ${DPCPP_FLAGS})
     target_link_options(${ADD_SYCL_TARGET} PUBLIC ${DPCPP_FLAGS})
   endfunction()

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -15,8 +15,9 @@ The most recent version of Celerity aims to support the following environments:
   * or on CPUs via OpenMP
 * ComputeCpp ≥ version 2.6.0
   * on Intel hardware
-  * with [stable](https://developer.codeplay.com/products/computecpp/ce/download) and [experimental](https://developer.codeplay.com/products/computecpp/ce/download?experimental=true) compilers
-* DPC++ ≥ revision [`7735139b`](https://github.com/intel/llvm/commit/7735139b)
+  * with [stable](https://developer.codeplay.com/products/computecpp/ce/download)
+    and [experimental](https://developer.codeplay.com/products/computecpp/ce/download?experimental=true) compilers
+* DPC++ ≥ revision [`3fd08509`](https://github.com/intel/llvm/commit/3fd08509)
   * on Intel hardware
 
 ## Continuously Tested Configurations
@@ -30,7 +31,7 @@ Those are:
 | ComputeCpp | 2.6.0, 2.7.0, 2.8.0, 2.9.0 (stable)                                            | Ubuntu 20.04 | Debug          |
 | ComputeCpp | 2.10.0 (stable)                                                                | Ubuntu 22.04 | Debug, Release |
 | ComputeCpp | 2.10.0 (experimental compiler)                                                 | Ubuntu 22.04 | Debug, Release |
-| DPC++      | [`7735139b`](https://github.com/intel/llvm/commit/7735139b)                    | Ubuntu 20.04 | Debug          |
+| DPC++      | [`3fd08509`](https://github.com/intel/llvm/commit/3fd08509)                    | Ubuntu 20.04 | Debug          |
 | DPC++      | [`HEAD`](https://github.com/intel/llvm/)                                       | Ubuntu 22.04 | Debug, Release |
 | hipSYCL    | [`7b00e2ef`](https://github.com/illuhad/hipSYCL/commit/7b00e2ef) (CUDA 11.0.3) | Ubuntu 20.04 | Debug          |
 | hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (CUDA 11.7.0)                     | Ubuntu 22.04 | Debug, Release |

--- a/include/accessor.h
+++ b/include/accessor.h
@@ -283,12 +283,9 @@ class accessor<DataT, Dims, Mode, target::device> : public detail::accessor_base
 	friend bool operator!=(const accessor& lhs, const accessor& rhs) { return !(lhs == rhs); }
 
   private:
-#if CELERITY_WORKAROUND(DPCPP) || CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 7)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations" // target::gobal_buffer is now target::device, but only for very recent versions of DPC++
+#if CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 7)
 	using sycl_accessor_t = cl::sycl::accessor<DataT, Dims, Mode, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::true_t>;
-#pragma GCC diagnostic pop
-#elif CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 9)
+#elif CELERITY_WORKAROUND(DPCPP) || CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 9)
 	using sycl_accessor_t = cl::sycl::accessor<DataT, Dims, Mode, cl::sycl::access::target::device, cl::sycl::access::placeholder::true_t>;
 #else
 	using sycl_accessor_t = cl::sycl::accessor<DataT, Dims, Mode, cl::sycl::target::device>;
@@ -582,7 +579,7 @@ class accessor<DataT, Dims, Mode, target::host_task> : public detail::accessor_b
 template <typename DataT, int Dims = 1>
 class local_accessor {
   private:
-#if CELERITY_WORKAROUND(DPCPP) || CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 6)
+#if CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 6)
 	using sycl_accessor = cl::sycl::accessor<DataT, Dims, cl::sycl::access::mode::read_write, cl::sycl::access::target::local>;
 #else
 	using sycl_accessor = cl::sycl::local_accessor<DataT, Dims>;

--- a/include/item.h
+++ b/include/item.h
@@ -225,9 +225,7 @@ class nd_item {
 
 	size_t get_group_range(int dimension) const { return m_group_range[dimension]; }
 
-#if !CELERITY_WORKAROUND(DPCPP) // no sub_group support
 	cl::sycl::sub_group get_sub_group() const { return m_sycl_item.get_sub_group(); }
-#endif
 
 	range<Dims> get_global_range() const { return m_global_range; }
 

--- a/test/device_selection_tests.cc
+++ b/test/device_selection_tests.cc
@@ -28,11 +28,19 @@ struct mock_device {
 		return *m_platform;
 	}
 
+#if CELERITY_WORKAROUND(HIPSYCL) || CELERITY_WORKAROUND(COMPUTECPP) // old API: device enum
 	template <sycl::info::device Param>
 	auto get_info() const {
 		if constexpr(Param == sycl::info::device::name) { return m_name; }
 		if constexpr(Param == sycl::info::device::device_type) { return m_type; }
 	}
+#else // new API: device tag type
+	template <typename Param>
+	auto get_info() const {
+		if constexpr(std::is_same_v<Param, sycl::info::device::name>) { return m_name; }
+		if constexpr(std::is_same_v<Param, sycl::info::device::device_type>) { return m_type; }
+	}
+#endif
 
 	dt get_type() const { return m_type; }
 
@@ -77,7 +85,11 @@ struct mock_platform {
 		return m_devices;
 	}
 
+#if CELERITY_WORKAROUND(HIPSYCL) || CELERITY_WORKAROUND(COMPUTECPP) // old API: platform enum
 	template <sycl::info::platform Param>
+#else // new API: platform tag type
+	template <typename Param>
+#endif
 	std::string get_info() const {
 		return m_name;
 	}

--- a/test/sycl_tests.cc
+++ b/test/sycl_tests.cc
@@ -69,11 +69,8 @@ TEMPLATE_TEST_CASE_METHOD_SIG(dim_device_queue_fixture, "ranged_sycl_access work
 template <access_mode, bool>
 class access_test_kernel;
 
-#if CELERITY_WORKAROUND(DPCPP) || CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 7)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations" // target::gobal_buffer is now target::device, but only for very recent versions of DPC++
+#if CELERITY_WORKAROUND_LESS_OR_EQUAL(COMPUTECPP, 2, 7)
 constexpr auto sycl_target_device = cl::sycl::access::target::global_buffer;
-#pragma GCC diagnostic pop
 #else
 constexpr auto sycl_target_device = cl::sycl::access::target::device;
 #endif


### PR DESCRIPTION
After being stuck on [a bug](https://github.com/celerity/celerity-runtime/actions/runs/2924269790/jobs/4663659961) for some time, recent versions of DPC++ are compatible with Celerity again. This PR bumps the minimum required version to a commit from the beginning of October and adjusts the necessary workarounds. This also enables subgroup support in Celerity when compiling against DPC++.

The CI temporarily targets `dpcpp:HEAD` to show compatibility. I willl re-tag `latest` and revert this as soon as the PR is accepted.
