### PR TITLE
Build latest hipSYCL against CUDA 12.1 on Ubuntu 23.04

### DIFF
--- a/.github/workflows/build_matrix.json
+++ b/.github/workflows/build_matrix.json
@@ -5,13 +5,15 @@
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
         { "sycl": "hipsycl", "sycl-version": "24980221", "ubuntu-version": "20.04", "platform": "nvidia", "build-type": "Debug" },
-        { "sycl": "hipsycl", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Debug" },
-        { "sycl": "hipsycl", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Release" }
+        { "sycl": "hipsycl", "sycl-version": "24980221", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Debug" },
+        { "sycl": "hipsycl", "sycl-version": "24980221", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Release" },
+        { "sycl": "hipsycl", "sycl-version": "latest", "ubuntu-version": "23.04", "platform": "nvidia", "build-type": "Debug" },
+        { "sycl": "hipsycl", "sycl-version": "latest", "ubuntu-version": "23.04", "platform": "nvidia", "build-type": "Release" }
     ],
     "nightly": [
         { "sycl": "dpcpp", "sycl-version": "HEAD", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "HEAD", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
-        { "sycl": "hipsycl", "sycl-version": "HEAD", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Debug" },
-        { "sycl": "hipsycl", "sycl-version": "HEAD", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Release" }
+        { "sycl": "hipsycl", "sycl-version": "HEAD", "ubuntu-version": "23.04", "platform": "nvidia", "build-type": "Debug" },
+        { "sycl": "hipsycl", "sycl-version": "HEAD", "ubuntu-version": "23.04", "platform": "nvidia", "build-type": "Release" }
     ]
 }

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -31,3 +31,20 @@ Those are:
 | hipSYCL    | [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221) (Clang 10, CUDA 11.0.3) | Ubuntu 20.04 | Debug          |
 | hipSYCL    | [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221) (Clang 14, CUDA 11.8.0) | Ubuntu 22.04 | Debug, Release |
 | hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (Clang 16, CUDA 12.1.0)\*                   | Ubuntu 23.04 | Debug, Release |
+
+\* currently requires a patch for an illegal macro definition in CUDA:
+  
+```diff
+--- a/include/crt/host_defines.h	2023-04-03 14:40:16.471254404 +0200
++++ b/include/crt/host_defines.h	2023-03-23 22:07:22.000000000 +0100
+@@ -70,7 +70,7 @@
+ #define __no_return__ \
+         __attribute__((noreturn))
+         
+-#if defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA_LIBDEVICE__)
++#if (defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA_LIBDEVICE__)) && !defined(__clang__)
+ /* gcc allows users to define attributes with underscores, 
+    e.g., __attribute__((__noinline__)).
+    Consider a non-CUDA source file (e.g. .cpp) that has the 
+
+```

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -9,8 +9,8 @@ sidebar_label: Platform Support
 The most recent version of Celerity aims to support the following environments:
 
 * hipSYCL ≥ revision [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221), with
-  * Clang ≥ 10.0
   * CUDA ≥ 11.0
+  * Clang ≥ 10.0 for CUDA &lt; 12.0, Clang ≥ 16.0 for CUDA ≥ 12.0
   * on NVIDIA hardware with compute capability ≥ 7.0
   * or on CPUs via OpenMP
 * DPC++ ≥ revision [`61e51015`](https://github.com/intel/llvm/commit/61e51015)
@@ -24,9 +24,10 @@ We automatically verify Celerity's build process and test suites against a selec
 
 Those are:
 
-| SYCL       | SYCL version                                                                   | OS           | Build type     |
-|------------|--------------------------------------------------------------------------------|--------------|----------------|
-| DPC++      | [`61e51015`](https://github.com/intel/llvm/commit/61e51015)                    | Ubuntu 20.04 | Debug          |
-| DPC++      | [`HEAD`](https://github.com/intel/llvm/)                                       | Ubuntu 22.04 | Debug, Release |
-| hipSYCL    | [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221) (CUDA 11.0.3) | Ubuntu 20.04 | Debug          |
-| hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (CUDA 12.1.0)                     | Ubuntu 22.04 | Debug, Release |
+| SYCL       | SYCL version                                                                             | OS           | Build type     |
+|------------|------------------------------------------------------------------------------------------|--------------|----------------|
+| DPC++      | [`61e51015`](https://github.com/intel/llvm/commit/61e51015)                              | Ubuntu 20.04 | Debug          |
+| DPC++      | [`HEAD`](https://github.com/intel/llvm/)                                                 | Ubuntu 22.04 | Debug, Release |
+| hipSYCL    | [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221) (Clang 10, CUDA 11.0.3) | Ubuntu 20.04 | Debug          |
+| hipSYCL    | [`24980221`](https://github.com/illuhad/hipSYCL/commit/24980221) (Clang 14, CUDA 11.8.0) | Ubuntu 22.04 | Debug, Release |
+| hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (Clang 16, CUDA 12.1.0)\*                   | Ubuntu 23.04 | Debug, Release |

--- a/examples/convolution/convolution.cc
+++ b/examples/convolution/convolution.cc
@@ -101,7 +101,9 @@ int main(int argc, char* argv[]) {
 			sum -= in[{item[0] + 1, item[1]}];
 			sum -= in[{item[0], item[1] - 1}];
 			sum -= in[{item[0], item[1] + 1}];
-			out[item] = fmin(float3(1.f, 1.f, 1.f), sum);
+			out[item].x() = sycl::fmin(1.f, sum.x());
+			out[item].y() = sycl::fmin(1.f, sum.y());
+			out[item].z() = sycl::fmin(1.f, sum.z());
 		});
 	});
 


### PR DESCRIPTION
As noted in #168, Clang < 16 is incompatible with CUDA > 12. Docker images have been updated in the background so that with this PR, Ubuntu 22.04 / Clang 14 builds against CUDA 11.8, and a custom Ubuntu 23.04 / Clang 16 image is used to build against CUDA 12.1. To simplify workflow definitions, the hipSYCL version on 22.04 is now pinned.

With hipSYCL on CUDA 12, ptxas segfaults in the convolution example on `fmin(float3, float3)` for an unknown reason. Replacing the operation with a component-wise fmin seems to fix the issue.