### PR TITLE
Update tested CUDA versions documentation

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -29,4 +29,4 @@ Those are:
 | DPC++      | [`61e51015`](https://github.com/intel/llvm/commit/61e51015)                    | Ubuntu 20.04 | Debug          |
 | DPC++      | [`HEAD`](https://github.com/intel/llvm/)                                       | Ubuntu 22.04 | Debug, Release |
 | hipSYCL    | [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221) (CUDA 11.0.3) | Ubuntu 20.04 | Debug          |
-| hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (CUDA 11.7.0)                     | Ubuntu 22.04 | Debug, Release |
+| hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (CUDA 12.1.0)                     | Ubuntu 22.04 | Debug, Release |


### PR DESCRIPTION
In a failed attempt to make CMake find the "CUDA Toolkit" for #162, I've bumped the minimum CUDA version we test against to 11.3, as the corresponding Docker container (built by nvidia) is the first to install the `cuda-toolkit` package. I've then realized that it was actually a CMake version issue. Nevertheless, I think there's no harm in bumping to 11.3, which is about two years old at this point. While at it, I've also bumped the "bleeding edge" container, which we use to test against hipSYCL-HEAD, to use CUDA 12.1.

This just updates the documentation to reflect that.