### PR TITLE
Fix build with DPC++ HEAD

### DIFF
--- a/test/region_map_tests.cc
+++ b/test/region_map_tests.cc
@@ -272,7 +272,7 @@ TEST_CASE("region_map handles basic operations in 1D", "[region_map]") {
 	SECTION("update with split") {
 		rm.update_box({32, 96}, 1337);
 		const auto results = rm.get_region_values({0, size});
-		CHECK_RESULTS(results, {{0, 32}, -1}, {{32, 96}, 1337}, {{96, size}, default_value});
+		CHECK_RESULTS(results, {{0, 32}, default_value}, {{32, 96}, 1337}, {{96, size}, default_value});
 	}
 
 	SECTION("update multiple") {


### PR DESCRIPTION
DPC++'s most recent Clang found an illegal variable initialization in `region_map_tests`.

This PR allows us to build against the current DPC++ HEAD again.

- [Failing Build (master)](https://github.com/celerity/celerity-runtime/actions/runs/7635808724)
- [Fixed Build (this branch)](https://github.com/celerity/celerity-runtime/actions/runs/7640286198)