### PR TITLE
Report code coverage via coveralls.io

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -173,6 +173,9 @@ jobs:
           path: ${{ env.build-name }}.log
       - name: Build examples against installed Celerity
         run: bash /root/build-examples.sh ${{ env.container-workspace }}/examples --build-type ${{ matrix.build-type }}
+      - name: Reset coverage counters
+        if: matrix.build-type == 'Debug' && matrix.sycl == 'simsycl' # celerity-build/simsycl image enables --coverage for Debug builds
+        run: fastcov -z -d "${{ env.build-dir }}"
       # For a run with ASan, we need to fake dlclose() so all shared libraries are still mapped when leaks are evaluated
       # - otherwise, we will see "<unknown module>" instead of a proper trace if it originated in an unloaded library
       # (see https://github.com/google/sanitizers/issues/89#issuecomment-406316683). LD_PRELOAD will be set to CI_LD_PRELOAD
@@ -220,6 +223,13 @@ jobs:
         run: |
           echo "${{ matrix.sycl }}-HEAD-${{ matrix.build-type }}-works=1" >> "$GITHUB_OUTPUT"
           echo "${{ matrix.sycl }}-HEAD-ubuntu-version=${{ matrix.ubuntu-version }}" >> "$GITHUB_OUTPUT"
+      - name: Collect & report coverage
+        if: matrix.build-type == 'Debug' && matrix.sycl == 'simsycl' # celerity-build/simsycl image enables --coverage for Debug builds
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          "${{ env.container-workspace }}/ci/capture-coverage.sh" "${{ env.container-workspace }}" "${{ env.build-dir }}" -o lcov.info
+          coveralls report lcov.info
 
   # Tag "HEAD" images that built and tested successfully as "latest".
   # This is only done for nightly builds (or when specifying the "tag-latest" option on manually triggered runs).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="docs/celerity_logo.png" alt="Celerity Logo">
 </p>
 
-# Celerity Runtime - [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/celerity/celerity-runtime/blob/master/LICENSE) [![Semver 2.0](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/spec/v2.0.0.html) [![PRs # Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/celerity/celerity-runtime/blob/master/CONTRIBUTING.md)
+# Celerity Runtime — [![Coverage Status](https://coveralls.io/repos/github/celerity/celerity-runtime/badge.svg?branch=master)](https://coveralls.io/github/celerity/celerity-runtime?branch=master) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/celerity/celerity-runtime/blob/master/LICENSE) [![Semver 2.0](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/spec/v2.0.0.html) [![PRs # Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/celerity/celerity-runtime/blob/master/CONTRIBUTING.md)
 
 The Celerity distributed runtime and API aims to bring the power and ease of
 use of [SYCL](https://sycl.tech) to distributed memory clusters.

--- a/ci/capture-coverage.sh
+++ b/ci/capture-coverage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# usage: capture-coverage.sh source-dir build-dir <options...>
+
+set -eu -o pipefail
+
+SOURCE_DIR="$(realpath "$1")"
+BUILD_DIR="$(realpath "$2")"
+
+exec fastcov \
+	--compiler-directory "$SOURCE_DIR" \
+	--search-directory "$BUILD_DIR" \
+	--process-gcno \
+	--include "$SOURCE_DIR/include" "$SOURCE_DIR/src" \
+	--branch-coverage \
+	--exclude-br-lines-starting-with assert CELERITY_DETAIL_ASSERT_ON_HOST \
+	--lcov \
+	--output lcov.info


### PR DESCRIPTION
This PR
1. Instruments the simsycl-debug CI build with GCC's `--coverage` flag to export coverage data (one `.gcno` file for every `.o` file)
2. Runs unit tests and system tests (generating one `.gcda` file with counters per `.gcno` file)
3. Aggregates the `.gcda` files using [fastcov](https://github.com/RPGillespie6/fastcov) into an [LCOV](https://github.com/linux-test-project/lcov) info file
4. Uploads the info file to [coveralls.io](https://coveralls.io/github/celerity/celerity-runtime) to generate statistics and a coverage badge (which is now in the README).

Note that the coverage badge still says "unknown" because it reports the master branch, so the badge will be correct after the merge.