### PR TITLE
Fix a sporadic lifetime issue with log capturing in unit tests

### DIFF
--- a/test/accessor_tests.cc
+++ b/test/accessor_tests.cc
@@ -654,29 +654,34 @@ namespace detail {
 #if !CELERITY_ACCESSOR_BOUNDARY_CHECK
 		SKIP("CELERITY_ACCESSOR_BOUNDARY_CHECK=0");
 #endif
-
 		buffer<int, Dims> buff(range_cast<Dims>(range<3>{10, 20, 30}));
 		const auto accessible_sr = subrange_cast<Dims>(subrange<3>{{5, 10, 15}, {1, 2, 3}});
 		const auto oob_idx_lo = id_cast<Dims>(id<3>{1, 2, 3});
 		const auto oob_idx_hi = id_cast<Dims>(id<3>{7, 13, 25});
-		distr_queue q;
 
-		celerity::test_utils::log_capture lc;
+		// we need to be careful about the orderign of the construction and destruction
+		// of the Celerity queue and the log capturing utility here
+		std::unique_ptr<celerity::test_utils::log_capture> lc;
+		{
+			distr_queue q;
 
-		q.submit([&](handler& cgh) {
-			accessor acc(buff, cgh, celerity::access::fixed(accessible_sr), celerity::write_only, celerity::no_init);
-			cgh.parallel_for<acc_out_of_bounds_kernel<Dims>>(range<Dims>(unit_range), [=](item<Dims>) {
-				acc[oob_idx_lo] = 0;
-				acc[oob_idx_hi] = 0;
+			lc = std::make_unique<celerity::test_utils::log_capture>();
+
+			q.submit([&](handler& cgh) {
+				accessor acc(buff, cgh, celerity::access::fixed(accessible_sr), celerity::write_only, celerity::no_init);
+				cgh.parallel_for<acc_out_of_bounds_kernel<Dims>>(range<Dims>(unit_range), [=](item<Dims>) {
+					acc[oob_idx_lo] = 0;
+					acc[oob_idx_hi] = 0;
+				});
 			});
-		});
-		q.slow_full_sync();
+			q.slow_full_sync();
+		}
 
 		const auto attempted_sr = subrange<3>{id_cast<3>(oob_idx_lo), range_cast<3>(oob_idx_hi - oob_idx_lo + id_cast<Dims>(range<Dims>(unit_range)))};
 		const auto error_message = fmt::format("Out-of-bounds access in kernel 'acc_out_of_bounds_kernel<{}>' detected: Accessor 0 for buffer 0 attempted to "
 		                                       "access indices between {} which are outside of mapped subrange {}",
 		    Dims, attempted_sr, subrange_cast<3>(accessible_sr));
-		CHECK_THAT(lc.get_log(), Catch::Matchers::ContainsSubstring(error_message));
+		CHECK_THAT(lc->get_log(), Catch::Matchers::ContainsSubstring(error_message));
 	}
 
 } // namespace detail

--- a/test/log_test_utils.h
+++ b/test/log_test_utils.h
@@ -16,11 +16,15 @@ class log_capture {
 		m_level_before = spdlog::get_level();
 		m_tmp_level = std::min(m_level_before, level);
 		spdlog::set_level(m_tmp_level);
+		m_flush_before = logger->flush_level();
+		m_tmp_flush = std::min(m_flush_before, level);
+		logger->flush_on(m_tmp_flush);
 	}
 
 	~log_capture() {
 		spdlog::set_level(m_level_before);
 		const auto logger = spdlog::default_logger_raw();
+		logger->flush_on(m_flush_before);
 		assert(*logger->sinks().rbegin() == m_ostream_sink);
 		logger->sinks().pop_back();
 	}
@@ -31,7 +35,7 @@ class log_capture {
 	}
 
   private:
-	spdlog::level::level_enum m_tmp_level, m_level_before;
+	spdlog::level::level_enum m_tmp_level, m_level_before, m_tmp_flush, m_flush_before;
 	std::ostringstream m_oss;
 	std::shared_ptr<spdlog::sinks::ostream_sink_st> m_ostream_sink;
 
@@ -39,6 +43,10 @@ class log_capture {
 		if(spdlog::get_level() != m_tmp_level) {
 			FAIL_CHECK("global spdlog level has changed since log_capture was instantiated - captured logs may depend on CELERITY_LOG_LEVEL!");
 			m_tmp_level = spdlog::get_level();
+		}
+		if(spdlog::default_logger_raw()->flush_level() != m_tmp_flush) {
+			FAIL_CHECK("spdlog flush level has changed since log_capture was instantiated!");
+			m_tmp_flush = spdlog::default_logger_raw()->flush_level();
 		}
 	}
 };


### PR DESCRIPTION
I believe that this lifetime issue is what caused the sporadic failures of some CI jobs in debug builds on some recent PRs.

The problem in the original code was actually rather easy to reproduce, it happened roughly one in 5 times. I've run the test in question 100 times with this version and there were no issues.