### PR TITLE
Enable data transfers larger than 2 GiB

### DIFF
--- a/include/buffer_transfer_manager.h
+++ b/include/buffer_transfer_manager.h
@@ -24,6 +24,8 @@ namespace detail {
 			bool complete = false;
 		};
 
+		buffer_transfer_manager();
+
 		std::shared_ptr<const transfer_handle> push(const command_pkg& pkg);
 		std::shared_ptr<const transfer_handle> await_push(const command_pkg& pkg);
 
@@ -74,6 +76,8 @@ namespace detail {
 		//  - Incoming pushes that have not yet been requested through ::await_push
 		//  - Still outstanding pushes that have been requested through ::await_push
 		std::unordered_map<command_id, std::shared_ptr<incoming_transfer_handle>> m_push_blackboard;
+
+		mpi_support::data_type m_send_recv_unit;
 
 		void poll_incoming_transfers();
 		void update_incoming_transfers();

--- a/include/command.h
+++ b/include/command.h
@@ -223,8 +223,7 @@ namespace detail {
 		using payload_type = command_id;
 
 		command_pkg pkg;
-		size_t num_dependencies = 0; // This information is duplicated from unique_frame_ptr::get_payload_count() so that we can still use a
-		                             // `const command_frame &` without its owning pointer
+		size_t num_dependencies = 0;
 		payload_type dependencies[];
 
 		// variable-sized structure

--- a/include/frame.h
+++ b/include/frame.h
@@ -59,7 +59,6 @@ class unique_frame_ptr : private std::unique_ptr<Frame, unique_frame_delete<Fram
 	Frame* get_pointer() { return impl::get(); }
 	const Frame* get_pointer() const { return impl::get(); }
 	size_t get_size_bytes() const { return m_size_bytes; }
-	size_t get_payload_count() const { return (m_size_bytes - sizeof(Frame)) / sizeof(payload_type); }
 
 	using impl::operator bool;
 	using impl::operator*;

--- a/include/mpi_support.h
+++ b/include/mpi_support.h
@@ -1,9 +1,24 @@
 #pragma once
 
+#include <mpi.h>
+
 namespace celerity::detail::mpi_support {
 
 constexpr int TAG_CMD = 0;
 constexpr int TAG_DATA_TRANSFER = 1;
 constexpr int TAG_TELEMETRY = 2;
+
+class data_type {
+  public:
+	explicit data_type(MPI_Datatype dt) : m_dt(dt) {}
+	data_type(const data_type&) = delete;
+	data_type& operator=(const data_type&) = delete;
+	~data_type() { MPI_Type_free(&m_dt); }
+
+	operator MPI_Datatype() const { return m_dt; }
+
+  private:
+	MPI_Datatype m_dt;
+};
 
 } // namespace celerity::detail::mpi_support

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -117,7 +117,6 @@ namespace detail {
 				MPI_Get_count(&status, MPI_BYTE, &frame_bytes);
 				unique_frame_ptr<command_frame> frame(from_size_bytes, static_cast<size_t>(frame_bytes));
 				MPI_Mrecv(frame.get_pointer(), frame_bytes, MPI_BYTE, &msg, &status);
-				assert(frame->num_dependencies == frame.get_payload_count());
 				command_queue.push(std::move(frame));
 
 				if(!m_first_command_received) {


### PR DESCRIPTION
Currently, buffer data transfers are limited to 2 GiB by the `MPI_Isend`/`Irecv` API that takes 32-bit signed integer element counts. This PR increases the limit to 128GiB by transferring data as arrays of a 64-byte custom MPI type.

Since the receiver side cannot recover the byte-exact frame size, we also have to drop `unique_frame_ptr::get_payload_count()`, which was fortunately only used in one assertion.