### PR TITLE
[IDAG] Out-of-Order Engine for Instruction Dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ set(SOURCES
   src/grid.cc
   src/instruction_graph_generator.cc
   src/mpi_communicator.cc
+  src/out_of_order_engine.cc
   src/print_graph.cc
   src/recorders.cc
   src/receive_arbiter.cc

--- a/include/out_of_order_engine.h
+++ b/include/out_of_order_engine.h
@@ -1,0 +1,86 @@
+#include "types.h"
+
+#include <memory>
+#include <optional>
+
+namespace celerity::detail::out_of_order_engine_detail {
+struct engine_impl;
+}
+
+namespace celerity::detail {
+
+class instruction;
+struct system_info;
+
+/// State machine controlling when and in what manner instructions are assigned to execution resources in adherence to the dependency graph.
+///
+/// Based on their type, instructions can either be assigned to begin executing immediately as soon as all their predecessors are complete, or they can be
+/// enqueued eagerly in one of the backend's thread queues or in-order device queues to hide launch latencies where possible.
+class out_of_order_engine {
+  public:
+	/// Identifies a category of execution resources that may be distinguished further by a device- or lane id.
+	enum class target {
+		/// Execution can begin immediately, no queueing takes place in the backend and no lane is assigned. Used for low-overhead instructions that do not
+		/// profit from additional concurrency such as horizons, as well as for instructions where asynchronicity is managed outside the backend (p2p transfers
+		/// through communicator and receive_arbiter).
+		immediate,
+
+		/// The instruction shall be inserted to the backend's (singular) host allocation queue. No lane is assigned. Since at least CUDA serializes the slow
+		/// alloc / free operations anyway to update page tables globally, the added concurrency from multiple thread queues would not increase throughput. The
+		/// separation between alloc_queue and host_queues further enforces a host round-trip between every alloc_instruction and its first successor, which we
+		/// use to inform the executor of the newly allocated pointer for the purpose of accessor hydration.
+		alloc_queue,
+
+		/// The instruction shall be submitted to a backend thread queue identified by the lane id. Used for host tasks and host-to-host copies.
+		host_queue,
+
+		/// The instruction shall be submitted to a backend in-order device queue identified by the lane id. Used for device kernels and host-to-device /
+		/// device-to-device / device-to-host copies.
+		device_queue,
+	};
+
+	/// A lane identifies a thread queue for target::host_task and an in-order device queue with target::device_queue.
+	using lane_id = size_t;
+
+	/// Directions on how a single (ready) instruction is to be dispatched by the executor.
+	struct assignment {
+		const detail::instruction* instruction = nullptr;
+		out_of_order_engine::target target = out_of_order_engine::target::immediate;
+		std::optional<device_id> device; ///< Identifies the device to submit to (if target == device_queue) or to allocate on (if target == alloc_queue).
+		std::optional<lane_id> lane; ///< Identifies the thread queue (target == host_queue) or the in-order queue for the given device (target == alloc_queue).
+
+		assignment(const detail::instruction* instruction, const out_of_order_engine::target target, const std::optional<device_id> device = std::nullopt,
+		    const std::optional<lane_id> lane = std::nullopt)
+		    : instruction(instruction), target(target), device(device), lane(lane) {}
+	};
+
+	/// Constructor requires a `system_info` to enumerate devices and perform `memory_id -> device_id` mapping.
+	explicit out_of_order_engine(const system_info& system);
+
+	out_of_order_engine(const out_of_order_engine&) = delete;
+	out_of_order_engine(out_of_order_engine&&) = default;
+	out_of_order_engine& operator=(const out_of_order_engine&) = delete;
+	out_of_order_engine& operator=(out_of_order_engine&&) = default;
+
+	~out_of_order_engine();
+
+	/// True when all submitted instructions have completed.
+	bool is_idle() const;
+
+	/// Begin tracking an instruction so that it is eventually returned through `assign_one`. Must be called in topological order of dependencies, i.e. no
+	/// instruction must be submitted before one of its predecessors in the graph.
+	void submit(const instruction* instr);
+
+	/// Produce an assignment for one instruction for which either all predecessors have completed, or for which all incomplete predecessors can be implicitly
+	/// fulfilled by submitting to the same backend queue. If multiple instructions are eligible, assign the one with the highest priority.
+	[[nodiscard]] std::optional<assignment> assign_one();
+
+	/// Call once an instruction that was previously returned from `assign_one` has completed synchronously or asynchronously. For simplicity it is permitted
+	/// to mark assigned instructions as completed in any order, even if that would violate internal dependency order.
+	void complete_assigned(const instruction* instr);
+
+  private:
+	std::unique_ptr<out_of_order_engine_detail::engine_impl> m_impl;
+};
+
+} // namespace celerity::detail

--- a/include/system_info.h
+++ b/include/system_info.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "dense_map.h"
+#include "types.h"
+
+#include <bitset>
+
+namespace celerity::detail {
+
+/// Memory id for (unpinned) host memory allocated for or by the user. This memory id is assumed for pointers passed for buffer host-initialization and for the
+/// explicit user-side allocation of a buffer_snapshot that is performed before a buffer fence.
+inline constexpr memory_id user_memory_id = 0;
+
+/// Memory id for (pinned) host memory that the executor will obtain from the backend for buffer allocations and staging buffers.
+inline constexpr memory_id host_memory_id = 1;
+
+/// Memory id for the first device-native memory, if any.
+inline constexpr memory_id first_device_memory_id = 2;
+
+static constexpr size_t max_num_memories = 64;
+using memory_mask = std::bitset<max_num_memories>;
+
+/// Information about a single device in the local system.
+struct device_info {
+	/// Before accessing any memory on a device, instruction_graph_generator will prepare a corresponding allocation on its `native_memory`. Multiple
+	/// devices can share the same native memory. No attempts at reading from peer or shared memory to elide copies are currently made, but could be in the
+	/// future.
+	memory_id native_memory;
+};
+
+/// Information about a single memory in the local system.
+struct memory_info {
+	/// This mask contains a 1-bit for every memory_id that the associated backend queue can copy data from or to directly. instruction_graph_generator
+	/// expects this mapping to be reflexive, i.e. `system_info::memories[a].copy_peers[b] == system_info::memories[b].copy_peers[a]`.
+	/// Further, copies must always be possible between `host_memory_id` and `user_memory_id` as well as between `host_memory_id` and every other memory.
+	/// instruction_graph_generator will create a staging copy in host memory if data must be transferred between two memories that are not copy peers.
+	memory_mask copy_peers;
+};
+
+/// All information about the local system that influences the generated instruction graph.
+struct system_info {
+	dense_map<device_id, device_info> devices;
+	dense_map<memory_id, memory_info> memories;
+};
+
+} // namespace celerity::detail

--- a/include/types.h
+++ b/include/types.h
@@ -104,16 +104,6 @@ class allocation_id {
 	size_t m_raid : raw_allocation_id_bits;
 };
 
-/// Memory id for (unpinned) host memory allocated for or by the user. This memory id is assumed for pointers passed for buffer host-initialization and for the
-/// explicit user-side allocation of a buffer_snapshot that is performed before a buffer fence.
-inline constexpr memory_id user_memory_id = 0;
-
-/// Memory id for (pinned) host memory that the executor will obtain from the backend for buffer allocations and staging buffers.
-inline constexpr memory_id host_memory_id = 1;
-
-/// Memory id for the first device-native memory, if any.
-inline constexpr memory_id first_device_memory_id = 2;
-
 /// allocation_id equivalent of a null pointer.
 inline constexpr allocation_id null_allocation_id{};
 

--- a/src/out_of_order_engine.cc
+++ b/src/out_of_order_engine.cc
@@ -1,0 +1,444 @@
+#include "out_of_order_engine.h"
+#include "dense_map.h"
+#include "instruction_graph.h"
+#include "system_info.h"
+#include "utils.h"
+
+#include <queue>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <matchbox.hh>
+
+namespace celerity::detail::out_of_order_engine_detail {
+
+using target = out_of_order_engine::target;
+using lane_id = out_of_order_engine::lane_id;
+using assignment = out_of_order_engine::assignment;
+
+/// Comparison operator to make priority_queue<instruction*> return concurrent instructions in decreasing priority.
+struct instruction_priority_less {
+	bool operator()(const instruction* lhs, const instruction* rhs) const { return lhs->get_priority() < rhs->get_priority(); }
+};
+
+/// Instruction is not eligible for assignment yet. Implies `num_incomplete_predecessors > 0`.
+struct unassigned_state {
+	/// Flag allowing us to shortcut the eager-assignment check if we know that it cannot succeed (anymore). Set to false statically for the immediate and
+	/// alloc_queue target, and also set to false if the instruction was in `conditional_eagerly_assignable_state` but eager assignment had to be aborted
+	/// because the lane was not in the expected state anymore.
+	bool probe_for_eager_assignment = true;
+};
+
+/// Instruction has been inserted into `assignment_queue`, but has not yet been assigned. After popping it from the queue, it can potentially be assigned by
+/// eagerly enqueueing it to the lane where all its remaining predecessors are already assigned to. If a third instruction is submitted to the target lane in
+/// the meantime however, assignment will fail, and we revert back to `unassigned_state`. Implies `num_unassigned_predecessors == 0`.
+struct conditional_eagerly_assignable_state {
+	std::optional<device_id> device;
+	lane_id lane = -1;
+	const instruction* expected_last_submission_on_lane = nullptr;
+};
+
+/// Instruction is inserted into `assignment_queue` and will be unconditionally assigned after being popped.
+/// Implies `num_incomplete_predecessors == 0 && num_unassigned_predecessors == 0`.
+struct unconditional_assignable_state {};
+
+/// Instruction is assigned and waiting for a `complete_assigned()` call. Implies `num_incomplete_predecessors == 0 && num_unassigned_predecessors == 0`.
+struct assigned_state {
+	std::optional<device_id> device;
+	std::optional<lane_id> lane;
+};
+
+/// State maintained for every instruction between its submission and completion.
+struct incomplete_instruction_state {
+	const instruction* instr = nullptr;
+	out_of_order_engine::target target = out_of_order_engine::target::immediate;
+	gch::small_vector<device_id, 2> eligible_devices; ///< device-to-device copies can be submitted to host or destination device.
+	gch::small_vector<instruction_id> successors;     ///< we collect successors as they are submitted
+
+	/// An instruction with no incomplete predecessors is ready for immediate assignment.
+	size_t num_incomplete_predecessors = 0;
+
+	/// An instruction with no unassigned (but some incomplete) predecessors may be eligible for eager assignment (see try_mark_for_assignment).
+	size_t num_unassigned_predecessors = 0;
+
+	/// Data that only exist in specific assignment states.
+	std::variant<unassigned_state, conditional_eagerly_assignable_state, unconditional_assignable_state, assigned_state> assignment;
+
+	explicit incomplete_instruction_state(const instruction* instr) : instr(instr), assignment(unassigned_state()) {}
+};
+
+/// State maintained per host thread queue or device in-order queue.
+struct lane_state {
+	size_t num_in_flight_assigned_instructions = 0;
+	const instruction* last_incomplete_submission = nullptr;
+};
+
+/// State maintained for every "multi-lane" target, i.e., `target::host_queue` and `target::device_queue[num_devices]`.
+struct target_state {
+	std::vector<lane_state> lanes;
+};
+
+// Implementation is behind a pimpl because we expect it to grow in complexity when adding support for waiting on inter-queue events to increase scheduling
+// "eagerness" when an instruction needs to wait on multiple incomplete predecessors. This can already be implemented with AdaptiveCpp using the
+// enqueue_custom_operation extension, but requires a similar interop story in DPC++, see https://github.com/intel/llvm/issues/13706 .
+struct engine_impl {
+	const system_info system;
+
+	target_state host_queue_target_state;
+	dense_map<device_id, target_state> device_queue_target_states;
+
+	/// The set of all instructions between submit() and complete_assigned(). Keyed by `instruction_id` to allow collecting successors through iterating over a
+	/// newly submitted instruction's dependencies, which are given in terms of instruction ids. Any dependency that is not found in `incomplete_instructions`
+	/// is assumed to have completed earlier (triggering its removal from the map).
+	std::unordered_map<instruction_id, incomplete_instruction_state> incomplete_instructions;
+
+	/// Queue of all instructions in `conditional_eagerly_assignable_state` and `unconditional_assignable_state`, in decreasing order of instruction priority.
+	std::priority_queue<const instruction*, std::vector<const instruction*>, instruction_priority_less> assignment_queue;
+
+	explicit engine_impl(const system_info& system);
+
+	// Non-copyable: Only used through unique_ptr.
+	~engine_impl() = default;
+	engine_impl(const engine_impl&) = delete;
+	engine_impl(engine_impl&&) = delete;
+	engine_impl& operator=(const engine_impl&) = delete;
+	engine_impl& operator=(engine_impl&&) = delete;
+
+	target_state& get_target_state(const target tgt, const std::optional<device_id>& device);
+
+	/// Retrieve state for an existing lane.
+	lane_state& get_lane_state(const target tgt, const std::optional<device_id>& device, const lane_id lane);
+
+	/// Linearly search for a lane that has no in-flight instructions within a target_state. If none exists, add an additional lane.
+	lane_id get_free_lane_id(const target tgt, const std::optional<device_id>& device);
+
+	/// Attempt to replace assignment state for an incomplete instruction with `conditional_eagerly_assignable_state` or `unconditional_assignable_state` in
+	/// response to either the initial submission or to completion of one or more predecessors. If successful, the instruction ends up in `assignment_queue`.
+	void try_mark_for_assignment(incomplete_instruction_state& node);
+
+	void submit(const instruction* const instr);
+
+	void complete(const instruction* const instr);
+
+	bool is_idle() const;
+
+	/// Return the highest-priority instruction from `assignment_queue` that is unconditionally assignable (helper).
+	incomplete_instruction_state* pop_assignable();
+
+	std::optional<assignment> assign_one();
+};
+
+engine_impl::engine_impl(const system_info& system) : system(system), device_queue_target_states(system.devices.size()) {}
+
+target_state& engine_impl::get_target_state(const target tgt, const std::optional<device_id>& device) {
+	switch(tgt) {
+	case target::host_queue: assert(!device.has_value()); return host_queue_target_state;
+	case target::device_queue: assert(device.has_value()); return device_queue_target_states[*device];
+	default: utils::unreachable();
+	}
+}
+
+lane_state& engine_impl::get_lane_state(const target tgt, const std::optional<device_id>& device, const lane_id lane) {
+	return get_target_state(tgt, device).lanes.at(lane);
+}
+
+lane_id engine_impl::get_free_lane_id(const target tgt, const std::optional<device_id>& device) {
+	auto& target_state = get_target_state(tgt, device);
+	for(lane_id lid = 0; lid < target_state.lanes.size(); ++lid) {
+		if(target_state.lanes[lid].num_in_flight_assigned_instructions == 0) return lid;
+	}
+	target_state.lanes.emplace_back();
+	return target_state.lanes.size() - 1;
+}
+
+void engine_impl::try_mark_for_assignment(incomplete_instruction_state& node) {
+	if(std::holds_alternative<assigned_state>(node.assignment)                     // already assigned
+	    || std::holds_alternative<unconditional_assignable_state>(node.assignment) // no upgrade path from here
+	    || node.num_unassigned_predecessors > 0) {                                 // an instruction cannot be assigned before its predecessors
+		return;
+	}
+
+	if(std::holds_alternative<conditional_eagerly_assignable_state>(node.assignment)) {
+		// already in assignment_queue - try upgrading to `unconditional_assignable_state`
+		if(node.num_incomplete_predecessors == 0) { node.assignment = unconditional_assignable_state{}; }
+		return;
+	}
+
+	assert(std::holds_alternative<unassigned_state>(node.assignment));
+	if(node.num_incomplete_predecessors == 0) {
+		node.assignment = unconditional_assignable_state{};
+		assignment_queue.push(node.instr);
+		return;
+	}
+
+	auto& unassigned = std::get<unassigned_state>(node.assignment);
+	if(!unassigned.probe_for_eager_assignment) return; // shortcut: we know this to be false ahead-of-time in many cases
+
+	// We don't do eager assignment for the immediate target (because there is no in-order queueing behavior) nor for the `alloc_queue` target (because
+	// allocations currently never form dependency chains where this would be beneficial - this might change though when we implement IDAG allocation pooling).
+	assert(node.target == target::device_queue || node.target == target::host_queue);
+
+	// The instruction still has pending dependencies, so it can't be assigned immediately, but might be assigned eagerly to a thread queue or in-order queue if
+	// (1) all its dependencies are on the same device and lane and (2) one of the dependencies is the last submitted instruction within that lane. We still
+	// require it to go through `assignment_queue` first for priority ordering, so condition (2) can change if another, higher-priority instruction is
+	// popped and assigned before this instruction - in that case, we revert back to `unassigned_state` (see pop_assignable).
+	std::optional<conditional_eagerly_assignable_state>
+	    eagerly_assignable_now; // accumulator for verifying that _all_ incomplete dependencies are on the same lane
+	for(auto dep_iid : node.instr->get_dependencies()) {
+		const auto dep_it = incomplete_instructions.find(dep_iid);
+		if(dep_it == incomplete_instructions.end()) continue; // dependency has completed before
+
+		auto& [_, dep] = *dep_it;
+		auto& dep_assigned = std::get<assigned_state>(dep.assignment); // otherwise num_unassigned_predecessors would have been > 0 above
+
+		if(dep.target != node.target) return; // incompatible targets
+
+		assert(dep_assigned.device.has_value() != dep.eligible_devices.empty());
+		if(dep_assigned.device.has_value()
+		    && std::find(node.eligible_devices.begin(), node.eligible_devices.end(), *dep_assigned.device) == node.eligible_devices.end()) {
+			return; // dependency's device is not eligible for this instruction
+		}
+
+		if(eagerly_assignable_now.has_value()) {
+			if(eagerly_assignable_now->device != dep_assigned.device) return; // there are dependencies on more than one device
+			if(eagerly_assignable_now->lane != dep_assigned.lane) return;     // there are dependencies on multiple lanes
+		} else {
+			assert(dep_assigned.lane.has_value());
+			eagerly_assignable_now = conditional_eagerly_assignable_state{dep_assigned.device, *dep_assigned.lane};
+		}
+
+		auto& lane = get_lane_state(node.target, eagerly_assignable_now->device, eagerly_assignable_now->lane);
+		if(lane.last_incomplete_submission == dep.instr) { eagerly_assignable_now->expected_last_submission_on_lane = dep.instr; }
+	}
+
+	// If we didn't return early so far (1) all incomplete dependencies are on the same lane
+	assert(eagerly_assignable_now.has_value()); // otherwise num_incomplete_predecessors would have been == 0 above
+
+	// Only if (2) one of the incomplete dependencies was last in the target lane will this be non-null
+	if(eagerly_assignable_now->expected_last_submission_on_lane == nullptr) return;
+
+	node.assignment = *eagerly_assignable_now;
+	assignment_queue.push(node.instr);
+}
+
+void engine_impl::submit(const instruction* const instr) {
+	const auto iid = instr->get_id();
+	auto [node_it, inserted] = incomplete_instructions.emplace(iid, incomplete_instruction_state(instr));
+	assert(inserted);
+	auto& node = node_it->second;
+
+	const auto add_eligible_devices_by_memory_id = [&](const memory_id mid) {
+		/// We assume that there's either a 1:1 device <-> memory mapping for device-accessible memory, or when it's not, it's irrelevant which device we
+		/// dispatch alloc / free instructions to.
+		for(device_id did = 0; did < system.devices.size(); ++did) {
+			if(system.devices[did].native_memory == mid) { node.eligible_devices.push_back(did); }
+		}
+	};
+
+	// Perform target / queue assignment here instead of instruction graph generation time because the IDAG is too abstract of a description to know
+	// about in-order queues, and because at least for copy-instruction we want to retain dynamic queue assignment to submit to either the source or
+	// destination device and lengthen the path that can be scheduled onto a single in-order queue.
+	matchbox::match(
+	    *instr,                                //
+	    [&](const alloc_instruction& ainstr) { //
+		    node.target = target::alloc_queue;
+		    add_eligible_devices_by_memory_id(ainstr.get_allocation_id().get_memory_id());
+	    },
+	    [&](const free_instruction& finstr) { //
+		    node.target = target::alloc_queue;
+		    add_eligible_devices_by_memory_id(finstr.get_allocation_id().get_memory_id());
+	    },
+	    [&](const copy_instruction& cinstr) {
+		    const auto source_mid = cinstr.get_source_allocation().id.get_memory_id();
+		    const auto dest_mid = cinstr.get_dest_allocation().id.get_memory_id();
+
+		    // Eligible devices are tried in array-order within `assign_one`. If no other constraints exist, prefer assigning this instruction to the
+		    // dest-memory device to allow eager assignment of a subsequent kernel launch to the same in-order queue.
+		    add_eligible_devices_by_memory_id(dest_mid);
+		    add_eligible_devices_by_memory_id(source_mid);
+
+		    if(!node.eligible_devices.empty()) {
+			    node.target = target::device_queue;
+		    } else {
+			    assert(source_mid <= host_memory_id && dest_mid <= host_memory_id);
+			    node.target = target::host_queue;
+		    }
+	    },
+	    [&](const device_kernel_instruction& dkinstr) {
+		    node.target = target::device_queue;
+		    node.eligible_devices.push_back(dkinstr.get_device_id());
+	    },
+	    [&](const host_task_instruction& htinstr) { //
+		    node.target = target::host_queue;
+	    },
+	    [&](const clone_collective_group_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const send_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const receive_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const split_receive_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const await_receive_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const gather_receive_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const fill_identity_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const reduce_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const fence_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const destroy_host_object_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const horizon_instruction& /* other */) { node.target = target::immediate; },
+	    [&](const epoch_instruction& /* other */) { node.target = target::immediate; });
+
+	auto& unassigned = node.assignment.emplace<unassigned_state>();
+	// target::immediate is not backed by an in-order queue, and alloc/free_instructions do not generate dependency chains frequently enough to justify
+	// maintaining an in_order_queue_state
+	unassigned.probe_for_eager_assignment = node.target == target::device_queue || node.target == target::host_queue;
+
+	for(const auto pred_iid : instr->get_dependencies()) {
+		// If predecessor is not found in `incomplete_instructions`, it has completed previously
+		if(const auto pred_it = incomplete_instructions.find(pred_iid); pred_it != incomplete_instructions.end()) {
+			auto& predecessor = pred_it->second;
+			predecessor.successors.push_back(iid);
+			++node.num_incomplete_predecessors;
+			if(!std::holds_alternative<assigned_state>(predecessor.assignment)) { ++node.num_unassigned_predecessors; }
+		}
+	}
+
+	// It might be possible to immediately assign the new instruction
+	try_mark_for_assignment(node);
+}
+
+void engine_impl::complete(const instruction* const instr) {
+	const auto node_it = incomplete_instructions.find(instr->get_id());
+	assert(node_it != incomplete_instructions.end());
+	auto deleted_node = std::move(node_it->second); // move so we can access members / iterate successors after erasure
+	incomplete_instructions.erase(node_it);
+
+	auto& was_assigned = std::get<assigned_state>(deleted_node.assignment);
+	if(deleted_node.target == target::host_queue || deleted_node.target == target::device_queue) {
+		// "remove" instruction from assigned lane
+		assert(was_assigned.lane.has_value());
+		auto& lane = get_lane_state(deleted_node.target, was_assigned.device, *was_assigned.lane);
+		assert(lane.num_in_flight_assigned_instructions > 0);
+		lane.num_in_flight_assigned_instructions -= 1;
+		if(lane.last_incomplete_submission == instr) { lane.last_incomplete_submission = nullptr; }
+	}
+
+	for(const auto succ_iid : deleted_node.successors) {
+		// When multiple instructions complete in the same time step, out_of_order_engine explicitly allows them to be marked as completed in arbitrary
+		// order even if that would violate the internal dependency relationship. This avoids the need for duplicating dependency tracking elsewhere.
+		// As a consequence, some successors might have already been removed from the set and we need to call find() instead of at() here.
+		if(const auto succ_it = incomplete_instructions.find(succ_iid); succ_it != incomplete_instructions.end()) {
+			auto& successor = succ_it->second;
+			assert(successor.num_incomplete_predecessors > 0);
+			--successor.num_incomplete_predecessors;
+			try_mark_for_assignment(successor);
+		}
+	}
+}
+
+bool engine_impl::is_idle() const {
+#ifndef NDEBUG
+	if(incomplete_instructions.empty()) {
+		assert(assignment_queue.empty());
+		for(const auto& device_state : device_queue_target_states) {
+			for(const auto& lane : device_state.lanes) {
+				assert(lane.num_in_flight_assigned_instructions == 0);
+			}
+		}
+		for(const auto& lane : host_queue_target_state.lanes) {
+			assert(lane.num_in_flight_assigned_instructions == 0);
+		}
+	}
+#endif
+	return incomplete_instructions.empty();
+}
+
+incomplete_instruction_state* engine_impl::pop_assignable() {
+	while(!assignment_queue.empty()) {
+		const auto instr = assignment_queue.top();
+		assignment_queue.pop();
+
+		auto& node = incomplete_instructions.at(instr->get_id());
+		assert(node.num_unassigned_predecessors == 0);
+
+		if(const auto eagerly_assignable_when_pushed = std::get_if<conditional_eagerly_assignable_state>(&node.assignment)) {
+			assert(node.num_incomplete_predecessors > 0); // otherwise this would be an immediately_assignable_state
+			assert(eagerly_assignable_when_pushed->expected_last_submission_on_lane != nullptr);
+			const auto& lane = get_lane_state(node.target, eagerly_assignable_when_pushed->device, eagerly_assignable_when_pushed->lane);
+			if(lane.last_incomplete_submission == nullptr
+			    || lane.last_incomplete_submission == eagerly_assignable_when_pushed->expected_last_submission_on_lane) {
+				// Our preferred lane is still in the required state to go through with eager assignment
+				return &node;
+			} else {
+				// A third instruction has been submitted to our preferred lane since, so we drop eager assignment and don't need to attempt it again, since
+				// none of our dependencies can now end up last in the queue anymore.
+				node.assignment.emplace<unassigned_state>().probe_for_eager_assignment = false;
+				continue;
+			}
+		} else {
+			assert(std::holds_alternative<unconditional_assignable_state>(node.assignment));
+			assert(node.num_incomplete_predecessors == 0);
+			return &node;
+		}
+	}
+
+	return nullptr;
+}
+
+std::optional<assignment> engine_impl::assign_one() {
+	const auto node_ptr = pop_assignable();
+	if(node_ptr == nullptr) return std::nullopt;
+
+	auto& node = *node_ptr;
+
+	assigned_state assigned;
+	if(const auto& eagerly_assignable = std::get_if<conditional_eagerly_assignable_state>(&node.assignment)) {
+		// After an instruction is popped from the assignment queue, "eager-assignability" is unconditional. Force-assign to the same lane to implicitly fulfill
+		// all remaining dependencies through queue ordering.
+		assigned.device = eagerly_assignable->device;
+		assigned.lane = eagerly_assignable->lane;
+		assert(
+		    assigned.lane.has_value() && eagerly_assignable->expected_last_submission_on_lane != nullptr
+		    && get_lane_state(node.target, assigned.device, *assigned.lane).last_incomplete_submission == eagerly_assignable->expected_last_submission_on_lane);
+	} else {
+		if(!node.eligible_devices.empty()) {
+			// "Heuristically" pick a device
+			assert(node.target == target::alloc_queue || node.target == target::device_queue);
+			assigned.device = node.eligible_devices.front();
+		}
+		if(node.target == target::host_queue || node.target == target::device_queue) { //
+			// Select a free existing lane or create a new one. This might cause excessive numbers of threads or in-order queues to be constructed in the
+			// backend (even though this number is indirectly bounded by breadth horizons). TODO in the future consider limiting the number of lanes while
+			// avoiding potential deadlocks that can then arise from stalling / temporally re-ordering collective host tasks between nodes.
+			assigned.lane = get_free_lane_id(node.target, assigned.device);
+		}
+	}
+	node.assignment = assigned;
+
+	if(assigned.lane.has_value()) {
+		auto& lane = get_lane_state(node.target, assigned.device, *assigned.lane);
+		lane.num_in_flight_assigned_instructions += 1;
+		lane.last_incomplete_submission = node.instr;
+	}
+
+	for(const auto successor : node.successors) {
+		auto& successor_node = incomplete_instructions.at(successor);
+		assert(successor_node.num_unassigned_predecessors > 0);
+		if(--successor_node.num_unassigned_predecessors == 0) {
+			// might now be eligible for eager assignment
+			try_mark_for_assignment(successor_node);
+		}
+	}
+
+	return assignment{node.instr, node.target, assigned.device, assigned.lane};
+}
+
+} // namespace celerity::detail::out_of_order_engine_detail
+
+namespace celerity::detail {
+
+out_of_order_engine::out_of_order_engine(const system_info& system) : m_impl(new out_of_order_engine_detail::engine_impl(system)) {}
+out_of_order_engine::~out_of_order_engine() = default;
+bool out_of_order_engine::is_idle() const { return m_impl->is_idle(); }
+void out_of_order_engine::submit(const instruction* const instr) { m_impl->submit(instr); }
+void out_of_order_engine::complete_assigned(const instruction* instr) { m_impl->complete(instr); }
+std::optional<out_of_order_engine::assignment> out_of_order_engine::assign_one() { return m_impl->assign_one(); }
+
+} // namespace celerity::detail

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -61,6 +61,11 @@ std::string escape_for_dot_label(std::string str) {
 	return str;
 }
 
+[[noreturn]] void unreachable() {
+	assert(!"executed unreachable code");
+	abort();
+}
+
 // The panic solution defaults to `log_and_abort`, but is set to `throw_logic_error` in test binaries. Since panics are triggered from celerity library code, we
 // manage it in a global and decide which path to take at runtime. We have also considered deciding this at link time by defining a weak symbol (GCC
 // __attribute__((weak))) in the library which is overwritten by a strong symbol in the test library, but decided against this because there is no equivalent in

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_TARGETS
   instruction_graph_misc_tests
   instruction_graph_p2p_tests
   instruction_graph_reduction_tests
+  out_of_order_engine_tests
   print_graph_tests
   region_map_tests
   range_tests

--- a/test/out_of_order_engine_tests.cc
+++ b/test/out_of_order_engine_tests.cc
@@ -1,0 +1,586 @@
+#include "instruction_graph.h"
+#include "launcher.h"
+#include "out_of_order_engine.h"
+#include "test_utils.h"
+#include "types.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+using namespace celerity;
+using namespace celerity::detail;
+
+
+class assigned_set_query {
+  public:
+	explicit assigned_set_query(std::vector<out_of_order_engine::assignment> isq_vec) : m_assignments(std::move(isq_vec)) {}
+
+	/// Has `instr` been assigned with `target::immediate`?
+	bool executed_immediately(const instruction* instr) const {
+		const auto it = std::find_if(m_assignments.begin(), m_assignments.end(),
+		    [&](const out_of_order_engine::assignment& isq) { return isq.instruction == instr && isq.target == out_of_order_engine::target::immediate; });
+		return it != m_assignments.end();
+	}
+
+	/// Has `instr` been assigned with `target::alloc_queue`?
+	bool queued_for_alloc(const instruction* instr) const {
+		const auto it = std::find_if(m_assignments.begin(), m_assignments.end(),
+		    [&](const out_of_order_engine::assignment& isq) { return isq.instruction == instr && isq.target == out_of_order_engine::target::alloc_queue; });
+		return it != m_assignments.end();
+	}
+
+	/// Has `instr` been assigned with `target::host_queue`?
+	bool queued_on_host(const instruction* instr) const {
+		const auto it = std::find_if(m_assignments.begin(), m_assignments.end(),
+		    [&](const out_of_order_engine::assignment& isq) { return isq.instruction == instr && isq.target == out_of_order_engine::target::host_queue; });
+		return it != m_assignments.end();
+	}
+
+	/// Has `instr` been assigned with `target::device_queue` for `device`?
+	bool queued_on_device(const instruction* instr, const device_id device) const {
+		const auto it = std::find_if(m_assignments.begin(), m_assignments.end(), [&](const out_of_order_engine::assignment& isq) {
+			return isq.instruction == instr && isq.target == out_of_order_engine::target::device_queue && isq.device == device;
+		});
+		return it != m_assignments.end();
+	}
+
+	/// True if exactly `expected` instructions were assigned and no more.
+	bool assigned_instructions_are(std::vector<const instruction*> expected) const {
+		std::vector<const instruction*> actual(m_assignments.size());
+		std::transform(m_assignments.begin(), m_assignments.end(), actual.begin(), [](const out_of_order_engine::assignment& isq) { return isq.instruction; });
+		std::sort(actual.begin(), actual.end());
+		std::sort(expected.begin(), expected.end());
+		return actual == expected;
+	}
+
+	/// True iff all instructions in `sequence` are assigned to the same lane in the given order.
+	bool assigned_in_order(std::vector<const instruction*> sequence) const {
+		auto isq_it = m_assignments.begin();
+		std::optional<out_of_order_engine::target> prev_target;
+		std::optional<device_id> prev_device;
+		std::optional<size_t> prev_lane;
+		for(auto seq_it = sequence.begin(); seq_it != sequence.end(); ++seq_it) {
+			while(isq_it != m_assignments.end() && isq_it->instruction != *seq_it) {
+				++isq_it;
+			}
+			if(isq_it == m_assignments.end()) return false;
+
+			if(prev_target.has_value() && prev_target != isq_it->target) return false;
+			if(prev_device.has_value() && prev_device != isq_it->device) return false;
+			if(prev_lane.has_value() && prev_lane != isq_it->lane) return false;
+			prev_target = isq_it->target;
+			prev_device = isq_it->device;
+			prev_lane = isq_it->lane;
+		}
+		return true;
+	}
+
+	/// True iff all instructions in `left` and `right` are assigned, but never any from `left` and `right` both on the same lane.
+	bool assigned_concurrently(const std::vector<const instruction*>& left, const std::vector<const instruction*>& right) const {
+		for(const auto l : left) {
+			for(const auto r : right) {
+				const auto al = std::find_if(m_assignments.begin(), m_assignments.end(), //
+				    [&](const out_of_order_engine::assignment& isq) { return isq.instruction == l; });
+				const auto ar = std::find_if(m_assignments.begin(), m_assignments.end(), //
+				    [&](const out_of_order_engine::assignment& isq) { return isq.instruction == r; });
+				if(al == m_assignments.end() || ar == m_assignments.end()) return false;
+				return al->target != ar->target || al->device != ar->device || al->lane != ar->lane;
+			}
+		}
+		return true;
+	}
+
+	/// Requires that `instr` is assigned and returns the original `assignment` for that instruction.
+	const out_of_order_engine::assignment& assignment_for(const instruction* instr) const {
+		const auto it =
+		    std::find_if(m_assignments.begin(), m_assignments.end(), [=](const out_of_order_engine::assignment& a) { return a.instruction == instr; });
+		REQUIRE(it != m_assignments.end());
+		return *it;
+	}
+
+  private:
+	std::vector<out_of_order_engine::assignment> m_assignments;
+};
+
+/// Creates instructions directly (without going through graph generation) and submits them to an out_of_order_engine.
+class out_of_order_test_context {
+  public:
+	explicit out_of_order_test_context(const size_t num_devices) : m_engine(test_utils::make_system_info(num_devices, true /* supports_d2d_copies */)) {}
+
+	const instruction* alloc(const std::vector<const instruction*>& dependencies, const memory_id mid, const int priority = 0) {
+		return create<alloc_instruction>(dependencies, priority, allocation_id(mid, 1), 1024, 1);
+	}
+
+	const instruction* free(const std::vector<const instruction*>& dependencies, const memory_id mid, const int priority = 0) {
+		return create<free_instruction>(dependencies, priority, allocation_id(mid, 1));
+	}
+
+	const instruction* device_kernel(const std::vector<const instruction*>& dependencies, const device_id did, const int priority = 0) {
+		return create<device_kernel_instruction>(
+		    dependencies, priority, did, device_kernel_launcher{}, box<3>(), buffer_access_allocation_map{},
+		    buffer_access_allocation_map {} //
+		    CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, task_id(0), "task"));
+	}
+
+	const instruction* copy(const std::vector<const instruction*>& dependencies, const memory_id source, const memory_id dest, const int priority = 0) {
+		const box<3> box(id(0, 0, 0), id(1, 1, 1));
+		return create<copy_instruction>(dependencies, priority, allocation_id(source, 1), allocation_id(dest, 1), box, box, box, sizeof(int));
+	}
+
+	const instruction* host_task(const std::vector<const instruction*>& dependencies, const int priority = 0) {
+		return create<host_task_instruction>(
+		    dependencies, priority, host_task_launcher{}, box<3>(), range<3>(), buffer_access_allocation_map{},
+		    collective_group_id {} CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, task_id(0), "task"));
+	}
+
+	const instruction* epoch(const std::vector<const instruction*>& dependencies, const int priority = 0) {
+		return create<epoch_instruction>(dependencies, priority, task_id(0), epoch_action::none, instruction_garbage{});
+	}
+
+	void complete(const instruction* instr) { m_engine.complete_assigned(instr); }
+
+	std::optional<out_of_order_engine::assignment> assign_one() {
+		const auto assignment = m_engine.assign_one();
+		if(assignment.has_value()) {
+			CHECK(assignment->instruction != nullptr);
+			switch(assignment->target) {
+			case out_of_order_engine::target::immediate: //
+				CHECK(assignment->device == std::nullopt);
+				CHECK(assignment->lane == std::nullopt);
+				break;
+			case out_of_order_engine::target::alloc_queue: //
+				CHECK(assignment->lane == std::nullopt);
+				break;
+			case out_of_order_engine::target::host_queue: //
+				CHECK(assignment->device == std::nullopt);
+				CHECK(assignment->lane.has_value());
+				break;
+			case out_of_order_engine::target::device_queue: //
+				CHECK(assignment->device.has_value());
+				CHECK(assignment->lane.has_value());
+				break;
+			default: FAIL();
+			}
+		}
+		return assignment;
+	}
+
+	assigned_set_query assign_all() {
+		std::vector<out_of_order_engine::assignment> isq_vec;
+		while(const auto assignment = assign_one()) {
+			isq_vec.push_back(*assignment);
+		}
+		return assigned_set_query(std::move(isq_vec));
+	}
+
+	bool is_idle() const { return m_engine.is_idle(); }
+
+  private:
+	instruction_id m_next_iid = 0;
+	std::vector<std::unique_ptr<instruction>> m_instrs;
+	out_of_order_engine m_engine;
+
+	template <typename Instruction, typename... CtorParams>
+	const instruction* create(const std::vector<const instruction*>& dependencies, const int priority, const CtorParams&... ctor_args) {
+		const auto iid = m_next_iid++;
+		const auto instr = m_instrs.emplace_back(std::make_unique<Instruction>(iid, priority, ctor_args...)).get();
+		for(const auto dep : dependencies) {
+			instr->add_dependency(dep->get_id());
+		}
+		m_engine.submit(instr);
+		return instr;
+	}
+};
+
+TEST_CASE("out_of_order_engine schedules independent chains concurrently", "[out_of_order_engine]") {
+	out_of_order_test_context octx(4);
+	const auto d0_k0 = octx.device_kernel({}, device_id(0));
+	const auto d1_k0 = octx.device_kernel({}, device_id(1));
+	const auto d0_k1 = octx.device_kernel({d0_k0}, device_id(0));
+	const auto d1_k1 = octx.device_kernel({d1_k0}, device_id(1));
+	const auto h0 = octx.host_task({d0_k1, d1_k1});
+	const auto h1 = octx.host_task({h0});
+	const auto h2 = octx.host_task({h0, h1});
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({d0_k0, d0_k1, d1_k0, d1_k1}));
+		CHECK(iq.queued_on_device(d0_k0, device_id(0)));
+		CHECK(iq.queued_on_device(d0_k1, device_id(0)));
+		CHECK(iq.queued_on_device(d1_k0, device_id(1)));
+		CHECK(iq.queued_on_device(d1_k1, device_id(1)));
+		CHECK(iq.assigned_in_order({d0_k0, d0_k1}));
+		CHECK(iq.assigned_in_order({d1_k0, d1_k1}));
+		CHECK(iq.assigned_concurrently({d0_k0, d0_k1}, {d1_k0, d1_k1}));
+	}
+
+	octx.complete(d0_k0);
+	octx.complete(d0_k1);
+	octx.complete(d1_k0);
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({}));
+	}
+
+	octx.complete(d1_k1);
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({h0, h1, h2}));
+		CHECK(iq.assigned_in_order({h0, h1, h2}));
+	}
+}
+
+TEST_CASE("out_of_order_engine eagerly assigns copy-instructions to the lanes of their dependencies", "[out_of_order_engine]") {
+	out_of_order_test_context octx(4);
+	const auto d0_k0 = octx.device_kernel({}, device_id(0));
+	const auto d1_k0 = octx.device_kernel({}, device_id(1));
+	const auto d2_k0 = octx.device_kernel({}, device_id(2));
+	const auto d3_k0 = octx.device_kernel({}, device_id(3));
+	const auto copy_dep0 = octx.copy({d0_k0}, first_device_memory_id, first_device_memory_id + 1);
+	const auto copy_dep1 = octx.copy({d1_k0}, first_device_memory_id, first_device_memory_id + 1);
+	const auto copy_dep2 = octx.copy({d2_k0}, host_memory_id, first_device_memory_id + 2);
+	const auto copy_dep3 = octx.copy({d3_k0}, first_device_memory_id + 3, host_memory_id);
+	const auto copy_host = octx.copy({copy_dep3}, host_memory_id, host_memory_id); // can't be enqueued on a device in-order queue
+
+	CHECK_FALSE(octx.is_idle());
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({d0_k0, d1_k0, d2_k0, d3_k0, copy_dep0, copy_dep1, copy_dep2, copy_dep3}));
+		CHECK(iq.queued_on_device(d0_k0, device_id(0)));
+		CHECK(iq.queued_on_device(d1_k0, device_id(1)));
+		CHECK(iq.queued_on_device(d2_k0, device_id(2)));
+		CHECK(iq.queued_on_device(d3_k0, device_id(3)));
+		CHECK(iq.assigned_in_order({d0_k0, copy_dep0}));
+		CHECK(iq.assigned_in_order({d1_k0, copy_dep1}));
+		CHECK(iq.assigned_in_order({d2_k0, copy_dep2}));
+		CHECK(iq.assigned_in_order({d3_k0, copy_dep3}));
+	}
+
+	octx.complete(d0_k0);
+	octx.complete(d1_k0);
+	octx.complete(d2_k0);
+	octx.complete(d3_k0);
+	CHECK_FALSE(octx.is_idle());
+
+	const auto copy_indep0 = octx.copy({d0_k0 /* already complete */}, first_device_memory_id + 1, first_device_memory_id);
+	const auto copy_indep1 = octx.copy({d1_k0 /* already complete */}, first_device_memory_id, first_device_memory_id + 1);
+	const auto copy_indep2 = octx.copy({d2_k0 /* already complete */}, first_device_memory_id + 1, first_device_memory_id + 2);
+	const auto copy_indep3 = octx.copy({d3_k0 /* already complete */}, first_device_memory_id, first_device_memory_id + 3);
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({copy_indep0, copy_indep1, copy_indep2, copy_indep3}));
+		CHECK((iq.queued_on_device(copy_indep0, device_id(1)) || iq.queued_on_device(copy_indep0, device_id(0))));
+		CHECK((iq.queued_on_device(copy_indep1, device_id(0)) || iq.queued_on_device(copy_indep1, device_id(1))));
+		CHECK((iq.queued_on_device(copy_indep2, device_id(1)) || iq.queued_on_device(copy_indep2, device_id(2))));
+		CHECK((iq.queued_on_device(copy_indep3, device_id(0)) || iq.queued_on_device(copy_indep3, device_id(3))));
+	}
+
+	octx.complete(copy_dep2);
+	octx.complete(copy_dep1);
+	octx.complete(copy_dep0);
+	octx.complete(copy_dep3);
+	CHECK_FALSE(octx.is_idle());
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({copy_host}));
+		CHECK(iq.queued_on_host(copy_host));
+	}
+
+	octx.complete(copy_indep2);
+	octx.complete(copy_indep1);
+	octx.complete(copy_indep0);
+	octx.complete(copy_indep3);
+	CHECK_FALSE(octx.is_idle());
+
+	octx.complete(copy_host);
+	CHECK(octx.is_idle());
+}
+
+TEST_CASE("alloc / free instructions are scheduled on alloc_queue instead of host_queue", "[out_of_order_engine]") {
+	out_of_order_test_context octx(1);
+	const auto init_epoch = octx.epoch({});
+	const auto alloc_host = octx.alloc({init_epoch}, host_memory_id);
+	const auto alloc_device = octx.alloc({init_epoch}, first_device_memory_id);
+	const auto host_task = octx.host_task({alloc_host});
+	const auto device_kernel = octx.device_kernel({alloc_device}, device_id(0));
+	const auto free_host = octx.free({host_task}, host_memory_id);
+	const auto free_device = octx.free({device_kernel}, first_device_memory_id);
+	CHECK_FALSE(octx.is_idle());
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({init_epoch}));
+		CHECK(iq.executed_immediately(init_epoch));
+	}
+
+	octx.complete(init_epoch);
+	CHECK_FALSE(octx.is_idle());
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({alloc_host, alloc_device}));
+		CHECK(iq.queued_for_alloc(alloc_host));
+		CHECK(iq.queued_for_alloc(alloc_device));
+		CHECK(iq.assignment_for(alloc_host).device == std::nullopt);
+		CHECK(iq.assignment_for(alloc_device).device == device_id(0));
+	}
+
+	octx.complete(alloc_host);
+	octx.complete(alloc_device);
+	CHECK_FALSE(octx.is_idle());
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({host_task, device_kernel}));
+		CHECK(iq.queued_on_host(host_task));
+		CHECK(iq.queued_on_device(device_kernel, device_id(0)));
+	}
+
+	octx.complete(host_task);
+	octx.complete(device_kernel);
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({free_host, free_device}));
+		CHECK(iq.queued_for_alloc(free_host));
+		CHECK(iq.queued_for_alloc(free_device));
+	}
+
+	octx.complete(free_host);
+	octx.complete(free_device);
+	CHECK(octx.is_idle());
+}
+
+TEST_CASE("out_of_order_engine does not attempt to assign instructions more than once in the presence of eager assignment", "[out_of_order_engine]") {
+	out_of_order_test_context octx(1);
+	auto k1 = octx.device_kernel({}, device_id(0));
+	auto k2 = octx.device_kernel({k1}, device_id(0));
+
+	const auto assigned = octx.assign_one();
+	REQUIRE(assigned.has_value());
+	CHECK(assigned->instruction == k1);
+
+	octx.complete(k1);
+
+	const auto other = octx.assign_all();
+	CHECK(other.assigned_instructions_are({k2}));
+
+	octx.complete(k2);
+	CHECK(octx.is_idle());
+}
+
+// Even though instructions on an in-order queue / thread queue logically always finish in the order they were submitted, we might not poll events in the same
+// order within the executor (without additional effort), so out_of_order_engine instead supports completing instructions out-of-order (at little extra cost).
+TEST_CASE("assigned sets of instructions with internal dependencies can be completed out-of-order", "[out_of_order_engine]") {
+	out_of_order_test_context octx(1);
+	auto k1 = octx.device_kernel({}, device_id(0));
+	auto k2 = octx.device_kernel({k1}, device_id(0));
+
+	octx.assign_all();
+	CHECK_FALSE(octx.is_idle());
+
+	octx.complete(k2);
+	CHECK_FALSE(octx.is_idle());
+
+	octx.complete(k1);
+	CHECK(octx.is_idle());
+}
+
+TEST_CASE("concurrent instructions are assigned in decreasing priority", "[out_of_order_engine]") {
+	out_of_order_test_context octx(1);
+	auto k1 = octx.device_kernel({}, device_id(0), /* priority */ 1);
+	auto k3 = octx.device_kernel({}, device_id(0), /* priority */ 3);
+	auto k2 = octx.device_kernel({}, device_id(0), /* priority */ 2);
+
+	const auto first = octx.assign_one();
+	REQUIRE(first.has_value());
+	CHECK(first->instruction == k3);
+
+	const auto second = octx.assign_one();
+	REQUIRE(second.has_value());
+	CHECK(second->instruction == k2);
+
+	const auto third = octx.assign_one();
+	REQUIRE(third.has_value());
+	CHECK(third->instruction == k1);
+}
+
+TEST_CASE("eagerly-assignable instructions become immediately assignable once their predecessors complete", "[out_of_order_engine]") {
+	out_of_order_test_context octx(1);
+	auto k1 = octx.device_kernel({}, device_id(0), /* priority */ 0);
+	auto k2 = octx.device_kernel({k1}, device_id(0), /* priority */ 1);
+	auto k3 = octx.device_kernel({k1}, device_id(0), /* priority */ 0);
+	auto k4 = octx.device_kernel({k2}, device_id(0), /* priority */ 2);
+
+	const auto first = octx.assign_one();
+	REQUIRE(first.has_value());
+	CHECK(first->instruction == k1);
+
+	const auto second = octx.assign_one();
+	REQUIRE(second.has_value());
+	CHECK(second->instruction == k2);
+
+	// complete out-of-order so we are able to distinguish between eager and immediate assignment of k4
+	octx.complete(k2);
+
+	const auto third = octx.assign_one();
+	REQUIRE(third.has_value());
+	CHECK(third->instruction == k4); // immediately assignable now; highest priority
+}
+
+TEST_CASE("eagerly-assignable instructions remain so as long as their predecessors are partially complete", "[out_of_order_engine]") {
+	out_of_order_test_context octx(1);
+	const auto k1 = octx.device_kernel({}, device_id(0));
+	const auto k2 = octx.device_kernel({k1}, device_id(0));
+	const auto k3 = octx.device_kernel({k2}, device_id(0));
+	const auto k4 = octx.device_kernel({k3}, device_id(0));
+
+	const auto first = octx.assign_one();
+	REQUIRE(first.has_value());
+	CHECK(first->instruction == k1);
+
+	const auto second = octx.assign_one();
+	REQUIRE(second.has_value());
+	CHECK(second->instruction == k2);
+
+	const auto complete_first = GENERATE(values({1 /* in-order completion */, 2 /* out-of-order completion */}));
+	CAPTURE(complete_first);
+
+	octx.complete(complete_first == 1 ? k1 : k2);
+
+	const auto rest = octx.assign_all();
+	CHECK(rest.assigned_instructions_are({k3, k4}));
+	CHECK(rest.assigned_in_order({k3, k4}));
+}
+
+TEST_CASE("instructions are not eagerly assigned if their predecessors are assigned to a different device", "[out_of_order_engine]") {
+	out_of_order_test_context octx(2);
+	const auto k1 = octx.device_kernel({}, device_id(0));
+	const auto k2 = octx.device_kernel({k1}, device_id(1));
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({k1}));
+		CHECK(iq.queued_on_device(k1, device_id(0)));
+	}
+
+	octx.complete(k1);
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({k2}));
+		CHECK(iq.queued_on_device(k2, device_id(1)));
+	}
+
+	octx.complete(k2);
+	CHECK(octx.is_idle());
+}
+
+TEST_CASE("instructions are not eagerly assigned if their predecessors are assigned to a different lanes", "[out_of_order_engine]") {
+	out_of_order_test_context octx(2);
+	const auto k1 = octx.host_task({});
+	const auto k2 = octx.host_task({});
+	const auto k3 = octx.host_task({k1, k2});
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({k1, k2}));
+		CHECK(iq.queued_on_host(k1));
+		CHECK(iq.queued_on_host(k2));
+	}
+
+	const auto k_complete_first = GENERATE(values({1, 2}));
+	octx.complete(k_complete_first == 1 ? k1 : k2);
+
+	{
+		const auto iq = octx.assign_all();
+		CHECK(iq.assigned_instructions_are({k3}));
+	}
+
+	octx.complete(k_complete_first == 1 ? k2 : k1);
+	octx.complete(k3);
+	CHECK(octx.is_idle());
+}
+
+TEST_CASE("instructions with predecessors on multiple devices are eagerly assigned only if the last remaining dependency is on the same device",
+    "[out_of_order_engine]") //
+{
+	out_of_order_test_context octx(2);
+	const auto k1_d0 = octx.device_kernel({}, device_id(0));
+	const auto k2_d1 = octx.device_kernel({}, device_id(1));
+	const auto k3_d0 = octx.device_kernel({k1_d0, k2_d1}, device_id(0));
+
+	const auto iq_first = octx.assign_all();
+	CHECK(iq_first.assigned_instructions_are({k1_d0, k2_d1}));
+
+	const auto k_complete_first = GENERATE(values({1, 2}));
+	octx.complete(k_complete_first == 1 ? k1_d0 : k2_d1);
+
+	const auto iq_last = octx.assign_all();
+	if(k_complete_first == 2) {
+		// k2_d1 was completed first, so k3_d0 should be assigned to the same lane as k1_d0
+		CHECK(iq_last.assigned_instructions_are({k3_d0}));
+		CHECK(iq_last.queued_on_device(k3_d0, device_id(0)));
+		CHECK(iq_last.assignment_for(k3_d0).lane == iq_first.assignment_for(k1_d0).lane);
+	} else {
+		iq_last.assigned_instructions_are({/* none */});
+	}
+
+	octx.complete(k_complete_first == 1 ? k2_d1 : k1_d0);
+	octx.assign_all();
+	octx.complete(k3_d0);
+	CHECK(octx.is_idle());
+}
+
+TEST_CASE("eligibility for eager assignment is retracted when an instruction is overtaken by a higher-priority sibling", "[out_of_order_engine]") {
+	const auto higher_prio = GENERATE(values({2, 3}));
+
+	out_of_order_test_context octx(1);
+	const auto k1 = octx.host_task({});
+	const auto k2 = octx.host_task({k1}, higher_prio == 2 ? 1 : 0);
+	const auto k3 = octx.host_task({k1}, higher_prio == 3 ? 1 : 0);
+
+	const auto iq_first = octx.assign_all();
+	CHECK(iq_first.assigned_instructions_are({k1, higher_prio == 2 ? k2 : k3}));
+	CHECK(iq_first.assigned_in_order({k1, higher_prio == 2 ? k2 : k3}));
+
+	octx.complete(k1);
+
+	const auto iq_second = octx.assign_all();
+	CHECK(iq_second.assigned_instructions_are({higher_prio == 2 ? k3 : k2}));
+	// k2 and k3 are concurrent, check that they are assigned to different lanes now (eager assignment would have placed both on k1's lane)
+	CHECK(iq_second.assignment_for(higher_prio == 2 ? k3 : k2).lane != iq_first.assignment_for(k1).lane);
+
+	octx.complete(k2);
+	octx.complete(k3);
+	CHECK(octx.is_idle());
+}
+
+TEST_CASE("eager assignment is only attempted when the one incomplete dependency is last in the target lane", "[out_of_order_engine]") {
+	out_of_order_test_context octx(1);
+	const auto k1 = octx.device_kernel({}, device_id(0));
+	const auto k2 = octx.device_kernel({k1}, device_id(0));
+
+	const auto iq_12 = octx.assign_all();
+	CHECK(iq_12.queued_on_device(k1, device_id(0)));
+	CHECK(iq_12.queued_on_device(k2, device_id(0)));
+	CHECK(iq_12.assigned_in_order({k1, k2}));
+
+	const auto k3 = octx.device_kernel({k1}, device_id(0));
+
+	const auto iq_3_before = octx.assign_all();
+	CHECK(iq_3_before.assigned_instructions_are({})); // can't be queued eagerly
+
+	octx.complete(k1);
+
+	const auto iq_3 = octx.assign_all();
+	CHECK(iq_3.assigned_instructions_are({k3}));
+	CHECK(iq_3.queued_on_device(k3, device_id(0)));
+	CHECK(iq_12.assignment_for(k1).lane != iq_3.assignment_for(k3).lane);
+	CHECK(iq_12.assignment_for(k2).lane != iq_3.assignment_for(k3).lane);
+}

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -243,9 +243,9 @@ const char* const expected_device_enumeration_warnings_regex =
 
 namespace celerity::test_utils {
 
-detail::instruction_graph_generator::system_info make_system_info(const size_t num_devices, const bool supports_d2d_copies) {
+detail::system_info make_system_info(const size_t num_devices, const bool supports_d2d_copies) {
 	using namespace detail;
-	instruction_graph_generator::system_info info;
+	system_info info;
 	info.devices.resize(num_devices);
 	info.memories.resize(first_device_memory_id + num_devices);
 	info.memories[host_memory_id].copy_peers.set(host_memory_id);

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -14,7 +14,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <celerity.h>
 
-#include "accessor.h"
 #include "command.h"
 #include "command_graph.h"
 #include "device_queue.h"
@@ -26,6 +25,7 @@
 #include "region_map.h"
 #include "runtime.h"
 #include "scheduler.h"
+#include "system_info.h"
 #include "task_manager.h"
 #include "types.h"
 
@@ -331,7 +331,7 @@ namespace test_utils {
 		detail::add_reduction(cgh, mrf.create_reduction(vars.get_id(), include_current_buffer_value));
 	}
 
-	detail::instruction_graph_generator::system_info make_system_info(const size_t num_devices, const bool supports_d2d_copies);
+	detail::system_info make_system_info(const size_t num_devices, const bool supports_d2d_copies);
 
 	// This fixture (or a subclass) must be used by all tests that transitively use MPI.
 	class mpi_fixture {


### PR DESCRIPTION
This is the third PR in the Instruction Graph series and introduces the new executor state machine, dubbed the out-of-order-engine, as a stand-alone testable component.

Much like the current executor, the out-of-order engine keeps track of all instructions that have not yet completed and decides which instructions to schedule onto which backend resources at what time, and receives back information on which instructions have already completed. This will allow us to keep the instruction executor free of most instruction state tracking.

Unlike the current approach, this new form of scheduling is based on a definition of [backends](https://github.com/fknorr/celerity-runtime/blob/f937aa52f4eb568095b886dbcb8ea63a7b7568e4/include/backend/backend.h) which maintain an array of [in-order thread queues](https://github.com/fknorr/celerity-runtime/blob/f937aa52f4eb568095b886dbcb8ea63a7b7568e4/src/thread_queue.h) for host work and in-order SYCL queues for device submissions. This allows the engine to omit host / executor loop round-trips between consecutive GPU / CPU loads by scheduling successors onto the same in-order queues to implicitly fulfil dependencies, and thus hide SYCL and CUDA kernel launch latency

In the future I would like to improve this further with support to submit instructions with dependencies on multiple queues / devices earlier by waiting on in-flight SYCL events.

This PR still does not touch the actual executor yet, allowing us to see the unit [test coverage](https://coveralls.io/builds/67663683/source?filename=src%2Fout_of_order_engine.cc) of the engine in isolation.