### PR TITLE
Add experimental task hints API, support for 2D splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - `distr_queue::fence` and `buffer_snapshot` are now stable, subsuming the `experimental::` APIs of the same name (#225)
 - Celerity now warns at runtime when a task declares reads from uninitialized buffers or writes with overlapping ranges between nodes (#224)
 - Introduce new `experimental::hint` API for providing the runtime with additional information on how to execute a task (#227)
+- Introduce new `experimental::hints::split_1d` and `experimental::hints::split_2d` task hints for controlling how a task is split into chunks (#227)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add new `experimental::constrain_split` API to limit how a kernel can be split (#?)
 - `distr_queue::fence` and `buffer_snapshot` are now stable, subsuming the `experimental::` APIs of the same name (#225)
 - Celerity now warns at runtime when a task declares reads from uninitialized buffers or writes with overlapping ranges between nodes (#224)
+- Introduce new `experimental::hint` API for providing the runtime with additional information on how to execute a task (#227)
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ set(SOURCES
   src/recorders.cc
   src/runtime.cc
   src/scheduler.cc
+  src/split.cc
   src/task.cc
   src/task_manager.cc
   src/user_bench.cc

--- a/include/hint.h
+++ b/include/hint.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace celerity {
+class handler;
+}
+
+// Definition is in handler.h to avoid circular dependency
+namespace celerity::experimental {
+template <typename Hint>
+void hint(handler& cgh, Hint&& hint);
+}
+
+namespace celerity::detail {
+
+class hint_base {
+  public:
+	hint_base() = default;
+	hint_base(const hint_base&) = default;
+	hint_base& operator=(const hint_base&) = default;
+	hint_base(hint_base&&) = default;
+	hint_base& operator=(hint_base&&) = default;
+	virtual ~hint_base() = default;
+
+  private:
+	friend class celerity::handler;
+	virtual void validate(const hint_base& other) const {}
+};
+
+} // namespace celerity::detail
+
+namespace celerity::experimental::hints {}; // namespace celerity::experimental::hints

--- a/include/hint.h
+++ b/include/hint.h
@@ -32,4 +32,31 @@ class hint_base {
 
 } // namespace celerity::detail
 
-namespace celerity::experimental::hints {}; // namespace celerity::experimental::hints
+namespace celerity::experimental::hints {
+
+/**
+ * Suggests that the task should be split into 1D chunks.
+ * This is currently the default behavior.
+ */
+class split_1d : public detail::hint_base {
+  private:
+	void validate(const hint_base& other) const override;
+};
+
+/**
+ * Suggests that the task should be split into 2D chunks.
+ */
+class split_2d : public detail::hint_base {
+  private:
+	void validate(const hint_base& other) const override;
+};
+
+inline void split_1d::validate(const hint_base& other) const {
+	if(dynamic_cast<const split_2d*>(&other) != nullptr) { throw std::runtime_error("Cannot combine split_1d and split_2d hints"); }
+}
+
+inline void split_2d::validate(const hint_base& other) const {
+	if(dynamic_cast<const split_1d*>(&other) != nullptr) { throw std::runtime_error("Cannot combine split_1d and split_2d hints"); }
+}
+
+}; // namespace celerity::experimental::hints

--- a/include/split.h
+++ b/include/split.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <vector>
+
+#include "ranges.h"
+
+namespace celerity::detail {
+
+std::vector<chunk<3>> split_1d(const chunk<3>& full_chunk, const range<3>& granularity, const size_t num_chunks);
+std::vector<chunk<3>> split_2d(const chunk<3>& full_chunk, const range<3>& granularity, const size_t num_chunks);
+
+} // namespace celerity::detail

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -68,8 +68,8 @@ namespace detail {
 
 		virtual ~task_manager() = default;
 
-		template <typename CGF, typename... Hints>
-		task_id submit_command_group(CGF cgf, Hints... hints) {
+		template <typename CGF>
+		task_id submit_command_group(CGF cgf) {
 			auto reservation = m_task_buffer.reserve_task_entry(await_free_task_slot_callback());
 			const auto tid = reservation.get_tid();
 

--- a/src/split.cc
+++ b/src/split.cc
@@ -1,0 +1,166 @@
+#include "split.h"
+
+#include <array>
+#include <tuple>
+
+#include "grid.h"
+
+namespace {
+
+using namespace celerity;
+using namespace celerity::detail;
+
+[[maybe_unused]] void sanity_check_split(const chunk<3>& full_chunk, const std::vector<chunk<3>>& split) {
+	region<3> reconstructed_chunk;
+	for(auto& chnk : split) {
+		assert(region_intersection(reconstructed_chunk, box<3>(chnk)).empty());
+		reconstructed_chunk = region_union(box<3>(chnk), reconstructed_chunk);
+	}
+	assert(region_difference(reconstructed_chunk, box<3>(full_chunk)).empty());
+}
+
+template <int Dims>
+std::tuple<range<Dims>, range<Dims>, range<Dims>> compute_small_and_large_chunks(
+    const chunk<3>& full_chunk, const range<3>& granularity, const std::array<size_t, Dims>& actual_num_chunks) {
+	range<Dims> small_chunk_size{zeros};
+	range<Dims> large_chunk_size{zeros};
+	range<Dims> num_large_chunks{zeros};
+	for(int d = 0; d < Dims; ++d) {
+		const size_t ideal_chunk_size = full_chunk.range[d] / actual_num_chunks[d];
+		small_chunk_size[d] = (ideal_chunk_size / granularity[d]) * granularity[d];
+		large_chunk_size[d] = small_chunk_size[d] + granularity[d];
+		num_large_chunks[d] = (full_chunk.range[d] - small_chunk_size[d] * actual_num_chunks[d]) / granularity[d];
+	}
+	return {small_chunk_size, large_chunk_size, num_large_chunks};
+}
+
+/**
+ * Given a factorization of `num_chunks` (i.e., `f0 * f1 = num_chunks`), try to find the assignment of factors to
+ * dimensions that produces more chunks under the given constraints. If they are tied, try to find the assignment
+ * that results in a "nicer" split according to some heuristics (see below).
+ *
+ * The single argument `factor` specifies both factors, as `f0 = factor` and `f1 = num_chunks / factor`.
+ *
+ * @returns The number of chunks that can be created in dimension 0 and dimension 1, respectively. These are at most
+ *          (f0, f1) or (f1, f0), however may be less if constrained by the split granularity.
+ */
+std::array<size_t, 2> assign_split_factors_2d(const chunk<3>& full_chunk, const range<3>& granularity, const size_t factor, const size_t num_chunks) {
+	assert(num_chunks % factor == 0);
+	const size_t max_chunks[2] = {full_chunk.range[0] / granularity[0], full_chunk.range[1] / granularity[1]};
+	const size_t f0 = factor;
+	const size_t f1 = num_chunks / factor;
+
+	// Decide in which direction to split by first checking which
+	// factor assignment produces more chunks under the given constraints.
+	const std::array<size_t, 2> split_0_1 = {std::min(f0, max_chunks[0]), std::min(f1, max_chunks[1])};
+	const std::array<size_t, 2> split_1_0 = {std::min(f1, max_chunks[0]), std::min(f0, max_chunks[1])};
+	const auto count0 = split_0_1[0] * split_0_1[1];
+	const auto count1 = split_1_0[0] * split_1_0[1];
+
+	if(count0 > count1) { return split_0_1; }
+	if(count0 < count1) { return split_1_0; }
+
+	// If we're tied for the number of chunks we can create, try some heuristics to decide.
+
+	// If domain is square(-ish), prefer splitting along slower dimension.
+	// (These bounds have been chosen arbitrarily!)
+	const double squareishness = std::sqrt(full_chunk.range.size()) / static_cast<double>(full_chunk.range[0]);
+	if(squareishness > 0.95 && squareishness < 1.05) { return (f0 >= f1) ? split_0_1 : split_1_0; }
+
+	// For non-square domains, prefer split that produces shorter edges (compare sum of circumferences)
+	const auto circ0 = full_chunk.range[0] / split_0_1[0] + full_chunk.range[1] / split_0_1[1];
+	const auto circ1 = full_chunk.range[0] / split_1_0[0] + full_chunk.range[1] / split_1_0[1];
+	return circ0 < circ1 ? split_0_1 : split_1_0;
+
+	// TODO: Yet another heuristic we may want to consider is how even chunk sizes are,
+	// i.e., how balanced the workload is.
+}
+
+} // namespace
+
+namespace celerity::detail {
+
+std::vector<chunk<3>> split_1d(const chunk<3>& full_chunk, const range<3>& granularity, const size_t num_chunks) {
+#ifndef NDEBUG
+	assert(num_chunks > 0);
+	for(int d = 0; d < 3; ++d) {
+		assert(granularity[d] > 0);
+		assert(full_chunk.range[d] % granularity[d] == 0);
+	}
+#endif
+
+	// Due to split granularity requirements or if num_workers > global_size[0],
+	// we may not be able to create the requested number of chunks.
+	const std::array<size_t, 1> actual_num_chunks = {std::min(num_chunks, full_chunk.range[0] / granularity[0])};
+	const auto [small_chunk_size, large_chunk_size, num_large_chunks] = compute_small_and_large_chunks<1>(full_chunk, granularity, actual_num_chunks);
+
+	std::vector<chunk<3>> result(actual_num_chunks[0], {full_chunk.offset, full_chunk.range, full_chunk.global_size});
+	for(auto i = 0u; i < num_large_chunks[0]; ++i) {
+		result[i].range[0] = large_chunk_size[0];
+		result[i].offset[0] += i * large_chunk_size[0];
+	}
+	for(auto i = num_large_chunks[0]; i < actual_num_chunks[0]; ++i) {
+		result[i].range[0] = small_chunk_size[0];
+		result[i].offset[0] += num_large_chunks[0] * large_chunk_size[0] + (i - num_large_chunks[0]) * small_chunk_size[0];
+	}
+
+#ifndef NDEBUG
+	sanity_check_split(full_chunk, result);
+#endif
+
+	return result;
+}
+
+// TODO: Make the split dimensions configurable for 3D chunks?
+std::vector<chunk<3>> split_2d(const chunk<3>& full_chunk, const range<3>& granularity, const size_t num_chunks) {
+#ifndef NDEBUG
+	assert(num_chunks > 0);
+	for(int d = 0; d < 3; ++d) {
+		assert(granularity[d] > 0);
+		assert(full_chunk.range[d] % granularity[d] == 0);
+	}
+#endif
+
+	// Factorize num_chunks
+	// We start out with an initial guess of `factor = floor(sqrt(num_chunks))` (the other one is implicitly given by `num_chunks / factor`),
+	// and work our way down, keeping track of the best factorization we've found so far, until we find a factorization that produces
+	// the requested number of chunks, or until we reach (1, num_chunks), i.e., a 1D split.
+	size_t factor = std::floor(std::sqrt(num_chunks));
+	std::array<size_t, 2> best_chunk_counts = {0, 0};
+	while(factor >= 1) {
+		while(factor > 1 && num_chunks % factor != 0) {
+			factor--;
+		}
+		// The returned counts are at most (factor, num_chunks / factor), however may be less if constrained by the split granularity.
+		const auto chunk_counts = assign_split_factors_2d(full_chunk, granularity, factor, num_chunks);
+		if(chunk_counts[0] * chunk_counts[1] > best_chunk_counts[0] * best_chunk_counts[1]) { best_chunk_counts = chunk_counts; }
+		if(chunk_counts[0] * chunk_counts[1] == num_chunks) { break; }
+		factor--;
+	}
+	const auto actual_num_chunks = best_chunk_counts;
+	const auto [small_chunk_size, large_chunk_size, num_large_chunks] = compute_small_and_large_chunks<2>(full_chunk, granularity, actual_num_chunks);
+
+	std::vector<chunk<3>> result(actual_num_chunks[0] * actual_num_chunks[1], {full_chunk.offset, full_chunk.range, full_chunk.global_size});
+	id<3> offset = full_chunk.offset;
+
+	for(size_t j = 0; j < actual_num_chunks[0]; ++j) {
+		range<2> chunk_size = {(j < num_large_chunks[0]) ? large_chunk_size[0] : small_chunk_size[0], 0};
+		for(size_t i = 0; i < actual_num_chunks[1]; ++i) {
+			chunk_size[1] = (i < num_large_chunks[1]) ? large_chunk_size[1] : small_chunk_size[1];
+			auto& chnk = result[j * actual_num_chunks[1] + i];
+			chnk.offset = offset;
+			chnk.range[0] = chunk_size[0];
+			chnk.range[1] = chunk_size[1];
+			offset[1] += chunk_size[1];
+		}
+		offset[0] += chunk_size[0];
+		offset[1] = full_chunk.offset[1];
+	}
+
+#ifndef NDEBUG
+	sanity_check_split(full_chunk, result);
+#endif
+
+	return result;
+}
+} // namespace celerity::detail

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_TARGETS
   graph_gen_transfer_tests
   graph_compaction_tests
   grid_tests
+  hint_tests
   intrusive_graph_tests
   print_graph_tests
   region_map_tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TEST_TARGETS
   runtime_tests
   runtime_deprecation_tests
   sycl_tests
+  split_tests
   task_graph_tests
   task_ring_buffer_tests
   test_utils_tests

--- a/test/distributed_graph_generator_test_utils.h
+++ b/test/distributed_graph_generator_test_utils.h
@@ -85,6 +85,11 @@ class task_builder {
 			return chain<step>([constraint](handler& cgh) { experimental::constrain_split(cgh, constraint); });
 		}
 
+		template <typename Hint>
+		step hint(Hint hint) {
+			return chain<step>([&hint](handler& cgh) { experimental::hint(cgh, hint); });
+		}
+
 	  private:
 		dist_cdag_test_context& m_dctx;
 		std::deque<action> m_actions;

--- a/test/graph_gen_granularity_tests.cc
+++ b/test/graph_gen_granularity_tests.cc
@@ -74,6 +74,16 @@ TEST_CASE("distributed_graph_generator respects split constraints", "[distribute
 	CHECK(dynamic_cast<const execution_command*>(dctx.query(tid_b).get_raw(1)[0])->get_execution_range().range == range<3>{96, 1, 1});
 }
 
+TEST_CASE("distributed_graph_generator creates 2-dimensional chunks when providing the split_2d hint", "[distributed_graph_generator][split][task-hints]") {
+	const size_t num_nodes = 4;
+	dist_cdag_test_context dctx(num_nodes);
+	const auto tid_a = dctx.device_compute<class UKN(task)>(range<2>{128, 128}).hint(experimental::hints::split_2d{}).submit();
+	REQUIRE(dctx.query(tid_a).count() == 4);
+	for(node_id nid = 0; nid < 4; ++nid) {
+		CHECK(dynamic_cast<const execution_command*>(dctx.query(tid_a).get_raw(nid)[0])->get_execution_range().range == range<3>{64, 64, 1});
+	}
+}
+
 template <int Dims>
 class simple_task;
 

--- a/test/hint_tests.cc
+++ b/test/hint_tests.cc
@@ -1,0 +1,57 @@
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include <celerity.h>
+
+#include "test_utils.h"
+
+using namespace celerity;
+using namespace celerity::detail;
+
+class my_hint : public detail::hint_base {
+  public:
+	my_hint(int value) : m_value(value) {}
+	int get_value() const { return m_value; }
+
+  private:
+	int m_value;
+};
+
+class my_other_hint : public detail::hint_base {
+  private:
+	void validate(const hint_base& other) const override {
+		if(auto ptr = dynamic_cast<const my_hint*>(&other); ptr != nullptr) {
+			if(ptr->get_value() != 1337) throw std::runtime_error("not leet enough");
+		}
+	}
+};
+
+TEST_CASE_METHOD(test_utils::runtime_fixture, "hints can be attached to and retrieved from tasks", "[task-hints]") {
+	celerity::runtime::init(nullptr, nullptr);
+	auto& tm = detail::runtime::get_instance().get_task_manager();
+	const auto tid = test_utils::add_compute_task<class UKN(hint_task)>(tm, [&](handler& cgh) { experimental::hint(cgh, my_hint{1337}); });
+	const auto tsk = tm.get_task(tid);
+	const auto hint = tsk->get_hint<my_hint>();
+	REQUIRE(hint != nullptr);
+	CHECK(hint->get_value() == 1337);
+}
+
+TEST_CASE_METHOD(test_utils::runtime_fixture, "providing a hint of a particular type more than once throws", "[task-hints]") {
+	celerity::runtime::init(nullptr, nullptr);
+	auto& tm = detail::runtime::get_instance().get_task_manager();
+	test_utils::add_compute_task<class UKN(hint_task)>(tm, [&](handler& cgh) {
+		CHECK_NOTHROW(experimental::hint(cgh, my_hint{1337}));
+		CHECK_NOTHROW(experimental::hint(cgh, my_other_hint{}));
+		CHECK_THROWS_WITH(experimental::hint(cgh, my_hint{1337}), "Providing more than one hint of the same type is not allowed");
+	});
+}
+
+TEST_CASE_METHOD(test_utils::runtime_fixture, "hints can ensure combinations with other hints are valid", "[task-hints]") {
+	celerity::runtime::init(nullptr, nullptr);
+	auto& tm = detail::runtime::get_instance().get_task_manager();
+	test_utils::add_compute_task<class UKN(hint_task)>(tm, [&](handler& cgh) {
+		CHECK_NOTHROW(experimental::hint(cgh, my_other_hint{}));
+		CHECK_THROWS_WITH(experimental::hint(cgh, my_hint{1336}), "not leet enough");
+	});
+}

--- a/test/hint_tests.cc
+++ b/test/hint_tests.cc
@@ -55,3 +55,20 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "hints can ensure combinations wit
 		CHECK_THROWS_WITH(experimental::hint(cgh, my_hint{1336}), "not leet enough");
 	});
 }
+
+TEST_CASE_METHOD(test_utils::runtime_fixture, "split_1d and split_2d hints cannot be combined", "[task-hints]") {
+	celerity::runtime::init(nullptr, nullptr);
+	auto& tm = detail::runtime::get_instance().get_task_manager();
+	SECTION("1d then 2d") {
+		test_utils::add_compute_task<class UKN(hint_task)>(tm, [&](handler& cgh) {
+			CHECK_NOTHROW(experimental::hint(cgh, experimental::hints::split_1d{}));
+			CHECK_THROWS_WITH(experimental::hint(cgh, experimental::hints::split_2d{}), "Cannot combine split_1d and split_2d hints");
+		});
+	}
+	SECTION("2d then 1d") {
+		test_utils::add_compute_task<class UKN(hint_task)>(tm, [&](handler& cgh) {
+			CHECK_NOTHROW(experimental::hint(cgh, experimental::hints::split_2d{}));
+			CHECK_THROWS_WITH(experimental::hint(cgh, experimental::hints::split_1d{}), "Cannot combine split_1d and split_2d hints");
+		});
+	}
+}

--- a/test/split_tests.cc
+++ b/test/split_tests.cc
@@ -1,0 +1,306 @@
+#include <unordered_set>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+#include "test_utils.h"
+
+#include "split.h"
+
+using namespace celerity;
+using namespace celerity::detail;
+
+namespace {
+
+template <int Dims>
+chunk<3> make_full_chunk(range<Dims> range) {
+	return {id<3>{}, range_cast<3>(range), range_cast<3>(range)};
+}
+
+void check_1d_split(const chunk<3>& full_chunk, const std::vector<chunk<3>>& split_chunks, const std::vector<size_t>& chunk_ranges) {
+	REQUIRE(split_chunks.size() == chunk_ranges.size());
+	id<3> offset = full_chunk.offset;
+	for(size_t i = 0; i < split_chunks.size(); ++i) {
+		const auto& chnk = split_chunks[i];
+		REQUIRE_LOOP(chnk.offset == offset);
+		REQUIRE_LOOP(chnk.range[0] == chunk_ranges[i]);
+		REQUIRE_LOOP(chnk.global_size == full_chunk.global_size);
+		offset[0] += split_chunks[i].range[0];
+	}
+}
+
+/**
+ * Checks whether a split conforms to a given set of expected ranges and offsets.
+ *
+ * Note: The following assumes the convention that dimension 0 specifies a "row" or "height",
+ *       while dimension 1 specifies a "column" or "width".
+ *
+ * The expected ranges are specified in a "visual" representation of the form
+ *
+ * {
+ *  { height_0, { width_0, width_1, ..., width_N }},
+ *  ...
+ *  { height_N, { width_0, width_1, ..., width_N }}
+ * },
+ *
+ * where height_i refers to the height shared by all chunks within this row, and width_i refers
+ * to the width of an individual chunk.
+ */
+void check_2d_split(
+    const chunk<3>& full_chunk, const std::vector<chunk<3>>& split_chunks, const std::vector<std::pair<size_t, std::vector<size_t>>>& chunk_ranges) {
+	REQUIRE(split_chunks.size() == std::accumulate(chunk_ranges.begin(), chunk_ranges.end(), size_t(0), [](size_t c, auto& p) { return c + p.second.size(); }));
+	REQUIRE(std::all_of(chunk_ranges.begin(), chunk_ranges.end(), [&](auto& p) { return p.second.size() == chunk_ranges[0].second.size(); }));
+	id<3> offset = full_chunk.offset;
+	for(size_t j = 0; j < chunk_ranges.size(); ++j) {
+		const auto& [height, widths] = chunk_ranges[j];
+		for(size_t i = 0; i < widths.size(); ++i) {
+			const auto& chnk = split_chunks[j * chunk_ranges[0].second.size() + i];
+			REQUIRE_LOOP(chnk.offset == offset);
+			REQUIRE_LOOP(chnk.range[0] == height);
+			REQUIRE_LOOP(chnk.range[1] == widths[i]);
+			REQUIRE_LOOP(chnk.global_size == full_chunk.global_size);
+			offset[1] += widths[i];
+		}
+		offset[1] = full_chunk.offset[1];
+		offset[0] += height;
+	}
+}
+
+} // namespace
+
+TEST_CASE("split_1d creates evenly sized chunks if possible", "[split]") {
+	const auto full_chunk = make_full_chunk<1>({128});
+	const auto chunks = split_1d(full_chunk, ones, 4);
+	check_1d_split(full_chunk, chunks, {32, 32, 32, 32});
+}
+
+TEST_CASE("split_1d distributes remainder evenly", "[split]") {
+	const auto full_chunk = make_full_chunk<1>({13});
+	const auto chunks = split_1d(full_chunk, ones, 5);
+	check_1d_split(full_chunk, chunks, {3, 3, 3, 2, 2});
+}
+
+TEST_CASE("split_1d respects granularity constraints", "[split]") {
+	const auto full_chunk = make_full_chunk<1>({80});
+	const auto chunks = split_1d(full_chunk, {16, 1, 1}, 3);
+	check_1d_split(full_chunk, chunks, {32, 32, 16});
+}
+
+TEST_CASE("split_1d creates fewer chunks than requested if mandated by granularity", "[split]") {
+	const auto full_chunk = make_full_chunk<1>({96});
+	const auto chunks = split_1d(full_chunk, {48, 1, 1}, 3);
+	check_1d_split(full_chunk, chunks, {48, 48});
+}
+
+TEST_CASE("split_1d preserves offset of original chunk", "[split]") {
+	const auto full_chunk = chunk<3>{{37, 42, 7}, {128, 1, 1}, {128, 1, 1}};
+	const auto chunks = split_1d(full_chunk, ones, 4);
+
+	CHECK(chunks[0].offset == id<3>{37 + 0, 42, 7});
+	CHECK(chunks[1].offset == id<3>{37 + 32, 42, 7});
+	CHECK(chunks[2].offset == id<3>{37 + 64, 42, 7});
+	CHECK(chunks[3].offset == id<3>{37 + 96, 42, 7});
+
+	check_1d_split(full_chunk, chunks, {32, 32, 32, 32});
+}
+
+TEST_CASE("split_1d preserves ranges of original chunk in other dimensions", "[split]") {
+	const auto full_chunk = make_full_chunk<3>({128, 42, 341});
+	const auto chunks = split_1d(full_chunk, ones, 4);
+	for(size_t i = 0; i < 4; ++i) {
+		REQUIRE_LOOP(chunks[0].range == range<3>{32, 42, 341});
+	}
+}
+
+TEST_CASE("split_2d produces perfectly square chunks if possible", "[split]") {
+	const auto full_chunk = make_full_chunk<2>({128, 128});
+	const auto chunks = split_2d(full_chunk, ones, 4);
+	check_2d_split(full_chunk, chunks,
+	    {
+	        {64, {64, 64}},
+	        {64, {64, 64}},
+	    });
+}
+
+TEST_CASE("split_2d respects granularity constraints") {
+	SECTION("simple constrained split") {
+		const auto full_chunk = make_full_chunk<2>({128, 128});
+		const auto chunks = split_2d(full_chunk, {8, 8, 1}, 8);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {32, {64, 64}},
+		        {32, {64, 64}},
+		        {32, {64, 64}},
+		        {32, {64, 64}},
+		    });
+	}
+	SECTION("non-square full chunk, constrained to 1D split") {
+		const auto full_chunk = make_full_chunk<2>({256, 128});
+		const auto chunks = split_2d(full_chunk, {8, 128, 1}, 8);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {32, {128}},
+		        {32, {128}},
+		        {32, {128}},
+		        {32, {128}},
+		        {32, {128}},
+		        {32, {128}},
+		        {32, {128}},
+		        {32, {128}},
+		    });
+	}
+	SECTION("very imbalanced, constrained split") {
+		const auto full_chunk = make_full_chunk<2>({128, 128});
+		const auto chunks = split_2d(full_chunk, {32, 8, 1}, 4);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {64, {64, 64}},
+		        {64, {64, 64}},
+		    });
+	}
+}
+
+TEST_CASE("split_2d distributes remainder evenly") {
+	SECTION("unconstrained split") {
+		const auto full_chunk = make_full_chunk<2>({100, 100});
+		const auto chunks = split_2d(full_chunk, ones, 6);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {34, {50, 50}},
+		        {33, {50, 50}},
+		        {33, {50, 50}},
+		    });
+	}
+	SECTION("constrained split 1") {
+		const auto full_chunk = make_full_chunk<2>({128, 120});
+		const auto chunks = split_2d(full_chunk, {8, 8, 1}, 4);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {64, {64, 56}},
+		        {64, {64, 56}},
+		    });
+	}
+	SECTION("constrained split 2") {
+		const auto full_chunk = make_full_chunk<2>({128, 128});
+		const auto chunks = split_2d(full_chunk, {16, 8, 1}, 12);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {32, {48, 40, 40}},
+		        {32, {48, 40, 40}},
+		        {32, {48, 40, 40}},
+		        {32, {48, 40, 40}},
+		    });
+	}
+}
+
+TEST_CASE("split_2d creates fewer chunks than requested if mandated by granularity", "[split]") {
+	const auto full_chunk = make_full_chunk<2>({128, 128});
+	const auto chunks = split_2d(full_chunk, {64, 64, 1}, 3);
+	check_2d_split(full_chunk, chunks,
+	    {
+	        {64, {128}},
+	        {64, {128}},
+	    });
+}
+
+TEST_CASE("split_2d transposes split to better fit granularity constraints", "[split]") {
+	SECTION("case 1") {
+		const auto full_chunk = make_full_chunk<2>({128, 128});
+		const auto chunks = split_2d(full_chunk, {8, 64, 1}, 8);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {32, {64, 64}},
+		        {32, {64, 64}},
+		        {32, {64, 64}},
+		        {32, {64, 64}},
+		    });
+	}
+	SECTION("case 2") {
+		const auto full_chunk = make_full_chunk<2>({128, 128});
+		const auto chunks = split_2d(full_chunk, {64, 8, 1}, 8);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {64, {32, 32, 32, 32}},
+		        {64, {32, 32, 32, 32}},
+		    });
+	}
+}
+
+TEST_CASE("split_2d minimizes edge lengths for non-square domains") {
+	SECTION("case 1") {
+		const auto full_chunk = make_full_chunk<2>({256, 64});
+		const auto chunks = split_2d(full_chunk, ones, 8);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {64, {32, 32}},
+		        {64, {32, 32}},
+		        {64, {32, 32}},
+		        {64, {32, 32}},
+		    });
+	}
+	SECTION("case 2") {
+		const auto full_chunk = make_full_chunk<2>({64, 256});
+		const auto chunks = split_2d(full_chunk, ones, 8);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {32, {64, 64, 64, 64}},
+		        {32, {64, 64, 64, 64}},
+		    });
+	}
+}
+
+TEST_CASE("split_2d preserves offset of original chunk", "[split]") {
+	const auto full_chunk = chunk<3>{{37, 42, 7}, {64, 64, 1}, {128, 128, 1}};
+	const auto chunks = split_2d(full_chunk, ones, 4);
+	CHECK(chunks[0].offset == id<3>{37, 42, 7});
+	CHECK(chunks[1].offset == id<3>{37, 42 + 32, 7});
+	CHECK(chunks[2].offset == id<3>{37 + 32, 42 + 0, 7});
+	CHECK(chunks[3].offset == id<3>{37 + 32, 42 + 32, 7});
+}
+
+TEST_CASE("split_2d preserves ranges of original chunk in other dimensions", "[split]") {
+	const auto full_chunk = make_full_chunk<3>({128, 128, 341});
+	const auto chunks = split_2d(full_chunk, ones, 4);
+	for(size_t i = 0; i < 4; ++i) {
+		REQUIRE_LOOP(chunks[i].range == range<3>{64, 64, 341});
+	}
+}
+
+TEST_CASE("the behavior of split_2d on 1-dimensional chunks is well-defined", "[split]") {
+	SECTION("even split") {
+		const auto full_chunk = make_full_chunk<1>({128});
+		const auto chunks = split_2d(full_chunk, ones, 4);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {32, {1}},
+		        {32, {1}},
+		        {32, {1}},
+		        {32, {1}},
+		    });
+	}
+
+	SECTION("uneven split") {
+		const auto full_chunk = make_full_chunk<1>({13});
+		const auto chunks = split_1d(full_chunk, ones, 5);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {3, {1}},
+		        {3, {1}},
+		        {3, {1}},
+		        {2, {1}},
+		        {2, {1}},
+		    });
+	}
+
+	SECTION("constrained split") {
+		const auto full_chunk = make_full_chunk<1>({80});
+		const auto chunks = split_1d(full_chunk, {16, 1, 1}, 3);
+		check_2d_split(full_chunk, chunks,
+		    {
+		        {32, {1}},
+		        {32, {1}},
+		        {16, {1}},
+		    });
+	}
+}


### PR DESCRIPTION
This adds a new `experimental::hint` API that can be used to provide the runtime with additional information on how to process a task. The first two hints we have are `experimental::hints::split_1d` and `experimental::hints::split_2d`. As a 1D split is currently the default, the former is a no-op. For the latter this introduces a new `split_2d` function that attempts to produce a number of evenly sized chunks while satisfying the provided granularity constraints.

The algorithm works by trying to find two factors for `num_chunks`, the number of requested chunks, that are as close to `sqrt(num_chunks)` as possible while also producing the requested number of chunks, degrading to a 1D split in the worst case. Due to granularity constraints it is not always possible to produce the requested number of chunks however, in that case the algorithm will attempt to get as close as possible. Finding the factors requires at most `O(sqrt(num_chunks))` time.

Given the two factors, the algorithm uses two heuristics to decide to which side of the domain they should be assigned:
- If the domain is square-ish, the algorithm prefers to have more splits along the slower dimension.
- If the domain is non-square, the algorithm prefers the split that produces overall shorder edges (smaller sum of circumferences).

Here's a visual representation of some of the 2D splits from the unit tests. Each split is labelled in the form `<size0>x<size1> ~ <granularity0>x<granularity1> | <num chunks>`. Red lines represent split constraints (i.e., individual red boxes can not be split further):

![image](https://github.com/celerity/celerity-runtime/assets/791348/f9f59f4d-ee52-4d67-9dc3-535c87594517)
