### PR TITLE
Remove task_manager / buffer_manager dependency from recorders

### DIFF
--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -84,7 +84,7 @@ namespace detail {
 		friend struct buffer_manager_testspy;
 
 	  public:
-		enum class buffer_lifecycle_event { registered, unregistered };
+		enum class buffer_lifecycle_event { registered, unregistered, set_debug_name };
 
 		using buffer_lifecycle_callback = std::function<void(buffer_lifecycle_event, buffer_id)>;
 
@@ -274,8 +274,11 @@ namespace detail {
 		bool is_locked(buffer_id bid) const;
 
 		void set_debug_name(const buffer_id bid, const std::string& debug_name) {
-			std::lock_guard lock(m_mutex);
-			m_buffer_infos.at(bid).debug_name = debug_name;
+			{
+				std::lock_guard lock(m_mutex);
+				m_buffer_infos.at(bid).debug_name = debug_name;
+			}
+			m_lifecycle_cb(buffer_lifecycle_event::set_debug_name, bid);
 		}
 
 		std::string get_debug_name(const buffer_id bid) const {

--- a/include/print_graph.h
+++ b/include/print_graph.h
@@ -7,8 +7,8 @@
 
 namespace celerity::detail {
 
-[[nodiscard]] std::string print_task_graph(const task_recorder& recorder);
-[[nodiscard]] std::string print_command_graph(const node_id local_nid, const command_recorder& recorder);
+[[nodiscard]] std::string print_task_graph(const task_recorder& trec, const buffer_recorder& brec);
+[[nodiscard]] std::string print_command_graph(const node_id local_nid, const command_recorder& crec, const task_recorder& trec, const buffer_recorder& brec);
 [[nodiscard]] std::string combine_command_graphs(const std::vector<std::string>& graphs);
 
 } // namespace celerity::detail

--- a/include/recorders.h
+++ b/include/recorders.h
@@ -5,32 +5,59 @@
 
 namespace celerity::detail {
 
-class buffer_manager;
 class task_manager;
 
 // General recording
 
 struct access_record {
-	const buffer_id bid;
-	const std::string buffer_name;
-	const access_mode mode;
-	const region<3> req;
+	buffer_id bid;
+	access_mode mode;
+	region<3> req;
 };
 using access_list = std::vector<access_record>;
 
 struct reduction_record {
-	const reduction_id rid;
-	const buffer_id bid;
-	const std::string buffer_name;
-	const bool init_from_buffer;
+	reduction_id rid;
+	buffer_id bid;
+	bool init_from_buffer;
 };
 using reduction_list = std::vector<reduction_record>;
 
 template <typename IdType>
 struct dependency_record {
-	const IdType node;
-	const dependency_kind kind;
-	const dependency_origin origin;
+	IdType node;
+	dependency_kind kind;
+	dependency_origin origin;
+};
+
+// Buffer recording
+
+struct buffer_record {
+	buffer_id bid;
+	std::string debug_name;
+};
+
+class buffer_recorder {
+  public:
+	using buffer_records = std::vector<buffer_record>;
+
+	void create_buffer(const buffer_id bid) { m_recorded_buffers.push_back(buffer_record{bid, {}}); }
+
+	void set_buffer_debug_name(const buffer_id bid, std::string name) {
+		const auto it = std::find_if(m_recorded_buffers.begin(), m_recorded_buffers.end(), [bid](const buffer_record& rec) { return rec.bid == bid; });
+		assert(it != m_recorded_buffers.end());
+		it->debug_name = std::move(name);
+	}
+	const buffer_records& get_buffers() const { return m_recorded_buffers; }
+
+	const buffer_record& get_buffer(const buffer_id bid) const {
+		const auto it = std::find_if(m_recorded_buffers.begin(), m_recorded_buffers.end(), [bid](const buffer_record& rec) { return rec.bid == bid; });
+		assert(it != m_recorded_buffers.end());
+		return *it;
+	}
+
+  private:
+	buffer_records m_recorded_buffers;
 };
 
 // Task recording
@@ -38,32 +65,35 @@ struct dependency_record {
 using task_dependency_list = std::vector<dependency_record<task_id>>;
 
 struct task_record {
-	task_record(const task& from, const buffer_manager* buff_mngr);
+	explicit task_record(const task& tsk);
 
-	const task_id tid;
-	const std::string debug_name;
-	const collective_group_id cgid;
-	const task_type type;
-	const task_geometry geometry;
-	const reduction_list reductions;
-	const access_list accesses;
-	const side_effect_map side_effect_map;
-	const task_dependency_list dependencies;
+	task_id tid;
+	std::string debug_name;
+	collective_group_id cgid;
+	task_type type;
+	task_geometry geometry;
+	reduction_list reductions;
+	access_list accesses;
+	side_effect_map side_effect_map;
+	task_dependency_list dependencies;
 };
 
 class task_recorder {
   public:
-	using task_record = std::vector<task_record>;
+	using task_records = std::vector<task_record>;
 
-	task_recorder(const buffer_manager* buff_mngr = nullptr) : m_buff_mngr(buff_mngr) {}
+	void record_task(const task& tsk) { m_recorded_tasks.push_back(task_record(tsk)); }
 
-	void record_task(const task& tsk);
+	const task_records& get_tasks() const { return m_recorded_tasks; }
 
-	const task_record& get_tasks() const { return m_recorded_tasks; }
+	const task_record& get_task(const task_id tid) const {
+		const auto it = std::find_if(m_recorded_tasks.begin(), m_recorded_tasks.end(), [tid](const task_record& rec) { return rec.tid == tid; });
+		assert(it != m_recorded_tasks.end());
+		return *it;
+	}
 
   private:
-	task_record m_recorded_tasks;
-	const buffer_manager* m_buff_mngr;
+	task_records m_recorded_tasks;
 };
 
 // Command recording
@@ -71,46 +101,41 @@ class task_recorder {
 using command_dependency_list = std::vector<dependency_record<command_id>>;
 
 struct command_record {
-	const command_id cid;
-	const command_type type;
+	command_id cid;
+	command_type type;
 
-	const std::optional<epoch_action> epoch_action;
-	const std::optional<subrange<3>> execution_range;
-	const std::optional<reduction_id> reduction_id;
-	const std::optional<buffer_id> buffer_id;
-	const std::string buffer_name;
-	const std::optional<node_id> target;
-	const std::optional<region<3>> await_region;
-	const std::optional<subrange<3>> push_range;
-	const std::optional<transfer_id> transfer_id;
-	const std::optional<task_id> task_id;
-	const std::optional<task_geometry> task_geometry;
-	const bool is_reduction_initializer;
-	const std::optional<access_list> accesses;
-	const std::optional<reduction_list> reductions;
-	const std::optional<side_effect_map> side_effects;
-	const command_dependency_list dependencies;
-	const std::string task_name;
-	const std::optional<task_type> task_type;
-	const std::optional<collective_group_id> collective_group_id;
+	std::optional<epoch_action> epoch_action;
+	std::optional<subrange<3>> execution_range;
+	std::optional<reduction_id> reduction_id;
+	std::optional<buffer_id> buffer_id;
+	std::optional<node_id> target;
+	std::optional<region<3>> await_region;
+	std::optional<subrange<3>> push_range;
+	std::optional<transfer_id> transfer_id;
+	std::optional<task_id> task_id;
+	bool is_reduction_initializer;
+	std::optional<access_list> accesses;
+	command_dependency_list dependencies;
 
-	command_record(const abstract_command& cmd, const task_manager* task_mngr, const buffer_manager* buff_mngr);
+	explicit command_record(const abstract_command& cmd, const task* tsk);
 };
 
 class command_recorder {
   public:
-	using command_record = std::vector<command_record>;
+	using command_records = std::vector<command_record>;
 
-	command_recorder(const task_manager* task_mngr, const buffer_manager* buff_mngr = nullptr) : m_task_mngr(task_mngr), m_buff_mngr(buff_mngr) {}
+	void record_command(const abstract_command& cmd, const task* tsk) { m_recorded_commands.push_back(command_record(cmd, tsk)); }
 
-	void record_command(const abstract_command& com);
+	const command_records& get_commands() const { return m_recorded_commands; }
 
-	const command_record& get_commands() const { return m_recorded_commands; }
+	const command_record& get_command(const command_id cid) const {
+		const auto it = std::find_if(m_recorded_commands.begin(), m_recorded_commands.end(), [cid](const command_record& rec) { return rec.cid == cid; });
+		assert(it != m_recorded_commands.end());
+		return *it;
+	}
 
   private:
-	command_record m_recorded_commands;
-	const task_manager* m_task_mngr;
-	const buffer_manager* m_buff_mngr;
+	command_records m_recorded_commands;
 };
 
 } // namespace celerity::detail

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -111,6 +111,7 @@ namespace detail {
 		std::unique_ptr<task_manager> m_task_mngr;
 		std::unique_ptr<executor> m_exec;
 
+		std::unique_ptr<detail::buffer_recorder> m_buffer_recorder;
 		std::unique_ptr<detail::task_recorder> m_task_recorder;
 		std::unique_ptr<detail::command_recorder> m_command_recorder;
 
@@ -119,6 +120,7 @@ namespace detail {
 		runtime(runtime&&) = delete;
 
 		void handle_buffer_registered(buffer_id bid);
+		void handle_set_buffer_debug_name(buffer_id bid, const std::string& name);
 		void handle_buffer_unregistered(buffer_id bid);
 
 		/**

--- a/src/distributed_graph_generator.cc
+++ b/src/distributed_graph_generator.cc
@@ -21,7 +21,7 @@ distributed_graph_generator::distributed_graph_generator(
 	// set_epoch_for_new_commands).
 	auto* const epoch_cmd = cdag.create<epoch_command>(task_manager::initial_epoch_task, epoch_action::none);
 	epoch_cmd->mark_as_flushed(); // there is no point in flushing the initial epoch command
-	if(m_recorder != nullptr) m_recorder->record_command(*epoch_cmd);
+	if(m_recorder != nullptr) m_recorder->record_command(*epoch_cmd, nullptr);
 	m_epoch_for_new_commands = epoch_cmd->get_cid();
 }
 
@@ -138,7 +138,7 @@ std::unordered_set<abstract_command*> distributed_graph_generator::build_task(co
 	// If we have a command_recorder, record the current batch of commands
 	if(m_recorder != nullptr) {
 		for(const auto& cmd : m_current_cmd_batch) {
-			m_recorder->record_command(*cmd);
+			m_recorder->record_command(*cmd, utils::isa<task_command>(cmd) ? &tsk : nullptr);
 		}
 	}
 

--- a/src/recorders.cc
+++ b/src/recorders.cc
@@ -1,36 +1,30 @@
 #include "recorders.h"
-#include "buffer_manager.h"
-#include "task_manager.h"
-
-#include <regex>
+#include "task.h"
 
 namespace celerity::detail {
 
-// Naming
-
-std::string get_buffer_name(const buffer_id bid, const buffer_manager* buff_man) {
-	return buff_man != nullptr ? buff_man->get_buffer_info(bid).debug_name : "";
-}
-
 // Tasks
 
-access_list build_access_list(const task& tsk, const buffer_manager* buff_man, const std::optional<subrange<3>> execution_range = {}) {
+access_list build_access_list(const buffer_access_map& bam, int dims, const range<3>& global_size, const subrange<3>& exec_range) {
 	access_list ret;
-	const auto exec_range = execution_range.value_or(subrange<3>{tsk.get_global_offset(), tsk.get_global_size()});
-	const auto& bam = tsk.get_buffer_access_map();
 	for(const auto bid : bam.get_accessed_buffers()) {
 		for(const auto mode : bam.get_access_modes(bid)) {
-			const auto req = bam.get_mode_requirements(bid, mode, tsk.get_dimensions(), exec_range, tsk.get_global_size());
-			ret.push_back({bid, get_buffer_name(bid, buff_man), mode, req});
+			const auto req = bam.get_mode_requirements(bid, mode, dims, exec_range, global_size);
+			ret.push_back({bid, mode, req});
 		}
 	}
 	return ret;
 }
 
-reduction_list build_reduction_list(const task& tsk, const buffer_manager* buff_man) {
+access_list build_access_list(const task& tsk) {
+	return build_access_list(
+	    tsk.get_buffer_access_map(), tsk.get_dimensions(), tsk.get_global_size(), subrange<3>{tsk.get_global_offset(), tsk.get_global_size()});
+}
+
+reduction_list build_reduction_list(const task& tsk) {
 	reduction_list ret;
 	for(const auto& reduction : tsk.get_reductions()) {
-		ret.push_back({reduction.rid, reduction.bid, get_buffer_name(reduction.bid, buff_man), reduction.init_from_buffer});
+		ret.push_back({reduction.rid, reduction.bid, reduction.init_from_buffer});
 	}
 	return ret;
 }
@@ -43,14 +37,10 @@ task_dependency_list build_task_dependency_list(const task& tsk) {
 	return ret;
 }
 
-task_record::task_record(const task& from, const buffer_manager* buff_mngr)
+task_record::task_record(const task& from)
     : tid(from.get_id()), debug_name(utils::simplify_task_name(from.get_debug_name())), cgid(from.get_collective_group_id()), type(from.get_type()),
-      geometry(from.get_geometry()), reductions(build_reduction_list(from, buff_mngr)), accesses(build_access_list(from, buff_mngr)),
-      side_effect_map(from.get_side_effect_map()), dependencies(build_task_dependency_list(from)) {}
-
-void task_recorder::record_task(const task& tsk) { //
-	m_recorded_tasks.emplace_back(tsk, m_buff_mngr);
-}
+      geometry(from.get_geometry()), reductions(build_reduction_list(from)), accesses(build_access_list(from)), side_effect_map(from.get_side_effect_map()),
+      dependencies(build_task_dependency_list(from)) {}
 
 // Commands
 
@@ -90,11 +80,6 @@ std::optional<buffer_id> get_buffer_id(const abstract_command& cmd) {
 	return {};
 }
 
-std::string get_cmd_buffer_name(const std::optional<buffer_id>& bid, const buffer_manager* buff_mngr) {
-	if(buff_mngr == nullptr || !bid.has_value()) return "";
-	return get_buffer_name(bid.value(), buff_mngr);
-}
-
 std::optional<node_id> get_target(const abstract_command& cmd) {
 	if(const auto* push_cmd = dynamic_cast<const push_command*>(&cmd)) return push_cmd->get_target();
 	return {};
@@ -121,41 +106,16 @@ std::optional<task_id> get_task_id(const abstract_command& cmd) {
 	return {};
 }
 
-const task* get_task_for(const abstract_command& cmd, const task_manager* task_mngr) {
-	if(const auto* task_cmd = dynamic_cast<const task_command*>(&cmd)) {
-		if(task_mngr != nullptr) {
-			assert(task_mngr->has_task(task_cmd->get_tid()));
-			return task_mngr->get_task(task_cmd->get_tid());
-		}
-	}
-	return nullptr;
-}
-
-std::optional<task_geometry> get_task_geometry(const abstract_command& cmd, const task_manager* task_mngr) {
-	if(const auto* tsk = get_task_for(cmd, task_mngr)) return tsk->get_geometry();
-	return {};
-}
-
 bool get_is_reduction_initializer(const abstract_command& cmd) {
 	if(const auto* execution_cmd = dynamic_cast<const execution_command*>(&cmd)) return execution_cmd->is_reduction_initializer();
 	return false;
 }
 
-access_list build_cmd_access_list(const abstract_command& cmd, const task_manager* task_mngr, const buffer_manager* buff_man) {
-	if(const auto* tsk = get_task_for(cmd, task_mngr)) {
+access_list build_cmd_access_list(const abstract_command& cmd, const task* tsk) {
+	if(tsk != nullptr) {
 		const auto execution_range = get_execution_range(cmd).value_or(subrange<3>{tsk->get_global_offset(), tsk->get_global_size()});
-		return build_access_list(*tsk, buff_man, execution_range);
+		return build_access_list(tsk->get_buffer_access_map(), tsk->get_dimensions(), tsk->get_global_size(), execution_range);
 	}
-	return {};
-}
-
-reduction_list build_cmd_reduction_list(const abstract_command& cmd, const task_manager* task_mngr, const buffer_manager* buff_man) {
-	if(const auto* tsk = get_task_for(cmd, task_mngr)) return build_reduction_list(*tsk, buff_man);
-	return {};
-}
-
-side_effect_map get_side_effects(const abstract_command& cmd, const task_manager* task_mngr) {
-	if(const auto* tsk = get_task_for(cmd, task_mngr)) return tsk->get_side_effect_map();
 	return {};
 }
 
@@ -167,32 +127,11 @@ command_dependency_list build_command_dependency_list(const abstract_command& cm
 	return ret;
 }
 
-std::string get_task_name(const abstract_command& cmd, const task_manager* task_mngr) {
-	if(const auto* tsk = get_task_for(cmd, task_mngr)) return utils::simplify_task_name(tsk->get_debug_name());
-	return {};
-}
-
-std::optional<task_type> get_task_type(const abstract_command& cmd, const task_manager* task_mngr) {
-	if(const auto* tsk = get_task_for(cmd, task_mngr)) return tsk->get_type();
-	return {};
-}
-
-std::optional<collective_group_id> get_collective_group_id(const abstract_command& cmd, const task_manager* task_mngr) {
-	if(const auto* tsk = get_task_for(cmd, task_mngr)) return tsk->get_collective_group_id();
-	return {};
-}
-
-command_record::command_record(const abstract_command& cmd, const task_manager* task_mngr, const buffer_manager* buff_mngr)
+command_record::command_record(const abstract_command& cmd, const task* tsk)
     : cid(cmd.get_cid()), type(get_command_type(cmd)), epoch_action(get_epoch_action(cmd)), execution_range(get_execution_range(cmd)),
-      reduction_id(get_reduction_id(cmd)), buffer_id(get_buffer_id(cmd)), buffer_name(get_cmd_buffer_name(buffer_id, buff_mngr)), target(get_target(cmd)),
-      await_region(get_await_region(cmd)), push_range(get_push_range(cmd)), transfer_id(get_transfer_id(cmd)), task_id(get_task_id(cmd)),
-      task_geometry(get_task_geometry(cmd, task_mngr)), is_reduction_initializer(get_is_reduction_initializer(cmd)),
-      accesses(build_cmd_access_list(cmd, task_mngr, buff_mngr)), reductions(build_cmd_reduction_list(cmd, task_mngr, buff_mngr)),
-      side_effects(get_side_effects(cmd, task_mngr)), dependencies(build_command_dependency_list(cmd)), task_name(get_task_name(cmd, task_mngr)),
-      task_type(get_task_type(cmd, task_mngr)), collective_group_id(get_collective_group_id(cmd, task_mngr)) {}
-
-void command_recorder::record_command(const abstract_command& com) { //
-	m_recorded_commands.emplace_back(com, m_task_mngr, m_buff_mngr);
+      reduction_id(get_reduction_id(cmd)), buffer_id(get_buffer_id(cmd)), target(get_target(cmd)), await_region(get_await_region(cmd)),
+      push_range(get_push_range(cmd)), transfer_id(get_transfer_id(cmd)), task_id(get_task_id(cmd)),
+      is_reduction_initializer(get_is_reduction_initializer(cmd)), accesses(build_cmd_access_list(cmd, tsk)), dependencies(build_command_dependency_list(cmd)) {
 }
 
 } // namespace celerity::detail

--- a/test/dag_benchmarks.cc
+++ b/test/dag_benchmarks.cc
@@ -163,7 +163,7 @@ struct graph_generator_benchmark_context {
 	test_utils::mock_buffer_factory mbf;
 
 	explicit graph_generator_benchmark_context(size_t num_nodes)
-	    : num_nodes{num_nodes}, crec(&tm), dggen{num_nodes, 0 /* local_nid */, cdag, tm, test_utils::print_graphs ? &crec : nullptr}, mbf{tm, dggen} {
+	    : num_nodes{num_nodes}, dggen{num_nodes, 0 /* local_nid */, cdag, tm, test_utils::print_graphs ? &crec : nullptr}, mbf{tm, dggen} {
 		tm.register_task_callback([this](const task* tsk) {
 			const auto cmds = dggen.build_task(*tsk);
 			gser.flush(cmds);
@@ -469,9 +469,11 @@ void debug_graphs(BenchmarkContextFactory&& make_ctx, BenchmarkContextConsumer&&
 }
 
 TEST_CASE("printing benchmark task graphs", "[.][debug-graphs][task-graph]") {
-	debug_graphs([] { return task_manager_benchmark_context{}; }, [](auto&& ctx) { test_utils::maybe_print_task_graph(ctx.trec); });
+	debug_graphs(
+	    [] { return task_manager_benchmark_context{}; }, [](auto&& ctx) { test_utils::maybe_print_task_graph(ctx.trec, ctx.mbf.get_buffer_recorder()); });
 }
 
 TEST_CASE("printing benchmark command graphs", "[.][debug-graphs][command-graph]") {
-	debug_graphs([] { return graph_generator_benchmark_context{2}; }, [](auto&& ctx) { test_utils::maybe_print_command_graph(0, ctx.crec); });
+	debug_graphs([] { return graph_generator_benchmark_context{2}; },
+	    [](auto&& ctx) { test_utils::maybe_print_command_graph(0, ctx.crec, ctx.trec, ctx.mbf.get_buffer_recorder()); });
 }

--- a/test/print_graph_tests.cc
+++ b/test/print_graph_tests.cc
@@ -49,7 +49,7 @@ TEST_CASE("task-graph printing is unchanged", "[print_graph][task-graph]") {
 	    "<i>read_write</i> B1 {[0,0,0] - [1,1,1]}<br/><i>read</i> B0 {[0,0,0] - [64,1,1]}>];1->3[];2->3[];4[shape=box style=rounded label=<T4 "
 	    "\"task_consume_5\" <br/><b>device-compute</b> [0,0,0] + [64,1,1]<br/><i>read</i> B1 {[0,0,0] - [1,1,1]}>];3->4[];}";
 
-	CHECK(print_task_graph(tt.trec) == expected);
+	CHECK(print_task_graph(tt.trec, tt.mbf.get_buffer_recorder()) == expected);
 }
 
 namespace {
@@ -114,7 +114,7 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "buffer debug names show up in the
 	CHECK(celerity::debug::get_buffer_name(buff_a) == buff_name);
 
 	q.submit([&](handler& cgh) {
-		celerity::accessor acc_a{buff_a, cgh, acc::all{}, celerity::write_only};
+		celerity::accessor acc_a{buff_a, cgh, acc::one_to_one{}, celerity::write_only, celerity::no_init};
 		cgh.parallel_for<class UKN(print_graph_buffer_name)>(range, [=](item<1> item) { (void)acc_a; });
 	});
 
@@ -203,5 +203,5 @@ TEST_CASE("task-graph names are escaped", "[print_graph][task-graph][task-name]"
 	    tt.tm, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, acc::one_to_one{}); }, range);
 
 	const auto* escaped_name = "\"name_class&lt;...&gt;\"";
-	REQUIRE_THAT(print_task_graph(tt.trec), Catch::Matchers::ContainsSubstring(escaped_name));
+	REQUIRE_THAT(print_task_graph(tt.trec, tt.mbf.get_buffer_recorder()), Catch::Matchers::ContainsSubstring(escaped_name));
 }


### PR DESCRIPTION
This PR is a clean-up refactoring for parts of #197, and A back-port from the instruction graph branch which will remove `buffer_manager` and extend the recording / printing infrastructure further.

- Adds `buffer_recorder` for buffer-debug-name tracking (so we don't have to ask `buffer_manager`)
- Passes `buffer_recorder` into `print_task_graph` / `print_command_graph`, and `task_recorder` into `print_command_graph`, thereby removing duplicate information from records
