### PR TITLE
Stabilize experimental::fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Introduce new experimental `for_each_item` utility to iterate over a celerity range (#199)
 - Add new environment variables `CELERITY_HORIZON_STEP` and `CELERITY_HORIZON_MAX_PARALLELISM` to control Horizon generation (#199)
 - Add new `experimental::constrain_split` API to limit how a kernel can be split (#?)
+- `distr_queue::fence` and `buffer_snapshot` are now stable, subsuming the `experimental::` APIs of the same name (#225)
 
 ## Changed
 

--- a/docs/issues-and-limitations.md
+++ b/docs/issues-and-limitations.md
@@ -36,7 +36,7 @@ for (;;) {
             [=](celerity::item<1> item, auto& err) { err += ...; });
     });
     // `fence` will capture buffer contents once all writes have completed
-    auto future = celerity::experimental::fence(q, error);
+    auto future = q.fence(error);
     // optionally submit more work here to avoid stalling the async execution
     const float err = *future.get();
     if (err < epsilon) break;

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -116,9 +116,9 @@ void some_function(celerity::distr_queue& q) {
 }
 ```
 
-> Celerity supports experimental APIs that can replace most if not all uses for reference captures.
-> See `celerity::experimental::host_object`, `celerity::experimental::side_effect` and
-> `celerity::experimental::fence`.
+> Celerity supports APIs that can replace most if not all uses for reference captures.
+> See `celerity::distr_queue::fence`, `celerity::experimental::host_object` and
+> `celerity::experimental::side_effect`.
 
 ## Diverging Host-Execution on Different Nodes
 

--- a/examples/distr_io/distr_io.cc
+++ b/examples/distr_io/distr_io.cc
@@ -153,7 +153,7 @@ int main(int argc, char* argv[]) {
 			});
 		});
 
-		const bool files_equal = *celerity::experimental::fence(q, equal).get();
+		const bool files_equal = *q.fence(equal).get();
 		fmt::print(stderr, "=> Files are {}equal\n", files_equal ? "" : "NOT ");
 		return files_equal ? EXIT_SUCCESS : EXIT_FAILURE;
 	}

--- a/examples/hello_world/hello_world.cc
+++ b/examples/hello_world/hello_world.cc
@@ -14,6 +14,6 @@ int main() {
 		cgh.parallel_for(str_buffer.get_range(), [=](celerity::item<1> item) { str_acc[item] -= 1; });
 	});
 
-	auto output = celerity::experimental::fence(queue, str_buffer);
+	auto output = queue.fence(str_buffer);
 	std::cout << output.get().get_data() << std::endl;
 }

--- a/examples/matmul/matmul.cc
+++ b/examples/matmul/matmul.cc
@@ -107,6 +107,6 @@ int main() {
 	verify(queue, mat_a_buf, passed_obj);
 
 	// The value of `passed` can differ between hosts if only part of the verification failed.
-	const bool passed = celerity::experimental::fence(queue, passed_obj).get();
+	const bool passed = queue.fence(passed_obj).get();
 	return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -1257,7 +1257,7 @@ namespace detail {
 			cgh.host_task(on_master_node, [=] { acc = true; });
 		});
 
-		auto ret = experimental::fence(q, buf);
+		auto ret = q.fence(buf);
 		REQUIRE(ret.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
 		CHECK_FALSE(*ret.get()); // extra check that the task was not actually executed
 
@@ -1366,13 +1366,13 @@ namespace detail {
 			experimental::side_effect e(ho, cgh);
 			cgh.host_task(on_master_node, [=] { *e = 2; });
 		});
-		auto v2 = experimental::fence(q, ho);
+		auto v2 = q.fence(ho);
 
 		q.submit([&](handler& cgh) {
 			experimental::side_effect e(ho, cgh);
 			cgh.host_task(on_master_node, [=] { *e = 3; });
 		});
-		auto v3 = experimental::fence(q, ho);
+		auto v3 = q.fence(ho);
 
 		CHECK(v2.get() == 2);
 		CHECK(v3.get() == 3);
@@ -1388,7 +1388,7 @@ namespace detail {
 		});
 
 		const auto check_snapshot = [&](const subrange<2>& sr, const std::vector<int>& expected_data) {
-			const auto snapshot = experimental::fence(q, buf, sr).get();
+			const auto snapshot = q.fence(buf, sr).get();
 			CHECK(snapshot.get_subrange() == sr);
 			CHECK(memcmp(snapshot.get_data(), expected_data.data(), expected_data.size() * sizeof(int)) == 0);
 		};
@@ -1412,7 +1412,7 @@ namespace detail {
 			cgh.parallel_for<class UKN(init)>(buf.get_range(), [=](celerity::item<0> item) { *acc = 42; });
 		});
 
-		const auto snapshot = experimental::fence(q, buf).get();
+		const auto snapshot = q.fence(buf).get();
 		CHECK(*snapshot == 42);
 	}
 

--- a/test/system/distr_tests.cc
+++ b/test/system/distr_tests.cc
@@ -362,8 +362,8 @@ namespace detail {
 			cgh.host_task(on_master_node, [=] { acc[{1, 2, 3}] = 42; });
 		});
 
-		const auto gathered_from_master = experimental::fence(q, buf, subrange<3>({1, 2, 3}, {1, 1, 1})).get();
-		const auto host_rank = experimental::fence(q, obj).get();
+		const auto gathered_from_master = q.fence(buf, subrange<3>({1, 2, 3}, {1, 1, 1})).get();
+		const auto host_rank = q.fence(obj).get();
 
 		REQUIRE(gathered_from_master.get_range() == range<3>{1, 1, 1});
 		CHECK(gathered_from_master[0][0][0] == 42);

--- a/test/system_benchmarks.cc
+++ b/test/system_benchmarks.cc
@@ -65,7 +65,7 @@ TEMPLATE_TEST_CASE_METHOD_SIG(
 			});
 		});
 	});
-	CHECK(*experimental::fence(queue, success_buffer).get() == true);
+	CHECK(*queue.fence(success_buffer).get() == true);
 }
 
 TEMPLATE_TEST_CASE_METHOD_SIG(
@@ -135,5 +135,5 @@ TEMPLATE_TEST_CASE_METHOD_SIG(
 			});
 		});
 	});
-	CHECK(*experimental::fence(queue, success_buffer).get() == true);
+	CHECK(*queue.fence(success_buffer).get() == true);
 }


### PR DESCRIPTION
`celerity::experimental::fence` and `celerity::experimental::buffer_snapshot` are now `celerity::distr_queue::fence` (a member function) and `celerity::buffer_snapshot`. The experimental declarations are aliases of the new names, and a _deprecation test_ ensures they still work.

I have decided to keep the `fence` header since the definitions of `buffer_snapshot` and `*_fence_promise` don't fit into what I believe should be `distr_queue.h`.

Closes celerity/meta#69.