### PR TITLE
Avoid OOB access in backend_tests for platforms with no devices

### DIFF
--- a/test/backend_tests.cc
+++ b/test/backend_tests.cc
@@ -96,6 +96,7 @@ struct host_or_device {
 
 std::pair<host_or_device, host_or_device> select_source_and_target(const copy_test_type test_type, const sycl::platform& platform) {
 	const auto devices = platform.get_devices();
+	if(devices.empty()) { throw std::runtime_error(fmt::format("Platform {} has no devices", platform.get_info<sycl::info::platform::name>())); }
 	switch(test_type) {
 	case copy_test_type::intra_device: {
 		return std::pair{host_or_device{sycl::queue{devices[0]}}, host_or_device{sycl::queue{devices[0]}}};


### PR DESCRIPTION
We have observed hipSYCL to sometimes list platforms with no devices (in our case because OpenCL device enumeration failed). While this [should probably be considered non-conformant](https://github.com/KhronosGroup/SYCL-Docs/issues/459), we can be more defensive to avoid an OOB array access in `backend_tests`.