### PR TITLE
CI: Use Docker image from ghcr.io for benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
       container-workspace: /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
       build-dir: /root/build
     container:
-      image: celerity-build/hipsycl:ubuntu22.04-latest
+      image: ghcr.io/celerity/celerity-build/hipsycl:ubuntu22.04-d2bd9fc7
       volumes:
         - ccache:/ccache
     steps:

--- a/.github/workflows/build_matrix.json
+++ b/.github/workflows/build_matrix.json
@@ -1,5 +1,5 @@
 {
-    "NOTE": "Make sure to keep this in sync with docs/platform-support.md. Also ensure that the 'ubuntu-version' between 'HEAD' and 'latest' builds remains the same.",
+    "NOTE": "Make sure to keep this in sync with docs/platform-support.md and benchmark.yml. Also ensure that the 'ubuntu-version' between 'HEAD' and 'latest' builds remains the same.",
     "default": [
         { "sycl": "dpcpp", "sycl-version": "61e51015", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },


### PR DESCRIPTION
This update was missed when transitioning `celerity_ci.yml` to pull from `ghcr.io`.

This also switches us to the pinned version of hipSYCL / ACpp to ensure we do not mistake performance improvements / regressions in the SYCL implementation for ones in Celerity. ~~I've updated the benchmark results to set an appropriate baseline.~~