### PR TITLE
Replace utils::match with `matchbox` library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "vendor/mimalloc"]
 	path = vendor/mimalloc
 	url = https://github.com/microsoft/mimalloc.git
+[submodule "vendor/matchbox"]
+	path = vendor/matchbox
+	url = https://github.com/fknorr/matchbox.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ target_include_directories(celerity_runtime PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/celerity>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vendor/matchbox/include>
   $<INSTALL_INTERFACE:include/celerity/vendor>
 )
 
@@ -382,7 +383,9 @@ install(
   DESTINATION include/celerity
 )
 install(
-  FILES ${PROJECT_SOURCE_DIR}/vendor/ctpl_stl.h
+  FILES
+    ${PROJECT_SOURCE_DIR}/vendor/ctpl_stl.h
+    ${PROJECT_SOURCE_DIR}/vendor/matchbox/include/matchbox.hh
   DESTINATION include/celerity/vendor
 )
 install(

--- a/include/command.h
+++ b/include/command.h
@@ -8,7 +8,8 @@
 #include "ranges.h"
 #include "task.h"
 #include "types.h"
-#include "utils.h"
+
+#include <matchbox.hh>
 
 namespace celerity {
 namespace detail {
@@ -190,7 +191,7 @@ namespace detail {
 
 		std::optional<task_id> get_tid() const {
 			// clang-format off
-			return utils::match(data,
+			return matchbox::match(data,
 				[](const horizon_data& d) { return std::optional{d.tid}; },
 				[](const epoch_data& d) { return std::optional{d.tid}; },
 				[](const execution_data& d) { return std::optional{d.tid}; },
@@ -202,7 +203,7 @@ namespace detail {
 
 		command_type get_command_type() const {
 			// clang-format off
-			return utils::match(data,
+			return matchbox::match(data,
 				[](const std::monostate&) -> command_type {
 					assert(!"calling get_command_type() on an empty command_pkg");
 					std::terminate();

--- a/include/region_map.h
+++ b/include/region_map.h
@@ -10,9 +10,9 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <matchbox.hh>
 
 #include "grid.h"
-#include "utils.h"
 
 // Some toggles that affect performance (but also change the behavior!)
 // TODO: Consider making these template arguments instead (inside some config object), and add these:
@@ -884,7 +884,7 @@ namespace region_map_detail {
 			region<Dims> erased;
 			region<Dims> inserted;
 			for(const auto& a : m_update_actions) {
-				utils::match(
+				matchbox::match(
 				    a,
 				    [&](const typename types::erase_node_action& erase_action) {
 					    assert(region_intersection(erased, erase_action.box).empty());
@@ -899,7 +899,7 @@ namespace region_map_detail {
 #endif
 
 			for(const auto& a : m_update_actions) {
-				utils::match(
+				matchbox::match(
 				    a,
 				    [&](const typename types::erase_node_action& erase_action) {
 					    if(!erase_action.processed_locally) { erase(erase_action.box); }
@@ -1082,7 +1082,7 @@ namespace region_map_detail {
 			assert(did_erase);
 
 			for(auto& o : m_erase_orphans) {
-				utils::match(
+				matchbox::match(
 				    o.second,                                                                                    //
 				    [&](ValueType& v) { insert(o.first, v); },                                                   //
 				    [&](typename types::unique_inner_node_ptr& in) { insert_subtree(o.first, std::move(in)); }); //

--- a/include/utils.h
+++ b/include/utils.h
@@ -36,17 +36,6 @@ constexpr inline uint32_t popcount(const BitMaskT bit_mask) noexcept {
 	return counter;
 }
 
-template <typename... F>
-struct overload : F... {
-	explicit constexpr overload(F... f) : F(f)... {}
-	using F::operator()...;
-};
-
-template <typename Variant, typename... Arms>
-decltype(auto) match(Variant&& v, Arms&&... arms) {
-	return std::visit(overload{std::forward<Arms>(arms)...}, std::forward<Variant>(v));
-}
-
 // Implementation from Boost.ContainerHash, licensed under the Boost Software License, Version 1.0.
 inline void hash_combine(std::size_t& seed, std::size_t value) { seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2); }
 

--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -5,7 +5,8 @@
 #include "frame.h"
 #include "graph_serializer.h"
 #include "named_threads.h"
-#include "utils.h"
+
+#include <matchbox.hh>
 
 namespace celerity {
 namespace detail {
@@ -45,7 +46,7 @@ namespace detail {
 				const auto event = std::move(in_flight_events.front()); // NOLINT(performance-move-const-arg)
 				in_flight_events.pop();
 
-				utils::match(
+				matchbox::match(
 				    event,
 				    [&](const event_task_available& e) {
 					    assert(e.tsk != nullptr);


### PR DESCRIPTION
[matchbox](https://github.com/fknorr/matchbox) is a standalone library that emerged from our `utils::match` function. It provides additional functionality like being reference-transparent and also matching on `std::optional` and on inheritance hierarchies.

celerity-master only uses `match` in a few places, but the instruction-graph branch will do so much more extensively (see e.g. [instruction_graph.h](https://github.com/fknorr/celerity-runtime/blob/a4c50eee7b17c470e2917d48ba98de724ebc01e7/include/instruction_graph.h#L25) and [print_graph.cc](https://github.com/fknorr/celerity-runtime/blob/a4c50eee7b17c470e2917d48ba98de724ebc01e7/src/print_graph.cc#L306)).

Nevertheless I've decided to make a separate up-front PR for this because adding a third-party dependency is kind of a big deal (even if that dependency is maintained by me) and I do not want this to disappear beneath more visible code changes in the upcoming IDAG PRs.

Since matchbox is a single-header library, I've decided to install it like CTPL and not use FetchContent (also because matchbox currently cannot do installs).