### PR TITLE
CI: Complain if clang-format is not installed

### DIFF
--- a/ci/find-unformatted-files.sh
+++ b/ci/find-unformatted-files.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
+set -o pipefail -o nounset
+
 if [[ ! -d src ]]; then
     echo "Warning: This script should be run from within the repository root directory" >&2
+fi
+
+if [[ ! -x "$(which clang-format)" ]]; then
+    echo "Error: clang-format is not installed" >&2
+    exit 1
 fi
 
 SOURCES=$(find examples include src test \( -name "*.h" -o -name "*.cc" \) ! -name "stb*")
@@ -11,6 +18,6 @@ for s in $SOURCES; do
     # we use the XML replacements output together with grep as a workaround.
     NUM_REPLACEMENTS=$(clang-format -output-replacements-xml "$s" | grep -v -c -E "<(/?replacements|\?xml)")
     if [[ $NUM_REPLACEMENTS -ne 0 ]]; then
-        echo $s
+        echo "$s"
     fi
 done


### PR DESCRIPTION
Turns out our formatting check has been failing for a while due to a yet to be resolved issue with the `clang-format` symlink to `clang-format-14` missing in the linting container. This adds a check to see whether `clang-format` is available.