### PR TITLE
Manually create SYCL context to work around DPC++ bug

### DIFF
--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -19,7 +19,10 @@ namespace detail {
 
 		auto device = std::visit(
 		    [&cfg](const auto& value) { return ::celerity::detail::pick_device(cfg, value, cl::sycl::platform::get_platforms()); }, user_device_or_selector);
-		m_sycl_queue = std::make_unique<cl::sycl::queue>(device, handle_exceptions, props);
+
+		// Manually create context as workaround for https://github.com/intel/llvm/issues/10982
+		sycl::context ctx{device};
+		m_sycl_queue = std::make_unique<cl::sycl::queue>(ctx, device, handle_exceptions, props);
 
 		m_global_mem_total_size_bytes = m_sycl_queue->get_device().get_info<sycl::info::device::global_mem_size>();
 	}


### PR DESCRIPTION
Workaround for https://github.com/intel/llvm/issues/10982

With this `HEAD` builds now [pass CI again](https://github.com/celerity/celerity-runtime/actions/runs/6107109407/job/16573858581).