### PR TITLE
Region Map support extents with non-zero offset; make dimensionality implicit; fix empty queries

### DIFF
--- a/include/buffer_manager.h
+++ b/include/buffer_manager.h
@@ -146,7 +146,7 @@ namespace detail {
 				auto host_factory = [](const celerity::range<3>& r) { return std::make_unique<host_buffer_storage<DataT, Dims>>(range_cast<Dims>(r)); };
 				m_buffer_infos.emplace(
 				    bid, buffer_info{Dims, range, sizeof(DataT), is_host_initialized, {}, std::move(device_factory), std::move(host_factory)});
-				m_newest_data_location.emplace(bid, region_map<data_location>(range, Dims, data_location::nowhere));
+				m_newest_data_location.emplace(bid, region_map<data_location>(range, data_location::nowhere));
 
 #if defined(CELERITY_DETAIL_ENABLE_DEBUG)
 				m_buffer_types.emplace(bid, new buffer_type_guard<DataT, Dims>());

--- a/include/distributed_graph_generator.h
+++ b/include/distributed_graph_generator.h
@@ -83,7 +83,7 @@ class distributed_graph_generator {
 	distributed_graph_generator(const size_t num_nodes, const node_id local_nid, command_graph& cdag, const task_manager& tm,
 	    detail::command_recorder* recorder, const policy_set& policy = default_policy_set());
 
-	void add_buffer(const buffer_id bid, const int dims, const range<3>& range, bool host_initialized);
+	void add_buffer(const buffer_id bid, const range<3>& range, bool host_initialized);
 
 	std::unordered_set<abstract_command*> build_task(const task& tsk);
 

--- a/include/grid.h
+++ b/include/grid.h
@@ -81,6 +81,8 @@ class box /* class instead of struct: enforces min <= max invariant */ {
 #endif
 	}
 
+	static box full_range(const range<Dims>& range) { return box(id<Dims>(), id<Dims>(range)); }
+
 	bool empty() const {
 		if constexpr(Dims > 0) {
 			return m_max[0] == 0; // empty boxes are normalized to [0,0,0] - [0,0,0]

--- a/include/region_map.h
+++ b/include/region_map.h
@@ -1213,9 +1213,16 @@ namespace region_map_detail {
 	  public:
 		region_map_impl(const box<0>& /* extent */, ValueType default_value) : m_value(default_value) {}
 
-		void update_box(const box<1>& /* box */, const ValueType& value) { m_value = value; }
+		void update_box(const box<1>& box, const ValueType& value) {
+			assert(detail::box<1>(0, 1).covers(box));
+			if(!box.empty()) { m_value = value; }
+		}
 
-		std::vector<std::pair<box<1>, ValueType>> get_region_values(const box<1>& /* request */) const { return {{box<1>{0, 1}, m_value}}; }
+		std::vector<std::pair<box<1>, ValueType>> get_region_values(const box<1>& request) const {
+			assert(box<1>(0, 1).covers(request));
+			if(!request.empty()) { return {{box<1>{0, 1}, m_value}}; }
+			return {};
+		}
 
 		template <typename Functor>
 		void apply_to_values(const Functor& f) {

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -32,8 +32,8 @@ namespace detail {
 		 */
 		void notify_task_created(const task* const tsk) { notify(event_task_available{tsk}); }
 
-		void notify_buffer_registered(const buffer_id bid, const int dims, const range<3>& range, bool host_initialized) {
-			notify(event_buffer_registered{bid, dims, range, host_initialized});
+		void notify_buffer_registered(const buffer_id bid, const range<3>& range, bool host_initialized) {
+			notify(event_buffer_registered{bid, range, host_initialized});
 		}
 
 	  protected:
@@ -53,7 +53,6 @@ namespace detail {
 		};
 		struct event_buffer_registered {
 			buffer_id bid;
-			int dims;
 			celerity::range<3> range;
 			bool host_initialized;
 		};

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -115,7 +115,7 @@ namespace detail {
 		 * @brief Adds a new buffer for dependency tracking
 		 * @param host_initialized Whether this buffer has been initialized using a host pointer (i.e., it contains useful data before any write-task)
 		 */
-		void add_buffer(buffer_id bid, const int dims, const range<3>& range, bool host_initialized);
+		void add_buffer(buffer_id bid, const range<3>& range, bool host_initialized);
 
 		/**
 		 * Returns the specified task if it still exists, nullptr otherwise.

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -295,8 +295,8 @@ namespace detail {
 
 	void runtime::handle_buffer_registered(buffer_id bid) {
 		const auto& info = m_buffer_mngr->get_buffer_info(bid);
-		m_task_mngr->add_buffer(bid, info.dimensions, info.range, info.is_host_initialized);
-		m_schdlr->notify_buffer_registered(bid, info.dimensions, info.range, info.is_host_initialized);
+		m_task_mngr->add_buffer(bid, info.range, info.is_host_initialized);
+		m_schdlr->notify_buffer_registered(bid, info.range, info.is_host_initialized);
 	}
 
 	void runtime::handle_buffer_unregistered(buffer_id bid) { maybe_destroy_runtime(); }

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -53,7 +53,7 @@ namespace detail {
 					    serializer.flush(cmds);
 				    },
 				    [&](const event_buffer_registered& e) { //
-					    m_dggen->add_buffer(e.bid, e.dims, e.range, e.host_initialized);
+					    m_dggen->add_buffer(e.bid, e.range, e.host_initialized);
 				    },
 				    [&](const event_shutdown&) {
 					    assert(in_flight_events.empty());

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -15,8 +15,8 @@ namespace detail {
 		m_task_buffer.put(std::move(reserve), std::move(initial_epoch));
 	}
 
-	void task_manager::add_buffer(buffer_id bid, const int dims, const range<3>& range, bool host_initialized) {
-		m_buffers_last_writers.emplace(std::piecewise_construct, std::tuple{bid}, std::tuple{range, dims});
+	void task_manager::add_buffer(buffer_id bid, const range<3>& range, bool host_initialized) {
+		m_buffers_last_writers.emplace(bid, range);
 		if(host_initialized) { m_buffers_last_writers.at(bid).update_region(subrange<3>({}, range), m_epoch_for_new_tasks); }
 	}
 

--- a/test/debug/pretty_printables.cc
+++ b/test/debug/pretty_printables.cc
@@ -29,7 +29,7 @@ int main() {
 	    celerity::detail::box(celerity::id(21, 2, 3), celerity::id(24, 5, 6)),
 	});
 
-	[[maybe_unused]] celerity::detail::region_map<int> region_map(celerity::range<3>(10, 10, 10), 3);
+	[[maybe_unused]] celerity::detail::region_map<int> region_map(celerity::range<3>(10, 10, 10));
 	region_map.update_region(celerity::detail::box<3>({1, 1, 1}, {5, 5, 5}), 42);
 	region_map.update_region(celerity::detail::box<3>({1, 1, 1}, {3, 3, 3}), 69);
 	region_map.update_region(celerity::detail::box<3>({1, 1, 1}, {2, 2, 2}), 1337);

--- a/test/distributed_graph_generator_test_utils.h
+++ b/test/distributed_graph_generator_test_utils.h
@@ -507,9 +507,9 @@ class dist_cdag_test_context {
 	test_utils::mock_buffer<Dims> create_buffer(range<Dims> size, bool mark_as_host_initialized = false) {
 		const buffer_id bid = m_next_buffer_id++;
 		const auto buf = test_utils::mock_buffer<Dims>(bid, size);
-		m_tm.add_buffer(bid, Dims, range_cast<3>(size), mark_as_host_initialized);
+		m_tm.add_buffer(bid, range_cast<3>(size), mark_as_host_initialized);
 		for(auto& dggen : m_dggens) {
-			dggen->add_buffer(bid, Dims, range_cast<3>(size), mark_as_host_initialized);
+			dggen->add_buffer(bid, range_cast<3>(size), mark_as_host_initialized);
 		}
 		return buf;
 	}

--- a/test/region_map_tests.cc
+++ b/test/region_map_tests.cc
@@ -237,7 +237,7 @@ TEST_CASE("region_map handles basic operations in 0D", "[region_map]") {
 	region_map_impl<int, 0> rm{{}, default_value};
 
 	SECTION("query default value") {
-		const auto results = rm.get_region_values({0, 0});
+		const auto results = rm.get_region_values({0, 1});
 		CHECK_RESULTS(results, {{0, 1}, default_value});
 	}
 }
@@ -806,4 +806,18 @@ TEST_CASE("query regions are clamped from both sides in region maps with non-zer
 	const auto region_box = box<3>({1, 2, 3}, {7, 9, 11});
 	region_map<int> rm(region_box, 42);
 	CHECK(rm.get_region_values(box<3>::full_range({20, 19, 18})) == std::vector{std::pair{region_box, 42}});
+}
+
+TEMPLATE_TEST_CASE_SIG("get_region_values(<empty-region>) returns no boxes", "[region_map]", ((int Dims), Dims), 0, 1, 2, 3) {
+	region_map<int> rm(range_cast<3>(test_utils::truncate_range<Dims>({2, 3, 4})), -1);
+	CHECK(rm.get_region_values(box<3>()).empty());
+	CHECK(rm.get_region_values(region<3>()).empty());
+}
+
+TEMPLATE_TEST_CASE_SIG("update(<empty-box>) has no effect", "[region_map]", ((int Dims), Dims), 0, 1, 2, 3) {
+	region_map<int> rm(range_cast<3>(test_utils::truncate_range<Dims>({2, 3, 4})), 0);
+	rm.update_box(box<3>(), 1);
+	rm.update_region(box<3>(), 2);
+	const auto unit_box = box_cast<3>(box<0>());
+	CHECK(rm.get_region_values(unit_box) == std::vector{std::pair{unit_box, 0}});
 }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -220,9 +220,9 @@ namespace test_utils {
 		mock_buffer<Dims> create_buffer(range<Dims> size, bool mark_as_host_initialized = false) {
 			const detail::buffer_id bid = m_next_buffer_id++;
 			const auto buf = mock_buffer<Dims>(bid, size);
-			if(m_task_mngr != nullptr) { m_task_mngr->add_buffer(bid, Dims, detail::range_cast<3>(size), mark_as_host_initialized); }
-			if(m_schdlr != nullptr) { m_schdlr->notify_buffer_registered(bid, Dims, detail::range_cast<3>(size), mark_as_host_initialized); }
-			if(m_dggen != nullptr) { m_dggen->add_buffer(bid, Dims, detail::range_cast<3>(size), mark_as_host_initialized); }
+			if(m_task_mngr != nullptr) { m_task_mngr->add_buffer(bid, detail::range_cast<3>(size), mark_as_host_initialized); }
+			if(m_schdlr != nullptr) { m_schdlr->notify_buffer_registered(bid, detail::range_cast<3>(size), mark_as_host_initialized); }
+			if(m_dggen != nullptr) { m_dggen->add_buffer(bid, detail::range_cast<3>(size), mark_as_host_initialized); }
 			return buf;
 		}
 


### PR DESCRIPTION
This is a back-port from IDAG development.

The instruction graph generator tracks buffer accesses on a per-allocation basis, where each allocation has a potentially non-zero offset. With the existing region map API, this either requires maintaining rectangles within the "offset border" that are never queried, or a coordinate transformation in the generator. Fortunately `region_map_impl` already works on a `box<Dims> extent`, so we can just pass a `box` instead of a `range` to the `region_map` ctor.

Also, the implementation dimensionality is currently passed as an explicit ctor parameter to `region_map`, when since #201 , the minimum / effective dimensionality can be inferred from a range or box automatically. This avoids the need for passing `int dims` everywhere and has the benefit of making a `buffer<int, 3>(range(1000, 1, 1))` exactly as expensive to track as a `buffer<int, 1>(1000)`.

Lastly, the `region_map_impl<0>` specialization was behaving inconsistently around queries with empty boxes (aka `box<3>({0, 0, 0}, {0, 0, 0})`). This box cannot be cast to `box<0>` (which always has size 1). The incorrect behavior was even expected in an unit test - this was brought back in line with other dimensionalities; I've also added a more specific test.