### PR TITLE
[CI] Don't pin MPI ranks to CPU cores

### DIFF
--- a/ci/run-examples.sh
+++ b/ci/run-examples.sh
@@ -65,7 +65,7 @@ for e in "${!EXAMPLES[@]}"; do
     for n in "${NUM_NODES[@]}"; do
         echo -e "\n\n ---- Running \"$NAME\" on $n node(s) ----\n\n" >&2
         rm -rf "$ARTIFACT" # Delete artifact before each run to make sure it is actually created
-        mpirun -n "$n" bash /root/capture-backtrace.sh "${CMD[@]}"
+        mpirun --bind-to none -n "$n" bash /root/capture-backtrace.sh "${CMD[@]}"
         if [ -n "$ARTIFACT" ]; then
             if [ "$n" -eq "${NUM_NODES[0]}" ]; then
                 expected_checksum=$(md5sum "$ARTIFACT")

--- a/ci/run-system-tests.sh
+++ b/ci/run-system-tests.sh
@@ -21,6 +21,6 @@ for e in "${!SYSTEM_TESTS[@]}"; do
 
     for n in "${NUM_NODES[@]}"; do
         echo -e "\n\n ---- Running \"$EXE\" on $n node(s) ----\n\n" >&2
-        mpirun -n ${n} bash /root/capture-backtrace.sh ${CMD} || exit 1
+        mpirun --bind-to none -n ${n} bash /root/capture-backtrace.sh ${CMD} || exit 1
     done
 done


### PR DESCRIPTION
Currently each rank is limited to two physical cores, this removes the binding. This is not a performance consideration; limiting the number of concurrent threads may mask certain kinds of bugs.