### PR TITLE
Make buffer manager aware of current device memory usage

### DIFF
--- a/include/buffer_storage.h
+++ b/include/buffer_storage.h
@@ -7,6 +7,7 @@
 #include <CL/sycl.hpp>
 
 #include "backend/backend.h"
+#include "device_queue.h"
 #include "payload.h"
 #include "ranges.h"
 #include "workaround.h"
@@ -31,16 +32,11 @@ namespace detail {
 	template <typename DataT, int Dims>
 	class device_buffer {
 	  public:
-		device_buffer(const range<Dims>& range, sycl::queue& queue) : m_range(range), m_queue(queue) {
-			if(m_range.size() != 0) {
-				m_device_ptr = sycl::malloc_device<DataT>(m_range.size(), m_queue);
-				assert(m_device_ptr != nullptr);
-			}
+		device_buffer(const range<Dims>& range, device_queue& queue) : m_range(range), m_queue(queue) {
+			if(m_range.size() != 0) { m_device_allocation = m_queue.malloc<DataT>(m_range.size()); }
 		}
 
-		~device_buffer() {
-			if(m_range.size() != 0) { sycl::free(m_device_ptr, m_queue); }
-		}
+		~device_buffer() { m_queue.free(m_device_allocation); }
 
 		device_buffer(const device_buffer&) = delete;
 		device_buffer(device_buffer&&) noexcept = default;
@@ -49,16 +45,14 @@ namespace detail {
 
 		range<Dims> get_range() const { return m_range; }
 
-		DataT* get_pointer() { return m_device_ptr; }
+		DataT* get_pointer() { return static_cast<DataT*>(m_device_allocation.ptr); }
 
-		const DataT* get_pointer() const { return m_device_ptr; }
-
-		bool operator==(const device_buffer& rhs) const { return m_device_ptr == rhs.m_device_ptr && m_queue == rhs.m_queue && m_range == rhs.m_range; }
+		const DataT* get_pointer() const { return static_cast<DataT*>(m_device_allocation.ptr); }
 
 	  private:
 		range<Dims> m_range;
-		sycl::queue m_queue;
-		DataT* m_device_ptr = nullptr;
+		device_queue& m_queue;
+		device_allocation m_device_allocation;
 	};
 
 	template <typename DataT, int Dims>
@@ -129,8 +123,9 @@ namespace detail {
 	template <typename DataT, int Dims>
 	class device_buffer_storage : public buffer_storage {
 	  public:
-		device_buffer_storage(range<Dims> range, sycl::queue owning_queue)
-		    : buffer_storage(range_cast<3>(range), buffer_type::device_buffer), m_owning_queue(std::move(owning_queue)), m_device_buf(range, m_owning_queue) {}
+		device_buffer_storage(range<Dims> range, device_queue& owning_queue)
+		    : buffer_storage(range_cast<3>(range), buffer_type::device_buffer), m_owning_queue(owning_queue.get_sycl_queue()),
+		      m_device_buf(range, owning_queue) {}
 
 		size_t get_size() const override { return get_range().size() * sizeof(DataT); };
 
@@ -163,8 +158,6 @@ namespace detail {
 		}
 
 		void copy(const buffer_storage& source, id<3> source_offset, id<3> target_offset, range<3> copy_range) override;
-
-		sycl::queue& get_owning_queue() { return m_owning_queue; }
 
 	  private:
 		mutable sycl::queue m_owning_queue;

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -20,6 +20,8 @@ namespace detail {
 		auto device = std::visit(
 		    [&cfg](const auto& value) { return ::celerity::detail::pick_device(cfg, value, cl::sycl::platform::get_platforms()); }, user_device_or_selector);
 		m_sycl_queue = std::make_unique<cl::sycl::queue>(device, handle_exceptions, props);
+
+		m_global_mem_total_size_bytes = m_sycl_queue->get_device().get_info<sycl::info::device::global_mem_size>();
 	}
 
 	void device_queue::handle_async_exceptions(cl::sycl::exception_list el) const {


### PR DESCRIPTION
- Limit amount of device memory that can be used (currently set to 95%)
- Detect out-of-memory errors and print helpful error message listing all currently allocated buffers and their sizes
  - As it turns out DPC++ (on LevelZero at least) swaps out GPU memory to system memory, and it'll just continue work (albeit slowly)
- If resizing large buffer would exceed device memory, attempt to go through host first
- If accessing part of large buffer would result in resize that exceeds device memory, attempt to spill currently unused parts to the host