### PR TITLE
clang-tidy: Disable readability-function-cognitive-complexity for tests

### DIFF
--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,3 @@
+---
+InheritParentConfig: true
+Checks: -readability-function-cognitive-complexity


### PR DESCRIPTION
👆