### PR TITLE
Fix behaviour of fence and horizons in dry runs

### DIFF
--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -19,7 +19,14 @@ namespace detail {
 
 	void abstract_scheduler::schedule() {
 		graph_serializer serializer([this](command_pkg&& pkg) {
-			if(m_is_dry_run && pkg.get_command_type() != command_type::epoch) { return; }
+			if(m_is_dry_run && pkg.get_command_type() != command_type::epoch && pkg.get_command_type() != command_type::fence) {
+				// in dry runs, skip everything except epochs and fences
+				return;
+			}
+			if(m_is_dry_run && pkg.get_command_type() == command_type::fence) {
+				CELERITY_WARN("Encountered a \"fence\" command while \"CELERITY_DRY_RUN_NODES\" is set. "
+				              "The result of this operation will not match the expected output of an actual run.");
+			}
 			// Executor may not be set during tests / benchmarks
 			if(m_exec != nullptr) { m_exec->enqueue(std::move(pkg)); }
 		});

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -19,8 +19,9 @@ namespace detail {
 
 	void abstract_scheduler::schedule() {
 		graph_serializer serializer([this](command_pkg&& pkg) {
-			if(m_is_dry_run && pkg.get_command_type() != command_type::epoch && pkg.get_command_type() != command_type::fence) {
-				// in dry runs, skip everything except epochs and fences
+			if(m_is_dry_run && pkg.get_command_type() != command_type::epoch && pkg.get_command_type() != command_type::horizon
+			    && pkg.get_command_type() != command_type::fence) {
+				// in dry runs, skip everything except epochs, horizons and fences
 				return;
 			}
 			if(m_is_dry_run && pkg.get_command_type() == command_type::fence) {

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -66,6 +66,8 @@ namespace detail {
 	struct task_manager_testspy {
 		static std::optional<task_id> get_current_horizon(task_manager& tm) { return tm.m_current_horizon; }
 
+		static std::optional<task_id> get_latest_horizon_reached(task_manager& tm) { return tm.m_latest_horizon_reached; }
+
 		static int get_num_horizons(task_manager& tm) {
 			int horizon_counter = 0;
 			for(auto task_ptr : tm.m_task_buffer) {

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -353,55 +353,6 @@ namespace test_utils {
 		}
 	}
 
-	class set_test_env {
-	  public:
-#ifdef _WIN32
-		set_test_env(const std::string& env, const std::string& val) : m_env_var_name(env) {
-			//  We use the ANSI version of Get/Set, because it does not require type conversion of char to wchar_t, and we can safely do this
-			//  because we are not mutating the text and therefore can treat them as raw bytes without having to worry about the text encoding.
-			const auto name_size = GetEnvironmentVariableA(env.c_str(), nullptr, 0);
-			if(name_size > 0) {
-				m_original_value.resize(name_size);
-				const auto res = GetEnvironmentVariableA(env.c_str(), m_original_value.data(), name_size);
-				assert(res != 0 && "Failed to get celerity environment variable");
-			}
-			const auto res = SetEnvironmentVariableA(env.c_str(), val.c_str());
-			assert(res != 0 && "Failed to set celerity environment variable");
-		}
-
-		~set_test_env() {
-			if(m_original_value.empty()) {
-				const auto res = SetEnvironmentVariableA(m_env_var_name.c_str(), NULL);
-				assert(res != 0 && "Failed to delete celerity environment variable");
-			} else {
-				const auto res = SetEnvironmentVariableA(m_env_var_name.c_str(), m_original_value.c_str());
-				assert(res != 0 && "Failed to reset celerity environment variable");
-			}
-		}
-
-#else
-		set_test_env(const std::string& env, const std::string& val) {
-			const char* has_value = std::getenv(env.c_str());
-			if(has_value != nullptr) { m_original_value = has_value; }
-			const auto res = setenv(env.c_str(), val.c_str(), 1);
-			assert(res == 0 && "Failed to set celerity environment variable");
-			m_env_var_name = env;
-		}
-		~set_test_env() {
-			if(m_original_value.empty()) {
-				const auto res = unsetenv(m_env_var_name.c_str());
-				assert(res == 0 && "Failed to unset celerity environment variable");
-			} else {
-				const auto res = setenv(m_env_var_name.c_str(), m_original_value.c_str(), 1);
-				assert(res == 0 && "Failed to reset celerity environment variable");
-			}
-		}
-#endif
-	  private:
-		std::string m_env_var_name;
-		std::string m_original_value;
-	};
-
 } // namespace test_utils
 } // namespace celerity
 


### PR DESCRIPTION
Also added a unit test.

Note that I very minorly changed the existing dry run test: it was the only test to still use `test_utils::set_test_env`. Changing this to use the equivalent `libenvpp` functionality allowed me to get rid of the entire `set_test_env` test utility (which even had platform-specific code), making this a -20 net LoC change. Yay!

**Edit**:
Also fixed processing of horizons in dry runs and added a test for that.