### PR TITLE
CI: Fix formatting check and HEAD -> latest tagging

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -258,7 +258,7 @@ jobs:
             echo "$unformatted"
             echo EOF
           } >> "$GITHUB_OUTPUT"
-      - uses: "celerity/ci-report-action@v6"
+      - uses: "celerity/ci-report-action@v7"
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           unformatted-files: ${{ steps.formatting.outputs.unformatted-files }}

--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -197,8 +197,8 @@ jobs:
         name: Set outputs for HEAD builds
         if: matrix.sycl-version == 'HEAD'
         run: |
-          echo "${{ matrix.sycl }}-HEAD-${{ matrix.build-type }}-works=1 >> $GITHUB_OUTPUT"
-          echo "${{ matrix.sycl }}-HEAD-ubuntu-version=${{ matrix.ubuntu-version }} >> $GITHUB_OUTPUT"
+          echo "${{ matrix.sycl }}-HEAD-${{ matrix.build-type }}-works=1" >> "$GITHUB_OUTPUT"
+          echo "${{ matrix.sycl }}-HEAD-ubuntu-version=${{ matrix.ubuntu-version }}" >> "$GITHUB_OUTPUT"
 
   # Tag "HEAD" images that built and tested successfully as "latest".
   # This is only done for nightly builds (or when specifying the "tag-latest" option on manually triggered runs).
@@ -253,8 +253,11 @@ jobs:
         shell: bash
         run: |
           unformatted=$("./ci/find-unformatted-files.sh")
-          unformatted=${unformatted//$'\n'/'%0A'}
-          echo "unformatted-files=$unformatted >> $GITHUB_OUTPUT"
+          {
+            echo 'unformatted-files<<EOF'
+            echo "$unformatted"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - uses: "celerity/ci-report-action@v6"
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Both of them were broken due to unfortunate quotation mark placements. Apparently GitHub changed the evaluation behavior at some point (these used to work).