### PR TITLE
Tests: Do not value-capture buffers in host-tasks

### DIFF
--- a/test/accessor_tests.cc
+++ b/test/accessor_tests.cc
@@ -394,8 +394,8 @@ namespace detail {
 		});
 		q.submit([&](handler& cgh) {
 			accessor acc_1(buf_1, cgh, all(), read_only_host_task);
-			cgh.host_task(on_master_node, [=] {
-				for(size_t i = 0; i < buf_1.get_range().size(); ++i) {
+			cgh.host_task(on_master_node, [=, range = buf_1.get_range()] {
+				for(size_t i = 0; i < range.size(); ++i) {
 					REQUIRE_LOOP(acc_1[i] == value_b);
 				}
 			});
@@ -490,8 +490,8 @@ namespace detail {
 		});
 		q.submit([&](handler& cgh) {
 			accessor acc_1(buf_1, cgh, all(), read_only_host_task);
-			cgh.host_task(on_master_node, [=] {
-				for(size_t i = 0; i < buf_1.get_range().size(); ++i) {
+			cgh.host_task(on_master_node, [=, range = buf_1.get_range()] {
+				for(size_t i = 0; i < range.size(); ++i) {
 					REQUIRE_LOOP(acc_1[i] == value_b);
 				}
 			});


### PR DESCRIPTION
This fix is a backport from IDAG development.

Value-capturing a buffer lifetime-extends it such that its destructor may be called from the executor thread. This is already disallowed on the API side but not detected, and it is also not forward-compatible with lifetime management post-instruction-graph, where it was discovered.