### PR TITLE
Add CI badge to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ CMakeSettings.json
 compile_commands.json
 build
 build_*
+build-*
 install
 .cache/
 .vs/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="docs/celerity_logo.png" alt="Celerity Logo">
 </p>
 
-# Celerity Runtime — [![Coverage Status](https://coveralls.io/repos/github/celerity/celerity-runtime/badge.svg?branch=master)](https://coveralls.io/github/celerity/celerity-runtime?branch=master) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/celerity/celerity-runtime/blob/master/LICENSE) [![Semver 2.0](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/spec/v2.0.0.html) [![PRs # Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/celerity/celerity-runtime/blob/master/CONTRIBUTING.md)
+# Celerity Runtime — [![CI Workflow](https://github.com/celerity/celerity-runtime/actions/workflows/celerity_ci.yml/badge.svg)](https://github.com/celerity/celerity-runtime/actions/workflows/celerity_ci.yml) [![Coverage Status](https://coveralls.io/repos/github/celerity/celerity-runtime/badge.svg?branch=master)](https://coveralls.io/github/celerity/celerity-runtime?branch=master) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/celerity/celerity-runtime/blob/master/LICENSE) [![Semver 2.0](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/spec/v2.0.0.html) [![PRs # Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/celerity/celerity-runtime/blob/master/CONTRIBUTING.md)
 
 The Celerity distributed runtime and API aims to bring the power and ease of
 use of [SYCL](https://sycl.tech) to distributed memory clusters.


### PR DESCRIPTION
It seemed off to me to have a coverage badge but not a CI badge. Also, we all know that more badges = better project, right?

Also snuck in a minor addition to .gitignore for a different build path pattern.