### PR TITLE
add print performance counters for buffer_manager and btm

### DIFF
--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -265,6 +265,11 @@ namespace detail {
 			return m_buffer_infos.at(bid).debug_name;
 		}
 
+		void print_performance_metrics() const {
+			std::lock_guard lock(m_mutex);
+			CELERITY_INFO("BM: Lock attempts {} - resizes done {}", m_failed_lock_attempts, m_resizes_counter);
+		}
+
 	  private:
 		struct backing_buffer {
 			std::unique_ptr<buffer_storage> storage = nullptr;
@@ -326,6 +331,9 @@ namespace detail {
 		buffer_lifecycle_callback m_lifecycle_cb;
 		size_t m_buffer_count = 0;
 		mutable std::shared_mutex m_mutex;
+		// Counts failed attempts at locking any of the buffer locks.
+		unsigned int m_failed_lock_attempts = 0;
+		unsigned int m_resizes_counter = 0;
 		std::unordered_map<buffer_id, buffer_info> m_buffer_infos;
 		std::unordered_map<buffer_id, virtual_buffer> m_buffers;
 		std::unordered_map<buffer_id, std::vector<transfer>> m_scheduled_transfers;
@@ -343,7 +351,6 @@ namespace detail {
 
 		static resize_info is_resize_required(const backing_buffer& buffer, range<3> request_range, id<3> request_offset) {
 			assert(buffer.is_allocated());
-
 			// Empty-range buffer requirements never count towards the bounding box
 			if(request_range.size() == 0) { return resize_info{}; }
 			if(buffer.storage->get_range().size() == 0) { return resize_info{true, request_offset, request_range}; }

--- a/include/buffer_transfer_manager.h
+++ b/include/buffer_transfer_manager.h
@@ -34,6 +34,8 @@ namespace detail {
 		 */
 		void poll();
 
+		void print_performance_metrics() const;
+
 	  private:
 		struct data_frame {
 			using payload_type = std::byte;
@@ -84,6 +86,8 @@ namespace detail {
 		void update_outgoing_transfers();
 
 		static void commit_transfer(transfer_in& transfer);
+
+		size_t m_bytes_transfered = 0;
 	};
 
 } // namespace detail

--- a/include/executor.h
+++ b/include/executor.h
@@ -53,6 +53,8 @@ namespace detail {
 		 */
 		void shutdown();
 
+		void print_performance_metrics() const { m_btm->print_performance_metrics(); }
+
 	  private:
 		node_id m_local_nid;
 		host_queue& m_h_queue;

--- a/src/buffer_transfer_manager.cc
+++ b/src/buffer_transfer_manager.cc
@@ -51,6 +51,8 @@ namespace detail {
 		MPI_Isend(frame.get_pointer(), static_cast<int>(frame_units), m_send_recv_unit, static_cast<int>(data.target), mpi_support::TAG_DATA_TRANSFER,
 		    MPI_COMM_WORLD, &req);
 
+		m_bytes_transfered += frame.get_size_bytes();
+
 		auto transfer = std::make_unique<transfer_out>();
 		transfer->handle = t_handle;
 		transfer->request = req;
@@ -172,6 +174,8 @@ namespace detail {
 			bm.set_buffer_data(frame.bid, frame.sr, std::move(payload));
 		}
 	}
+
+	void buffer_transfer_manager::print_performance_metrics() const { CELERITY_INFO("BTM: bytes transfer {}", m_bytes_transfered); }
 
 } // namespace detail
 } // namespace celerity

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -239,6 +239,9 @@ namespace detail {
 			}
 		}
 
+		m_buffer_mngr->print_performance_metrics();
+		m_exec->print_performance_metrics();
+
 		// Shutting down the task_manager will cause all buffers captured inside command group functions to unregister.
 		// Since we check whether the runtime is still active upon unregistering, we have to set this to false first.
 		m_is_active = false;


### PR DESCRIPTION
Initial idea for reporting relevant performance counters:
- each relevant class keeps their own counters
- everyone with a relevant counter reports it through `print_performance_counters()` called from runtime and propagated. 

Adding @philippgs since he could come up with other metrics that could be interesting to keep an eye on.

