### PR TITLE
Bump minimum required SYCL versions, drop support for ComputeCpp

### DIFF
--- a/.github/workflows/build_matrix.json
+++ b/.github/workflows/build_matrix.json
@@ -1,10 +1,10 @@
 {
     "NOTE": "Make sure to keep this in sync with docs/platform-support.md. Also ensure that the 'ubuntu-version' between 'HEAD' and 'latest' builds remains the same.",
     "default": [
-        { "sycl": "dpcpp", "sycl-version": "3fd08509", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
+        { "sycl": "dpcpp", "sycl-version": "61e51015", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
-        { "sycl": "hipsycl", "sycl-version": "7b00e2ef", "ubuntu-version": "20.04", "platform": "nvidia", "build-type": "Debug" },
+        { "sycl": "hipsycl", "sycl-version": "24980221", "ubuntu-version": "20.04", "platform": "nvidia", "build-type": "Debug" },
         { "sycl": "hipsycl", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Debug" },
         { "sycl": "hipsycl", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Release" }
     ],

--- a/.github/workflows/build_matrix.json
+++ b/.github/workflows/build_matrix.json
@@ -1,14 +1,6 @@
 {
     "NOTE": "Make sure to keep this in sync with docs/platform-support.md. Also ensure that the 'ubuntu-version' between 'HEAD' and 'latest' builds remains the same.",
     "default": [
-        { "sycl": "computecpp", "sycl-version": "2.6.0", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
-        { "sycl": "computecpp", "sycl-version": "2.7.0", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
-        { "sycl": "computecpp", "sycl-version": "2.8.0", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
-        { "sycl": "computecpp", "sycl-version": "2.9.0", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
-        { "sycl": "computecpp", "sycl-version": "2.10.0", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
-        { "sycl": "computecpp", "sycl-version": "2.10.0", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
-        { "sycl": "computecpp", "sycl-version": "2.10.0-experimental", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
-        { "sycl": "computecpp", "sycl-version": "2.10.0-experimental", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
         { "sycl": "dpcpp", "sycl-version": "3fd08509", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ endif()
 
 set(CELERITY_DETAIL_IS_OLD_COMPUTECPP_COMPILER OFF)
 if(CELERITY_SYCL_IMPL STREQUAL "ComputeCpp")
+  message(FATAL "ComputeCpp is currently not supported.") # Comment out this error if you want to build against ComputeCpp anyway.
+
   # Determining the compiler version would usually be a job for FindComputeCpp, but since we're vendoring it, we try
   # to avoid introducing unnecessary changes.
   # TODO Replace this once FindComputeCpp supports distinguishing old and new ("experimental") compilers natively.

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -13,12 +13,10 @@ The most recent version of Celerity aims to support the following environments:
   * CUDA ≥ 11.0
   * on NVIDIA hardware with compute capability ≥ 7.0
   * or on CPUs via OpenMP
-* ComputeCpp ≥ version 2.6.0
-  * on Intel hardware
-  * with [stable](https://developer.codeplay.com/products/computecpp/ce/download)
-    and [experimental](https://developer.codeplay.com/products/computecpp/ce/download?experimental=true) compilers
 * DPC++ ≥ revision [`3fd08509`](https://github.com/intel/llvm/commit/3fd08509)
   * on Intel hardware
+
+ComputeCpp is currently not supported.
 
 ## Continuously Tested Configurations
 
@@ -28,9 +26,6 @@ Those are:
 
 | SYCL       | SYCL version                                                                   | OS           | Build type     |
 |------------|--------------------------------------------------------------------------------|--------------|----------------|
-| ComputeCpp | 2.6.0, 2.7.0, 2.8.0, 2.9.0 (stable)                                            | Ubuntu 20.04 | Debug          |
-| ComputeCpp | 2.10.0 (stable)                                                                | Ubuntu 22.04 | Debug, Release |
-| ComputeCpp | 2.10.0 (experimental compiler)                                                 | Ubuntu 22.04 | Debug, Release |
 | DPC++      | [`3fd08509`](https://github.com/intel/llvm/commit/3fd08509)                    | Ubuntu 20.04 | Debug          |
 | DPC++      | [`HEAD`](https://github.com/intel/llvm/)                                       | Ubuntu 22.04 | Debug, Release |
 | hipSYCL    | [`7b00e2ef`](https://github.com/illuhad/hipSYCL/commit/7b00e2ef) (CUDA 11.0.3) | Ubuntu 20.04 | Debug          |

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -8,12 +8,12 @@ sidebar_label: Platform Support
 
 The most recent version of Celerity aims to support the following environments:
 
-* hipSYCL ≥ revision [`7b00e2ef`](https://github.com/illuhad/hipSYCL/commit/7b00e2ef), with
+* hipSYCL ≥ revision [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221), with
   * Clang ≥ 10.0
   * CUDA ≥ 11.0
   * on NVIDIA hardware with compute capability ≥ 7.0
   * or on CPUs via OpenMP
-* DPC++ ≥ revision [`3fd08509`](https://github.com/intel/llvm/commit/3fd08509)
+* DPC++ ≥ revision [`61e51015`](https://github.com/intel/llvm/commit/61e51015)
   * on Intel hardware
 
 ComputeCpp is currently not supported.
@@ -26,7 +26,7 @@ Those are:
 
 | SYCL       | SYCL version                                                                   | OS           | Build type     |
 |------------|--------------------------------------------------------------------------------|--------------|----------------|
-| DPC++      | [`3fd08509`](https://github.com/intel/llvm/commit/3fd08509)                    | Ubuntu 20.04 | Debug          |
+| DPC++      | [`61e51015`](https://github.com/intel/llvm/commit/61e51015)                    | Ubuntu 20.04 | Debug          |
 | DPC++      | [`HEAD`](https://github.com/intel/llvm/)                                       | Ubuntu 22.04 | Debug, Release |
-| hipSYCL    | [`7b00e2ef`](https://github.com/illuhad/hipSYCL/commit/7b00e2ef) (CUDA 11.0.3) | Ubuntu 20.04 | Debug          |
+| hipSYCL    | [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221) (CUDA 11.0.3) | Ubuntu 20.04 | Debug          |
 | hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (CUDA 11.7.0)                     | Ubuntu 22.04 | Debug, Release |


### PR DESCRIPTION
This updates the minimum required versions for hipSYCL and DPC++ in anticipation of #162. Additionally, we have to drop support for ComputeCpp for the time being, as its USM support can be described as flaky at best, and working around all the encountered issues (if at all possible) is simply not worth the effort.