### PR TITLE
Include fmt headers directly rather than through spdlog

### DIFF
--- a/include/handler.h
+++ b/include/handler.h
@@ -7,7 +7,7 @@
 #include <utility>
 
 #include <CL/sycl.hpp>
-#include <spdlog/fmt/fmt.h>
+#include <fmt/format.h>
 
 #include "buffer.h"
 #include "cgf_diagnostics.h"

--- a/include/log.h
+++ b/include/log.h
@@ -6,7 +6,6 @@
 #include <utility>
 #include <variant>
 
-#include <spdlog/fmt/ostr.h> // Enable formatting of types that support operator<<(std::ostream&, T)
 #include <spdlog/spdlog.h>
 
 #include "print_utils.h"

--- a/include/print_utils.h
+++ b/include/print_utils.h
@@ -3,7 +3,7 @@
 #include "grid.h"
 #include "ranges.h"
 
-#include <spdlog/fmt/fmt.h>
+#include <fmt/format.h>
 
 template <typename Interface, int Dims>
 struct fmt::formatter<celerity::detail::coordinate<Interface, Dims>> : fmt::formatter<size_t> {

--- a/include/range_mapper.h
+++ b/include/range_mapper.h
@@ -4,7 +4,7 @@
 #include <type_traits>
 
 #include <CL/sycl.hpp>
-#include <spdlog/fmt/fmt.h>
+#include <fmt/format.h>
 
 #include "ranges.h"
 

--- a/include/region_map.h
+++ b/include/region_map.h
@@ -9,7 +9,7 @@
 #include <variant>
 #include <vector>
 
-#include <spdlog/fmt/fmt.h>
+#include <fmt/format.h>
 
 #include "grid.h"
 #include "utils.h"

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -1,7 +1,6 @@
 #include "print_graph.h"
 
-#include <spdlog/fmt/fmt.h>
-#include <spdlog/fmt/ostr.h>
+#include <fmt/format.h>
 
 #include "command.h"
 #include "command_graph.h"

--- a/src/worker_job.cc
+++ b/src/worker_job.cc
@@ -1,6 +1,6 @@
 #include "worker_job.h"
 
-#include <spdlog/fmt/fmt.h>
+#include <fmt/format.h>
 
 #include "buffer_manager.h"
 #include "closure_hydrator.h"

--- a/test/benchmark_reporters.cc
+++ b/test/benchmark_reporters.cc
@@ -13,9 +13,11 @@
 #include <catch2/catch_test_case_info.hpp>
 #include <catch2/reporters/catch_reporter_registrars.hpp>
 #include <catch2/reporters/catch_reporter_streaming_base.hpp>
-#include <spdlog/fmt/chrono.h>
-#include <spdlog/fmt/fmt.h>
-#include <spdlog/fmt/ostr.h>
+
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
 
 // Escape according to RFC 4180 (w/o line break support)
 static std::string escape_csv(const std::string& str) {

--- a/test/distributed_graph_generator_test_utils.h
+++ b/test/distributed_graph_generator_test_utils.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include <catch2/catch_message.hpp>
-#include <spdlog/fmt/fmt.h>
+#include <fmt/format.h>
 
 #include "access_modes.h"
 #include "command_graph.h"


### PR DESCRIPTION
We pulling in `fmt` as an explicit dependency, but are including its headers through `<spdlog/fmt>`. I was briefly confused how this was even compatible, but as it turns out spdlog takes care of transitively including the right headers if it was built with an external fmt implementation (as ours is).

Nevertheless, I've taken the opportunity to include the correct headers directly in our code to make things less confusing.

This also gets rid of two iostreams includes, so this is of course very dear to my heart ;)