### PR TITLE
Fix: Allocate memory for data frame padding

### DIFF
--- a/src/buffer_transfer_manager.cc
+++ b/src/buffer_transfer_manager.cc
@@ -34,14 +34,15 @@ namespace detail {
 		auto& bm = runtime::get_instance().get_buffer_manager();
 		const auto element_size = bm.get_buffer_info(data.bid).element_size;
 
-		unique_frame_ptr<data_frame> frame(from_payload_count, data.sr.range.size() * element_size);
+		unique_frame_ptr<data_frame> frame(from_payload_count, data.sr.range.size() * element_size, /* packet_size_bytes */ send_recv_unit_bytes);
 		frame->sr = data.sr;
 		frame->bid = data.bid;
 		frame->rid = data.rid;
 		frame->push_cid = pkg.cid;
 		bm.get_buffer_data(data.bid, data.sr, frame->data);
 
-		size_t frame_units = (frame.get_size_bytes() + send_recv_unit_bytes - 1) / send_recv_unit_bytes;
+		assert(frame.get_size_bytes() % send_recv_unit_bytes == 0);
+		const size_t frame_units = frame.get_size_bytes() / send_recv_unit_bytes;
 		CELERITY_TRACE("Ready to send {} of buffer {} ({} * {}B) to {}", data.sr, data.bid, frame_units, send_recv_unit_bytes, data.target);
 
 		// Start transmitting data


### PR DESCRIPTION
We send data frames in "packets" of 64 bytes (#153) to work around MPI's 32-bit-size limitation. The necessary rounding operation was only applied to the argument to `MPI_Isend`, but not the frame allocation. As a result, MPI overran the buffer  and sometimes read from unmapped memory.

This PR moves the padding computation to the `unique_frame_ptr` constructor through a `packet_size` parameter.