### PR TITLE
Disallow in-source build to prevent issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.13)
 
+if (CMAKE_CURRENT_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  message(FATAL_ERROR "Celerity does not support in-source builds.\nPlease use a dedicated build directory and remove ${CMAKE_CURRENT_BINARY_DIR}/CMakeCache.txt and ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles")
+endif()
+
 file(STRINGS "VERSION" Celerity_VERSION)
 string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ "${Celerity_VERSION}")
 set(CELERITY_VERSION_MAJOR ${CMAKE_MATCH_1})


### PR DESCRIPTION
It is always recommended (and a good practice) to compile in a build directory. But considering a celerity user could potentially not be familiarized with good programming/debugging practices, this check should save them some time of headache.