### PR TITLE
Run clang tidy in lint container

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -56,9 +56,7 @@ jobs:
       container-workspace: <placeholder>
       build-dir: /root/build
     container:
-      # We could run this for more than one implementation,
-      # but would likely end up with mostly duplicate diagnostics.
-      image: ghcr.io/celerity/celerity-build/dpcpp:ubuntu22.04-latest
+      image: ghcr.io/celerity/celerity-lint
       volumes:
         - ccache:/ccache
       credentials:


### PR DESCRIPTION
Turns out DPC++'s flags (`-fsycl` and friends) cause issues for clang-tidy-14. Run in celerity-lint container instead, which is now
based on hipSYCL and Ubuntu 22.04.