### PR TITLE
clang-tidy: Enable more checks, take 2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,6 +26,7 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: Inner
 PointerAlignment: Left
+QualifierAlignment: Left
 SpaceAfterCStyleCast: false
 SpaceBeforeParens: Never
 SpaceInEmptyParentheses: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,21 +12,33 @@
 #
 InheritParentConfig: false
 # See https://clang.llvm.org/extra/clang-tidy/checks/list.html for a full list of available checks.
-Checks:
-  -*,
-  readability-identifier-naming,
+# Note: We would like to enable `misc-const-correctness` (introduced with Clang 15), but it currently
+#       seems to be somewhat buggy still (producing false positives) => revisit at some point.
+Checks: -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-lambda-function-name,
   -bugprone-macro-parentheses,
-  # TODO: Figure out which ones we want to (at least partially) enable
-  # clang-analyzer-*,
-  # clang-diagnostic-*,
-  # cppcoreguidelines-*,
-  # mpi-*,
-  # performance-*,
-  # readability-*,
-  # -readability-uppercase-literal-suffix
+  misc-*,
+  -misc-const-correctness,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  mpi-*,
+  performance-*,
+  readability-*,
+  -readability-avoid-const-params-in-decls,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-uppercase-literal-suffix,
 
 CheckOptions:
   # Naming conventions

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@
 # 1. Automatic checks through an IDE (CLion, VsCode, ...)
 # 2. Running manually on select files (not recommended)
 #    `clang-tidy -p path/to/compile_commands.json file1 [file2, ...]`
+#    Note: A script for running clang-tidy on all Celerity sources is provided in `ci/run-clang-tidy.sh`
 # 3. Running on a diff (also done during CI)
 #    `git diff -U0 --no-color | clang-tidy-diff.py -p1 -path path/to/compile_commands.json`
 #
@@ -14,8 +15,11 @@ InheritParentConfig: false
 Checks:
   -*,
   readability-identifier-naming,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-lambda-function-name,
+  -bugprone-macro-parentheses,
   # TODO: Figure out which ones we want to (at least partially) enable
-  # bugprone-*,
   # clang-analyzer-*,
   # clang-diagnostic-*,
   # cppcoreguidelines-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,6 +46,10 @@ CheckOptions:
   - key: readability-identifier-naming.ParameterIgnoredRegexp
     # Allow single-letter uppercase function parameters
     value: "[A-Z]"
+  - key: readability-identifier-naming.ProtectedMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.ProtectedMemberPrefix
+    value: m_
   - key: readability-identifier-naming.PrivateMemberCase
     value: lower_case
   - key: readability-identifier-naming.PrivateMemberPrefix

--- a/ci/run-clang-tidy.sh
+++ b/ci/run-clang-tidy.sh
@@ -17,7 +17,7 @@ if [[ ! -d src ]]; then
 fi
 
 CLANG_TIDY=${CLANG_TIDY:-clang-tidy}
-if [[ ! -x "$CLANG_TIDY" ]]; then
+if [[ ! -x "$(which $CLANG_TIDY)" ]]; then
     echo "Clang tidy executable \`$CLANG_TIDY\` does not exist. Set CLANG_TIDY environment variable to override."
     exit 1
 fi

--- a/include/handler.h
+++ b/include/handler.h
@@ -41,7 +41,7 @@ namespace detail {
 #if !defined(_MSC_VER)
 		const std::unique_ptr<char, void (*)(void*)> demangled(abi::__cxa_demangle(name.c_str(), nullptr, nullptr, nullptr), std::free);
 		const std::string demangled_s(demangled.get());
-		if(size_t lastc; (lastc = demangled_s.rfind(":")) != std::string::npos) {
+		if(size_t lastc = demangled_s.rfind(':'); lastc != std::string::npos) {
 			name = demangled_s.substr(lastc + 1, demangled_s.length() - lastc - 1);
 		} else {
 			name = demangled_s;
@@ -368,7 +368,7 @@ namespace detail {
 
 	  protected:
 		live_pass_handler(const class task* task, subrange<3> sr, bool initialize_reductions)
-		    : m_task(std::move(task)), m_sr(sr), m_initialize_reductions(initialize_reductions) {}
+		    : m_task(task), m_sr(sr), m_initialize_reductions(initialize_reductions) {}
 
 		const class task* m_task = nullptr;
 

--- a/include/host_queue.h
+++ b/include/host_queue.h
@@ -69,7 +69,7 @@ class partition : public detail::sized_partition_base<Dims> {
  */
 class experimental::collective_partition : public partition<1> {
   public:
-	MPI_Comm get_collective_mpi_comm() const { return comm; }
+	MPI_Comm get_collective_mpi_comm() const { return m_comm; }
 
 	size_t get_node_index() const { return get_subrange().offset[0]; }
 
@@ -78,9 +78,9 @@ class experimental::collective_partition : public partition<1> {
   protected:
 	friend collective_partition detail::make_collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm);
 
-	MPI_Comm comm;
+	MPI_Comm m_comm;
 
-	collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm) : partition<1>(global_size, range), comm(comm) {}
+	collective_partition(const celerity::range<1>& global_size, const subrange<1>& range, MPI_Comm comm) : partition<1>(global_size, range), m_comm(comm) {}
 };
 
 template <>

--- a/src/task.cc
+++ b/src/task.cc
@@ -22,7 +22,7 @@ namespace detail {
 	}
 
 	template <int KernelDims>
-	subrange<3> apply_range_mapper(range_mapper_base const* rm, const chunk<KernelDims>& chnk) {
+	subrange<3> apply_range_mapper(const range_mapper_base* rm, const chunk<KernelDims>& chnk) {
 		switch(rm->get_buffer_dimensions()) {
 		case 1: return subrange_cast<3>(rm->map_1(chnk));
 		case 2: return subrange_cast<3>(rm->map_2(chnk));

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -55,7 +55,7 @@ namespace detail {
 
 	void task_manager::await_epoch(task_id epoch) { m_latest_epoch_reached.await(epoch); }
 
-	GridRegion<3> get_requirements(task const& tsk, buffer_id bid, const std::vector<cl::sycl::access::mode> modes) {
+	GridRegion<3> get_requirements(const task& tsk, buffer_id bid, const std::vector<cl::sycl::access::mode> modes) {
 		const auto& access_map = tsk.get_buffer_access_map();
 		const subrange<3> full_range{tsk.get_global_offset(), tsk.get_global_size()};
 		GridRegion<3> result;

--- a/src/user_bench.cc
+++ b/src/user_bench.cc
@@ -13,7 +13,9 @@ namespace experimental {
 			user_benchmarker::~user_benchmarker() {
 				while(!m_sections.empty()) {
 					const auto sec = m_sections.top();
-					end_section(sec.name);
+					try {
+						end_section(sec.name);
+					} catch(...) {}
 				}
 			}
 

--- a/test/benchmark_reporters.cc
+++ b/test/benchmark_reporters.cc
@@ -51,19 +51,19 @@ class benchmark_reporter_base : public Catch::StreamingReporterBase {
 	// TODO: Do we want to somehow report this?
 	void benchmarkFailed(Catch::StringRef benchmark_name) override { StreamingReporterBase::benchmarkFailed(benchmark_name); }
 
-	void sectionStarting(Catch::SectionInfo const& section_info) override {
+	void sectionStarting(const Catch::SectionInfo& section_info) override {
 		StreamingReporterBase::sectionStarting(section_info);
 		// Each test case has an implicit section with the name of the test case itself,
 		// so there is no need to capture that separately.
 		m_active_sections.push_back(section_info.name);
 	}
 
-	void testCasePartialEnded(Catch::TestCaseStats const& test_case_stats, uint64_t part_number) override {
+	void testCasePartialEnded(const Catch::TestCaseStats& test_case_stats, uint64_t part_number) override {
 		StreamingReporterBase::testCasePartialEnded(test_case_stats, part_number);
 		m_active_sections.clear();
 	}
 
-	void testRunEnded(Catch::TestRunStats const& test_run_stats) override {
+	void testRunEnded(const Catch::TestRunStats& test_run_stats) override {
 		StreamingReporterBase::testRunEnded(test_run_stats);
 		bool warning_printed = false;
 		for(auto it = m_test_case_benchmark_combinations.cbegin(); it != m_test_case_benchmark_combinations.cend(); ++it) {
@@ -104,12 +104,12 @@ class benchmark_csv_reporter : public benchmark_reporter_base {
 
 	static std::string getDescription() { return "Reporter for benchmarks in CSV format"; } // NOLINT(readability-identifier-naming)
 
-	void testRunStarting(Catch::TestRunInfo const& test_run_info) override {
+	void testRunStarting(const Catch::TestRunInfo& test_run_info) override {
 		benchmark_reporter_base::testRunStarting(test_run_info);
 		fmt::print(m_stream, "test case,benchmark name,samples,iterations,estimated,mean,low mean,high mean,std dev,low std dev,high std dev,raw\n");
 	}
 
-	void benchmarkEnded(Catch::BenchmarkStats<> const& benchmark_stats) override {
+	void benchmarkEnded(const Catch::BenchmarkStats<>& benchmark_stats) override {
 		benchmark_reporter_base::benchmarkEnded(benchmark_stats);
 		auto& info = benchmark_stats.info;
 		fmt::print(m_stream, "{},{},{},{},{},", escape_csv(get_test_case_name()), escape_csv(info.name), info.samples, info.iterations, info.estimatedDuration);
@@ -199,7 +199,7 @@ class benchmark_md_reporter : public benchmark_reporter_base {
 
 	static std::string getDescription() { return "Generates a Markdown report for benchmark results"; } // NOLINT(readability-identifier-naming)
 
-	void testRunStarting(Catch::TestRunInfo const& test_run_info) override {
+	void testRunStarting(const Catch::TestRunInfo& test_run_info) override {
 		benchmark_reporter_base::testRunStarting(test_run_info);
 
 		fmt::print(m_stream, "# Benchmark Results\n\n");
@@ -212,14 +212,14 @@ class benchmark_md_reporter : public benchmark_reporter_base {
 		meta_printer.print(m_stream);
 	}
 
-	void testRunEnded(Catch::TestRunStats const& test_run_stats) override {
+	void testRunEnded(const Catch::TestRunStats& test_run_stats) override {
 		benchmark_reporter_base::testRunEnded(test_run_stats);
 		fmt::print(m_stream, "\n\n");
 		m_results_printer.print(m_stream);
 		fmt::print(m_stream, "\nAll numbers are in nanoseconds.\n");
 	}
 
-	void benchmarkEnded(Catch::BenchmarkStats<> const& benchmark_stats) override {
+	void benchmarkEnded(const Catch::BenchmarkStats<>& benchmark_stats) override {
 		benchmark_reporter_base::benchmarkEnded(benchmark_stats);
 
 		const auto min = std::reduce(benchmark_stats.samples.cbegin(), benchmark_stats.samples.cend(),


### PR DESCRIPTION
This supersedes #149.

We haven't had any checks (except for naming) enabled in our clang-tidy config for the past 6 months or so, which not just means nothing gets checked during CI, but also that some IDEs (e.g. VSCode + clangd) don't show any diagnostics during programming.

This is a second stab at enabling more checks, this time however without `misc-const-correctness` and `misc-unused-parameters`. Those two were responsible for 95% of the changes in the previous patch, and I don't feel like going over everything again (since the auto-fix only works half of the time).

I've also snuck in a small change to the clang-format config to prescribe CV-qualifier positions to be west const.

The previous PR took quite a long time during CI (40 minutes); honestly I don't understand why (edit: I just remembered - the CI script doesn't run across TUs in parallel, something we could look at). A full run on all files takes 5 minutes on gpuc1, and CI should only run on changed files (the previous PR did touch a lot more files, though). Anyway, lets see how this pans out. For future reference, I measured the time required for each of the checks (shoutout to ChatGPT for co-authoring that script):

```
bugprone-* added 51.56 seconds (total 51.56)
-bugprone-easily-swappable-parameters added -1.67 seconds (total 49.89)
-bugprone-lambda-function-name added 0.14 seconds (total 50.03)
-bugprone-macro-parentheses added 0.48 seconds (total 50.51)
misc-* added 7.37 seconds (total 57.88)
-misc-no-recursion added -1.09 seconds (total 56.79)
-misc-non-private-member-variables-in-classes added 0.50 seconds (total 57.29)
clang-analyzer-* added 187.68 seconds (total 244.96)
clang-diagnostic-* added -0.60 seconds (total 244.36)
cppcoreguidelines-* added 19.73 seconds (total 264.09)
-cppcoreguidelines-avoid-c-arrays added -2.23 seconds (total 261.86)
-cppcoreguidelines-avoid-magic-numbers added -4.90 seconds (total 256.96)
-cppcoreguidelines-macro-usage added 4.19 seconds (total 261.15)
-cppcoreguidelines-pro-bounds-pointer-arithmetic added -0.04 seconds (total 261.11)
mpi-* added -0.99 seconds (total 260.12)
performance-* added 19.02 seconds (total 279.14)
readability-* added 22.42 seconds (total 301.57)
-readability-avoid-const-params-in-decls added -5.62 seconds (total 295.95)
-readability-identifier-length added 0.41 seconds (total 296.35)
-readability-magic-numbers added 2.31 seconds (total 298.66)
-readability-uppercase-literal-suffix added -4.19 seconds (total 294.47)
```