### PR TITLE
Accessor boundary check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,20 @@ project(celerity_runtime VERSION ${Celerity_VERSION} LANGUAGES CXX)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(ENABLE_ACC_CHECK ON)
+else()
+  set(ENABLE_ACC_CHECK OFF)
+endif()
+
 option(CELERITY_USE_MIMALLOC "Use the mimalloc memory allocator" ON)
+option(CELERITY_ACCESSOR_BOUNDARY_CHECK "Enable accessor boundary check" ${ENABLE_ACC_CHECK})
+
+if(CELERITY_ACCESSOR_BOUNDARY_CHECK)
+  message(STATUS "Accessor boundary check enabled - this will impact kernel performance")
+endif()
+
+unset(ENABLE_ACC_CHECK)
 
 set(CELERITY_CMAKE_DIR "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CELERITY_CMAKE_DIR}")
@@ -313,6 +326,7 @@ target_compile_definitions(celerity_runtime PUBLIC
   CELERITY_FEATURE_UNNAMED_KERNELS=$<BOOL:${CELERITY_FEATURE_UNNAMED_KERNELS}>
   CELERITY_DETAIL_HAS_NAMED_THREADS=$<BOOL:${CELERITY_DETAIL_HAS_NAMED_THREADS}>
   CELERITY_DETAIL_IS_OLD_COMPUTECPP_COMPILER=$<BOOL:${CELERITY_DETAIL_IS_OLD_COMPUTECPP_COMPILER}>
+  CELERITY_ACCESSOR_BOUNDARY_CHECK=$<BOOL:${CELERITY_ACCESSOR_BOUNDARY_CHECK}>
 )
 
 # Collect version information from git in src/version.cc. This target is always out of date, but the timestamp

--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -92,6 +92,7 @@ namespace detail {
 		using host_buffer_factory = std::function<std::unique_ptr<buffer_storage>(const range<3>&)>;
 
 		struct buffer_info {
+			int dimensions = -1;
 			celerity::range<3> range = {1, 1, 1};
 			size_t element_size = 0;
 			bool is_host_initialized;
@@ -139,7 +140,8 @@ namespace detail {
 					return std::make_unique<device_buffer_storage<DataT, Dims>>(range_cast<Dims>(r), q);
 				};
 				auto host_factory = [](const celerity::range<3>& r) { return std::make_unique<host_buffer_storage<DataT, Dims>>(range_cast<Dims>(r)); };
-				m_buffer_infos.emplace(bid, buffer_info{range, sizeof(DataT), is_host_initialized, {}, std::move(device_factory), std::move(host_factory)});
+				m_buffer_infos.emplace(
+				    bid, buffer_info{Dims, range, sizeof(DataT), is_host_initialized, {}, std::move(device_factory), std::move(host_factory)});
 				m_newest_data_location.emplace(bid, region_map<data_location>(range, data_location::nowhere));
 
 #if defined(CELERITY_DETAIL_ENABLE_DEBUG)

--- a/include/closure_hydrator.h
+++ b/include/closure_hydrator.h
@@ -62,6 +62,10 @@ class closure_hydrator {
 		range<3> backing_buffer_range;
 		id<3> backing_buffer_offset;
 		subrange<3> accessed_virtual_subrange;
+
+#if CELERITY_ACCESSOR_BOUNDARY_CHECK
+		id<3>* out_of_bounds_indices = nullptr;
+#endif
 	};
 
 	closure_hydrator(const closure_hydrator&) = delete;

--- a/include/worker_job.h
+++ b/include/worker_job.h
@@ -180,6 +180,10 @@ namespace detail {
 		cl::sycl::event m_event;
 		bool m_submitted = false;
 
+#if CELERITY_ACCESSOR_BOUNDARY_CHECK
+		std::vector<id<3>*> m_oob_indices_per_accessor;
+#endif
+
 		bool execute(const command_pkg& pkg) override;
 		std::string get_description(const command_pkg& pkg) override;
 	};


### PR DESCRIPTION
This PR depends on #173 

This check has proven quite useful when debugging, hence adding only for debug builds since it can also have a non negligible impact on performance, after all it happens for all accessor subscriptor operators.

Not sure if just reporting it as a `CELERITY_ERROR` is enough or if it would also be expected for it to exit and report it as a fatal error or similar. 