### PR TITLE
CI: Let clang-tidy auto-detect config files

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -58,9 +58,12 @@ jobs:
     container:
       # We could run this for more than one implementation,
       # but would likely end up with mostly duplicate diagnostics.
-      image: celerity-build/hipsycl:ubuntu22.04-latest
+      image: ghcr.io/celerity/celerity-build/hipsycl:ubuntu22.04-latest
       volumes:
         - ccache:/ccache
+      credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       # Here and in jobs below: We need to manually set the container workspace
       # path as an environment variable, as (curiously) the `github.workspace` context
@@ -141,9 +144,12 @@ jobs:
       build-dir: /root/build
       examples-build-dir: /root/build-examples
     container:
-      image: celerity-build/${{ matrix.sycl }}:ubuntu${{ matrix.ubuntu-version }}-${{ matrix.sycl-version }}
+      image: ghcr.io/celerity/celerity-build/${{ matrix.sycl }}:ubuntu${{ matrix.ubuntu-version }}-${{ matrix.sycl-version }}
       volumes:
         - ccache:/ccache
+      credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Set container workspace environment variable
         run: echo "container-workspace=$GITHUB_WORKSPACE" > $GITHUB_ENV
@@ -220,13 +226,22 @@ jobs:
           - sycl: "hipsycl"
             platform: "nvidia"
     env:
-      image-basename-dpcpp: celerity-build/dpcpp:ubuntu${{ needs.build-and-test.outputs.dpcpp-HEAD-ubuntu-version }}
-      image-basename-hipsycl: celerity-build/hipsycl:ubuntu${{ needs.build-and-test.outputs.hipsycl-HEAD-ubuntu-version }}
+      image-basename-dpcpp: ghcr.io/celerity/celerity-build/dpcpp:ubuntu${{ needs.build-and-test.outputs.dpcpp-HEAD-ubuntu-version }}
+      image-basename-hipsycl: ghcr.io/celerity/celerity-build/hipsycl:ubuntu${{ needs.build-and-test.outputs.hipsycl-HEAD-ubuntu-version }}
+    permissions:
+      packages: write
     steps:
+      - name: Log into Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - if: matrix.sycl == 'dpcpp'
         run: |
           if [[ "${{ needs.build-and-test.outputs.dpcpp-HEAD-Debug-works }}" -eq 1 ]] && [[ "${{ needs.build-and-test.outputs.dpcpp-HEAD-Release-works }}" -eq 1 ]]; then
             docker tag ${{ env.image-basename-dpcpp }}-HEAD ${{ env.image-basename-dpcpp }}-latest
+            docker push ${{ env.image-basename-dpcpp }}-latest
           else
             exit 1
           fi
@@ -234,6 +249,7 @@ jobs:
         run: |
           if [[ "${{ needs.build-and-test.outputs.hipsycl-HEAD-Debug-works }}" -eq 1 ]] && [[ "${{ needs.build-and-test.outputs.hipsycl-HEAD-Release-works }}" -eq 1 ]]; then
             docker tag ${{ env.image-basename-hipsycl }}-HEAD ${{ env.image-basename-hipsycl }}-latest
+            docker push ${{ env.image-basename-hipsycl }}-latest
           else
             exit 1
           fi
@@ -245,7 +261,10 @@ jobs:
     env:
       container-workspace: <placeholder>
     container:
-      image: celerity-lint
+      image: ghcr.io/celerity/celerity-lint
+      credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Set container workspace environment variable
         run: echo "container-workspace=$GITHUB_WORKSPACE" > $GITHUB_ENV

--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -91,8 +91,8 @@ jobs:
             --repo=${{ github.repository }} \
             --pr=${{ github.event.pull_request.number }} \
             --build_dir=${{ env.build-dir }} \
+            --config_file=${{ env.container-workspace }}/.clang-tidy \
             --include="*.h,*.cc,*.[ch]pp" \
-            --clang_tidy_checks="" \
             --lgtm-comment-body=""
 
   # We need to jump through some hoops to have different build matrices based on what triggered the workflow.

--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -91,8 +91,8 @@ jobs:
             --repo=${{ github.repository }} \
             --pr=${{ github.event.pull_request.number }} \
             --build_dir=${{ env.build-dir }} \
-            --config_file=${{ env.container-workspace }}/.clang-tidy \
             --include="*.h,*.cc,*.[ch]pp" \
+            --clang_tidy_checks="" \
             --lgtm-comment-body=""
 
   # We need to jump through some hoops to have different build matrices based on what triggered the workflow.

--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -58,7 +58,7 @@ jobs:
     container:
       # We could run this for more than one implementation,
       # but would likely end up with mostly duplicate diagnostics.
-      image: ghcr.io/celerity/celerity-build/hipsycl:ubuntu22.04-latest
+      image: ghcr.io/celerity/celerity-build/hipsycl:ubuntu23.04-latest
       volumes:
         - ccache:/ccache
       credentials:
@@ -82,10 +82,10 @@ jobs:
         run: |
           git clone https://github.com/ZedThree/clang-tidy-review.git
           cd clang-tidy-review
-          git checkout v0.9.0
-          pip install -r ./requirements.txt
+          git checkout v0.14.0
+          pip install --break-system-packages ./post/clang_tidy_review/
           cd ${{ env.container-workspace }}
-          python3 ${{ env.build-dir }}/clang-tidy-review/review.py \
+          python3 ${{ env.build-dir }}/clang-tidy-review/post/clang_tidy_review/clang_tidy_review/review.py \
             --clang_tidy_binary=clang-tidy \
             --token=${{ github.token }} \
             --repo=${{ github.repository }} \

--- a/include/distributed_graph_generator.h
+++ b/include/distributed_graph_generator.h
@@ -140,6 +140,8 @@ class distributed_graph_generator {
 	command_id m_epoch_for_new_commands = 0;
 	command_id m_epoch_last_pruned_before = 0;
 	command_id m_current_horizon = no_command;
+	// NOMERGE: make clang-tidy complain
+	size_t member_with_wrong_naming_convention = 0;
 
 	// Batch of commands currently being generated. Returned (and thereby emptied) by build_task().
 	std::unordered_set<abstract_command*> m_current_cmd_batch;

--- a/src/distributed_graph_generator.cc
+++ b/src/distributed_graph_generator.cc
@@ -173,6 +173,10 @@ void distributed_graph_generator::generate_distributed_commands(const task& tsk)
 	const box<3> empty_reduction_box({0, 0, 0}, {0, 0, 0});
 	const box<3> scalar_reduction_box({0, 0, 0}, {1, 1, 1});
 
+	// NOMERGE: make clang-tidy complain
+	std::array<size_t, 3> foo;
+	printf("%zu\n", foo[tsk.get_id()]);
+
 	// Iterate over all chunks, distinguish between local / remote chunks and normal / reduction access.
 	//
 	// Normal buffer access:

--- a/src/platform_specific/.clang-tidy
+++ b/src/platform_specific/.clang-tidy
@@ -1,0 +1,11 @@
+---
+InheritParentConfig: true
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.FunctionCase
+    value: UPPER_CASE
+  - key: readability-braces-around-statements.ShortStatementLines
+    value: 0
+  - key: readability-identifier-naming.PrivateMemberPrefix
+    value: thisisprivate_

--- a/src/platform_specific/affinity.unix.cc
+++ b/src/platform_specific/affinity.unix.cc
@@ -9,6 +9,18 @@
 namespace celerity {
 namespace detail {
 
+	// NOMERGE: make clang-tidy complain
+	int VERY_ANGRY(int param) {
+		if(param == 32) return 7;
+		return 8;
+	}
+
+	class WEIRD_NAMING_CONVENTIONS_HERE {
+	  private:
+		int thisisprivate_thingy = 123;
+		int m_private = 123;
+	};
+
 	uint32_t affinity_cores_available() {
 		cpu_set_t available_cores;
 		[[maybe_unused]] const auto ret = pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &available_cores);


### PR DESCRIPTION
clang-tidy-review v0.14.0 added support for this; it allows us to use different files for different folders.

Based on #232, so that should be merged first.