### PR TITLE
Execute horizons on dry runs 

### DIFF
--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -264,7 +264,7 @@ namespace detail {
 
 	void runtime::flush_command(node_id target, unique_frame_ptr<command_frame> frame) {
 		if(is_dry_run()) {
-			// We only want to send epochs to the master node for slow full sync and shutdown.
+			// Only flush epochs (for slow_full_sync / shutdown) and horizons (for deleting tasks from the ring buffer).
 			if(target != 0 || (frame->pkg.get_command_type() != command_type::epoch && frame->pkg.get_command_type() != command_type::horizon)) return;
 		}
 		// Even though command packages are small enough to use a blocking send we want to be able to send to the master node as well,

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -265,7 +265,7 @@ namespace detail {
 	void runtime::flush_command(node_id target, unique_frame_ptr<command_frame> frame) {
 		if(is_dry_run()) {
 			// We only want to send epochs to the master node for slow full sync and shutdown.
-			if(target != 0 || frame->pkg.get_command_type() != command_type::epoch) return;
+			if(target != 0 || (frame->pkg.get_command_type() != command_type::epoch && frame->pkg.get_command_type() != command_type::horizon)) return;
 		}
 		// Even though command packages are small enough to use a blocking send we want to be able to send to the master node as well,
 		// which is why we have to use Isend after all. We also have to make sure that the buffer stays around until the send is complete.


### PR DESCRIPTION
If no horizons are executed then task ring buffer doesn't update the counter of deleted tasks and gets full when it should not. 