### PR TITLE
[IDAG] Upstream Multi-Device Selection + Tests

### DIFF
--- a/include/device_selection.h
+++ b/include/device_selection.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include "config.h"
+#include "log.h"
+
+#include <sycl/sycl.hpp>
+
+namespace celerity::detail {
+
+// TODO these are required by distr_queue.h, but we don't want to pull all include dependencies of the pick_devices implementation into user code!
+struct auto_select_devices {};
+using device_selector = std::function<int(const sycl::device&)>;
+using devices_or_selector = std::variant<auto_select_devices, std::vector<sycl::device>, device_selector>;
+
+template <typename DeviceT>
+void check_required_device_aspects(const DeviceT& device) {
+	if(!device.has(sycl::aspect::usm_device_allocations)) { throw std::runtime_error("device does not support USM device allocations"); }
+	if(!device.has(sycl::aspect::usm_host_allocations)) { throw std::runtime_error("device does not support USM host allocations"); }
+}
+
+template <typename DevicesOrSelector, typename PlatformT>
+auto pick_devices(const host_config& cfg, const DevicesOrSelector& user_devices_or_selector, const std::vector<PlatformT>& platforms) {
+	using DeviceT = typename decltype(std::declval<PlatformT&>().get_devices())::value_type;
+	using BackendT = decltype(std::declval<DeviceT&>().get_backend());
+
+	constexpr bool user_devices_provided = std::is_same_v<DevicesOrSelector, std::vector<DeviceT>>;
+	constexpr bool device_selector_provided = std::is_invocable_r_v<int, DevicesOrSelector, DeviceT>;
+	constexpr bool auto_select = std::is_same_v<auto_select_devices, DevicesOrSelector>;
+	static_assert(user_devices_provided ^ device_selector_provided ^ auto_select,
+	    "pick_device requires either a list of devices, a selector, or the auto_select_devices tag");
+
+	std::vector<DeviceT> selected_devices;
+	std::string how_selected;
+
+	if(cfg.node_count > 1) {
+		CELERITY_WARN("Celerity detected more than one node (MPI rank) on this host, which is not recommended. Will attempt to distribute local devices evenly "
+		              "across nodes.");
+	}
+
+	if constexpr(user_devices_provided) {
+		const auto devices = user_devices_or_selector;
+		if(devices.empty()) { throw std::runtime_error("Device selection failed: The user-provided list of devices is empty"); }
+		auto backend = devices[0].get_backend();
+		for(size_t i = 0; i < devices.size(); ++i) {
+			if(devices[i].get_backend() != backend) {
+				throw std::runtime_error("Device selection failed: The user-provided list of devices contains devices from different backends");
+			}
+			try {
+				check_required_device_aspects(devices[i]);
+			} catch(std::runtime_error& e) {
+				throw std::runtime_error(fmt::format("Device selection failed: Device {} in user-provided list of devices caused error: {}", i, e.what()));
+			}
+		}
+		selected_devices = devices;
+		how_selected = "specified by user";
+	} else {
+		if(std::all_of(platforms.cbegin(), platforms.cend(), [](auto& p) { return p.get_devices().empty(); })) {
+			throw std::runtime_error("Device selection failed: No devices available");
+		}
+
+		const auto select_all = [platforms](auto& selector) {
+			std::unordered_map<BackendT, std::vector<std::pair<DeviceT, size_t>>> scored_devices_by_backend;
+			for(size_t i = 0; i < platforms.size(); ++i) {
+				const auto devices = platforms[i].get_devices(sycl::info::device_type::all);
+				for(size_t j = 0; j < devices.size(); ++j) {
+					try {
+						check_required_device_aspects(devices[j]);
+					} catch(std::runtime_error& e) {
+						CELERITY_TRACE("Ignoring platform {} \"{}\", device {} \"{}\": {}", i, platforms[i].template get_info<sycl::info::platform::name>(), j,
+						    devices[j].template get_info<sycl::info::device::name>(), e.what());
+						continue;
+					}
+					const auto score = selector(devices[j]);
+					if(score < 0) continue;
+					scored_devices_by_backend[devices[j].get_backend()].push_back(std::pair{devices[j], score});
+				}
+			}
+			size_t max_score = 0;
+			std::vector<DeviceT> max_score_devices;
+			for(auto& [backend, scored_devices] : scored_devices_by_backend) {
+				size_t sum_score = 0;
+				std::vector<DeviceT> devices;
+				for(auto& [d, score] : scored_devices) {
+					sum_score += score;
+					devices.push_back(d);
+				}
+				if(sum_score > max_score) {
+					max_score = sum_score;
+					max_score_devices = std::move(devices);
+				}
+			}
+			return max_score_devices;
+		};
+
+		if constexpr(device_selector_provided) {
+			how_selected = "via user-provided selector";
+			selected_devices = select_all(user_devices_or_selector);
+		} else {
+			how_selected = "automatically selected";
+			// First try to find eligible GPUs
+			const auto selector = [](const DeviceT& d) {
+				return d.template get_info<sycl::info::device::device_type>() == sycl::info::device_type::gpu ? 1 : -1;
+			};
+			selected_devices = select_all(selector);
+			if(selected_devices.empty()) {
+				// If none were found, fall back to other device types
+				const auto selector = [](const DeviceT& d) { return 1; };
+				selected_devices = select_all(selector);
+			}
+		}
+
+		if(selected_devices.empty()) { throw std::runtime_error("Device selection failed: No eligible devices found"); }
+	}
+
+	// When running with more than one local node, attempt to distribute devices evenly
+	if(cfg.node_count > 1) {
+		if(selected_devices.size() >= cfg.node_count) {
+			const size_t quotient = selected_devices.size() / cfg.node_count;
+			const size_t remainder = selected_devices.size() % cfg.node_count;
+
+			const auto rank = cfg.local_rank;
+			const size_t offset = rank < remainder ? rank * (quotient + 1) : remainder * (quotient + 1) + (rank - remainder) * quotient;
+			const size_t count = rank < remainder ? quotient + 1 : quotient;
+
+			std::vector<DeviceT> subset{selected_devices.begin() + offset, selected_devices.begin() + offset + count};
+			selected_devices = std::move(subset);
+		} else {
+			CELERITY_WARN(
+			    "Found fewer devices ({}) than local nodes ({}), multiple nodes will use the same device(s).", selected_devices.size(), cfg.node_count);
+			selected_devices = {selected_devices[cfg.local_rank % selected_devices.size()]};
+		}
+	}
+
+	for(device_id did = 0; did < selected_devices.size(); ++did) {
+		const auto platform_name = selected_devices[did].get_platform().template get_info<sycl::info::platform::name>();
+		const auto device_name = selected_devices[did].template get_info<sycl::info::device::name>();
+		CELERITY_INFO("Using platform \"{}\", device \"{}\" as D{} ({})", platform_name, device_name, did, how_selected);
+	}
+
+	return selected_devices;
+}
+
+/*
+template<typename T>
+concept BackendEnumerator = requires(const T &a) {
+    typename T::backend_type;
+    typename T::device_type;
+    {a.compatible_backends(std::declval<typename T::device_type>)} -> std::same_as<std::vector<T::backend_type>>;
+    {a.available_backends()} -> std::same_as<std::vector<T::backend_type>>;
+    {a.is_specialized(std::declval<T::backend_type>())} -> std::same_as<bool>;
+    {a.get_priority(std::declval<T::backend_type>())} -> std::same_as<int>;
+};
+*/
+
+template <typename BackendEnumerator>
+inline auto select_backend(const BackendEnumerator& enumerator, const std::vector<typename BackendEnumerator::device_type>& devices) {
+	using backend_type = typename BackendEnumerator::backend_type;
+
+	const auto available_backends = enumerator.available_backends();
+
+	std::vector<backend_type> common_backends;
+	for(auto& device : devices) {
+		auto device_backends = enumerator.compatible_backends(device);
+		common_backends = common_backends.empty() ? std::move(device_backends) : utils::set_intersection(common_backends, device_backends);
+	}
+
+	assert(!common_backends.empty());
+	std::sort(common_backends.begin(), common_backends.end(),
+	    [&](const backend_type lhs, const backend_type rhs) { return enumerator.get_priority(lhs) > enumerator.get_priority(rhs); });
+
+	for(const auto backend : common_backends) {
+		const auto is_specialized = enumerator.is_specialized(backend);
+		if(utils::contains(available_backends, backend)) {
+			if(is_specialized) {
+				CELERITY_DEBUG("Using {} backend for the selected devices.", backend);
+			} else {
+				CELERITY_WARN("No common backend specialization available for all selected devices, falling back to {}. Performance may be degraded.", backend);
+			}
+			return backend;
+		} else if(is_specialized) {
+			CELERITY_WARN(
+			    "All selected devices are compatible with specialized {} backend, but it has not been compiled. Performance may be degraded.", backend);
+		}
+	}
+	utils::panic("no compatible backend available");
+}
+
+} // namespace celerity::detail

--- a/test/device_selection_tests.cc
+++ b/test/device_selection_tests.cc
@@ -1,10 +1,19 @@
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
+#include "device_selection.h"
 #include "test_utils.h"
 
 using dt = sycl::info::device_type;
+using namespace celerity;
+using namespace celerity::detail;
 
 struct mock_platform;
 
@@ -13,46 +22,56 @@ struct type_and_name {
 	std::string name;
 };
 
+enum class mock_device_backend { foo, bar, qux };
+
 struct mock_device {
-	mock_device() : m_id(0), m_type(dt::gpu), m_platform(nullptr) {}
+	mock_device() : mock_device({0, dt::gpu, "", nullptr, {}}) {}
 
-	mock_device(size_t id, mock_platform& platform, dt type) : mock_device(id, platform, {type, fmt::format("Mock device {}", id)}){};
+	mock_device(size_t id, mock_platform& platform, dt type) : mock_device({id, type, fmt::format("Mock device {}", id), &platform, {}}){};
 
-	mock_device(size_t id, mock_platform& platform, const type_and_name& tan) : m_id(id), m_type(tan.type), m_name(tan.name), m_platform(&platform) {}
+	mock_device(size_t id, mock_platform& platform, const type_and_name& tan) : mock_device({id, tan.type, tan.name, &platform, {}}) {}
 
-	bool operator==(const mock_device& other) const { return other.m_id == m_id; }
+	bool operator==(const mock_device& other) const { return other.m_pimpl == m_pimpl; }
 
 	mock_platform& get_platform() const {
-		assert(m_platform != nullptr);
-		return *m_platform;
+		assert(m_pimpl->platform != nullptr);
+		return *m_pimpl->platform;
 	}
 
 	template <typename Param>
 	auto get_info() const {
-		if constexpr(std::is_same_v<Param, sycl::info::device::name>) { return m_name; }
-		if constexpr(std::is_same_v<Param, sycl::info::device::device_type>) { return m_type; }
+		if constexpr(std::is_same_v<Param, sycl::info::device::name>) { return m_pimpl->name; }
+		if constexpr(std::is_same_v<Param, sycl::info::device::device_type>) { return m_pimpl->type; }
 	}
 
-	dt get_type() const { return m_type; }
+	dt get_type() const { return m_pimpl->type; }
 
-	size_t get_id() const { return m_id; }
+	size_t get_id() const { return m_pimpl->id; }
+
+	mock_device_backend get_backend() const;
+
+	bool has(const sycl::aspect aspect) const { return m_pimpl->aspects.count(aspect) > 0 ? m_pimpl->aspects.at(aspect) : true; }
+
+	void set_aspect(const sycl::aspect aspect, const bool value) { m_pimpl->aspects[aspect] = value; }
+
+	size_t hash() const { return std::hash<impl*>{}(m_pimpl.get()); }
 
   private:
-	size_t m_id;
-	dt m_type;
-	std::string m_name;
-	mock_platform* m_platform;
+	struct impl {
+		size_t id;
+		dt type;
+		std::string name;
+		mock_platform* platform;
+		std::unordered_map<sycl::aspect, bool> aspects;
+	};
+	std::shared_ptr<impl> m_pimpl; // Use PIMPL for reference semantics
+
+	mock_device(impl i) : m_pimpl(std::make_shared<impl>(i)) {}
 };
 
-struct mock_platform_factory {
-  public:
-	template <typename... Args>
-	auto create_platforms(Args... args) {
-		return std::array<mock_platform, sizeof...(args)>{mock_platform(m_next_id++, args)...};
-	}
-
-  private:
-	size_t m_next_id = 0;
+template <>
+struct std::hash<mock_device> {
+	size_t operator()(const mock_device& dev) const { return dev.hash(); }
 };
 
 struct mock_platform {
@@ -86,467 +105,417 @@ struct mock_platform {
 
 	size_t get_id() const { return m_id; }
 
+	mock_device_backend get_backend() const { return m_backend; }
+	void set_backend(mock_device_backend backend) { m_backend = backend; }
+
   private:
 	size_t m_id;
 	std::string m_name;
 	size_t m_next_device_id = 0;
 	std::vector<mock_device> m_devices;
+	mock_device_backend m_backend = mock_device_backend::foo;
 };
 
-TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prefers user specified device pointer", "[device-selection]") {
-	celerity::detail::config cfg(nullptr, nullptr);
-	mock_platform_factory mpf;
+mock_device_backend mock_device::get_backend() const { return m_pimpl->platform->get_backend(); }
 
-	auto [mp] = mpf.create_platforms(std::nullopt);
-	auto md = mp.create_devices(dt::gpu)[0];
-
-	auto device = pick_device(cfg, md, std::vector<mock_platform>{mp});
-	CHECK(device == md);
+template <typename... Args>
+auto create_mock_platforms(Args... args) {
+	size_t next_id = 0;
+	return std::array<mock_platform, sizeof...(args)>{mock_platform(next_id++, args)...};
 }
 
-TEST_CASE_METHOD(celerity::test_utils::mpi_fixture,
-    "pick_device automatically selects a gpu device if available, otherwise falls back to the first device available", "[device-selection]") {
-	celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
+TEST_CASE("check_required_device_aspects throws if a device does not support required aspects", "[device-selection]") {
+	mock_device device;
+	CHECK_NOTHROW(check_required_device_aspects(device));
 
-	celerity::detail::config cfg(nullptr, nullptr);
-	mock_platform_factory mpf;
+	// Note: This assumes that the following checks are performed in reverse order within check_required_device_aspects
 
-	auto dv_type_1 = GENERATE(as<dt>(), dt::gpu, dt::accelerator, dt::cpu, dt::custom, dt::host);
-	CAPTURE(dv_type_1);
+	device.set_aspect(sycl::aspect::usm_host_allocations, false);
+	CHECK_THROWS_WITH(check_required_device_aspects(device), "device does not support USM host allocations");
 
-	auto dv_type_2 = GENERATE(as<dt>(), dt::gpu, dt::accelerator, dt::cpu, dt::custom, dt::host);
-	CAPTURE(dv_type_2);
+	device.set_aspect(sycl::aspect::usm_device_allocations, false);
+	CHECK_THROWS_WITH(check_required_device_aspects(device), "device does not support USM device allocations");
+}
 
-	auto [mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt);
+TEST_CASE("pick_devices prefers user-specified device list", "[device-selection]") {
+	test_utils::allow_max_log_level(log_level::warn);
 
-	auto md_1 = mp_1.create_devices(dv_type_1)[0];
-	auto md_2 = mp_2.create_devices(dv_type_2)[0];
+	const host_config h_cfg{1, 0};
+	auto [mp] = create_mock_platforms(std::nullopt);
 
-	auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_1, mp_2});
-	if(dv_type_1 == dt::gpu || (dv_type_1 != dt::gpu && dv_type_2 != dt::gpu)) {
-		CHECK(device == md_1);
+	CHECK_THROWS_WITH(
+	    pick_devices(h_cfg, std::vector<mock_device>{}, std::vector<mock_platform>{mp}), "Device selection failed: The user-provided list of devices is empty");
+
+	const auto devices = mp.create_devices(dt::gpu, dt::gpu, dt::cpu, dt::accelerator);
+	const auto selected = pick_devices(h_cfg, std::vector<mock_device>{devices.begin(), devices.end()}, std::vector<mock_platform>{mp});
+	CHECK(selected == std::vector<mock_device>{devices.begin(), devices.end()});
+}
+
+TEST_CASE("pick_devices requires user-specified devices to have the same backend", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	auto [mp_1, mp_2] = create_mock_platforms(std::nullopt, std::nullopt);
+	auto [md_1] = mp_1.create_devices(dt::gpu);
+	auto [md_2] = mp_2.create_devices(dt::gpu);
+
+	CHECK_NOTHROW(pick_devices(h_cfg, std::vector<mock_device>{md_1, md_2}, std::vector<mock_platform>{mp_1, mp_2}));
+
+	mp_1.set_backend(mock_device_backend::foo);
+	mp_2.set_backend(mock_device_backend::bar);
+	CHECK_THROWS_WITH(pick_devices(h_cfg, std::vector<mock_device>{md_1, md_2}, std::vector<mock_platform>{mp_1, mp_2}),
+	    "Device selection failed: The user-provided list of devices contains devices from different backends");
+}
+
+TEST_CASE("pick_devices throws if a user-specified devices does not support required aspects", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	auto [mp] = create_mock_platforms(std::nullopt);
+	auto [md_1, md_2] = mp.create_devices(dt::gpu, dt::gpu);
+	md_2.set_aspect(sycl::aspect::usm_device_allocations, false);
+	CHECK_THROWS_WITH(pick_devices(h_cfg, std::vector<mock_device>{md_1, md_2}, std::vector<mock_platform>{mp}),
+	    "Device selection failed: Device 1 in user-provided list of devices caused error: device does not support USM device allocations");
+}
+
+TEST_CASE("pick_devices selects the largest subset of GPUs that share the same backend", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	auto [mp_1, mp_2, mp_3] = create_mock_platforms(std::nullopt, std::nullopt, std::nullopt);
+	mp_1.create_devices(dt::gpu);
+	auto [md_2, md_3, md_4] = mp_2.create_devices(dt::gpu, dt::gpu, dt::gpu);
+	mp_3.create_devices(dt::gpu, dt::gpu);
+
+	mp_1.set_backend(mock_device_backend::foo);
+	mp_2.set_backend(mock_device_backend::bar);
+	mp_3.set_backend(mock_device_backend::qux);
+
+	const auto selected = pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp_1, mp_2, mp_3});
+	CHECK(selected == std::vector<mock_device>{md_2, md_3, md_4});
+}
+
+TEST_CASE("pick_devices falls back to other device types if no GPUs are available", "[device-selection]") {
+	test_utils::allow_max_log_level(log_level::warn);
+
+	const host_config h_cfg{1, 0};
+	auto [mp_1, mp_2, mp_3] = create_mock_platforms(std::nullopt, std::nullopt, std::nullopt);
+	mp_1.create_devices(dt::cpu);
+	auto [md_2, md_3, md_4] = mp_2.create_devices(dt::accelerator, dt::cpu, dt::host);
+	mp_3.create_devices(dt::cpu, dt::accelerator);
+
+	mp_1.set_backend(mock_device_backend::foo);
+	mp_2.set_backend(mock_device_backend::bar);
+	mp_3.set_backend(mock_device_backend::qux);
+
+	const auto selected_1 = pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp_1, mp_2, mp_3});
+	CHECK(selected_1 == std::vector<mock_device>{md_2, md_3, md_4});
+
+	// Once there is a GPU however, it takes precedence
+	auto [md_9] = mp_3.create_devices(dt::gpu);
+	const auto selected_2 = pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp_1, mp_2, mp_3});
+	CHECK(selected_2 == std::vector<mock_device>{md_9});
+}
+
+TEST_CASE("pick_devices only considers devices that support required aspects", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	auto type = GENERATE(dt::gpu, dt::cpu);
+	auto [mp_1, mp_2, mp_3] = create_mock_platforms(std::nullopt, std::nullopt, std::nullopt);
+	mp_1.create_devices(type);
+	auto [md_2, md_3, md_4] = mp_2.create_devices(type, type, type);
+	auto [md_5, md_6] = mp_3.create_devices(type, type);
+
+	mp_1.set_backend(mock_device_backend::foo);
+	mp_2.set_backend(mock_device_backend::bar);
+	mp_3.set_backend(mock_device_backend::qux);
+
+	md_2.set_aspect(sycl::aspect::usm_device_allocations, false);
+	md_3.set_aspect(sycl::aspect::usm_device_allocations, false);
+
+	const auto selected = pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp_1, mp_2, mp_3});
+	CHECK(selected == std::vector<mock_device>{md_5, md_6});
+}
+
+TEST_CASE("pick_devices supports passing a device selector function", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	auto [mp_1, mp_2] = create_mock_platforms(std::nullopt, std::nullopt);
+	auto [md_1] = mp_1.create_devices(dt::gpu);
+	auto [md_2] = mp_2.create_devices(dt::gpu);
+
+	mp_1.set_backend(mock_device_backend::foo);
+	mp_2.set_backend(mock_device_backend::bar);
+
+	const auto device_idx = GENERATE(0, 1);
+	CAPTURE(device_idx);
+	const auto to_select = std::array<mock_device, 2>{md_1, md_2}[device_idx];
+
+	auto device_selector = [to_select](const mock_device& d) { return d == to_select ? 2 : 1; };
+	auto selected = pick_devices(h_cfg, device_selector, std::vector<mock_platform>{mp_1, mp_2});
+	CHECK(selected == std::vector<mock_device>{to_select});
+}
+
+TEST_CASE("pick_devices selects the subset of devices with the largest cumulative selector score sharing the same backend", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	auto [mp_1, mp_2, mp_3] = create_mock_platforms(std::nullopt, std::nullopt, std::nullopt);
+	auto [md_1] = mp_1.create_devices(dt::gpu);
+	auto [md_2, md_3, md_4] = mp_2.create_devices(dt::cpu, dt::gpu, dt::accelerator);
+	auto [md_5, md_6] = mp_3.create_devices(dt::host, dt::cpu);
+
+	mp_1.set_backend(mock_device_backend::foo);
+	mp_2.set_backend(mock_device_backend::bar);
+	mp_3.set_backend(mock_device_backend::qux);
+
+	const auto ignore_md_4 = GENERATE(true, false);
+	const auto md_6_no_usm = GENERATE(true, false);
+
+	md_6.set_aspect(sycl::aspect::usm_device_allocations, !md_6_no_usm);
+
+	const std::vector<std::vector<int>> scores = {
+	    {/* md_1 */ 50}, {/* md_2 */ 10, /* md_3 */ 20, /* md_4 */ ignore_md_4 ? -1 : 30}, {/* md_5 */ 30, /* md_6 */ 40}};
+	const auto selector = [&scores](const mock_device& d) { return scores[d.get_platform().get_id()][d.get_id()]; };
+
+	const auto selected = pick_devices(h_cfg, selector, std::vector<mock_platform>{mp_1, mp_2, mp_3});
+
+	if(ignore_md_4) {
+		if(md_6_no_usm) {
+			CHECK(selected == std::vector<mock_device>{md_1});
+		} else {
+			CHECK(selected == std::vector<mock_device>{md_5, md_6});
+		}
 	} else {
-		CHECK(device == md_2);
+		if(md_6_no_usm) {
+			CHECK(selected == std::vector<mock_device>{md_2, md_3, md_4});
+		} else {
+			CHECK(selected == std::vector<mock_device>{md_5, md_6});
+		}
 	}
 }
 
-TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device selects device using CELERITY_DEVICES", "[device-selection]") {
-	celerity::detail::config cfg(nullptr, nullptr);
-	mock_platform_factory mpf;
+TEST_CASE("pick_devices does not consider devices with a negative selector score", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	auto [mp] = create_mock_platforms(std::nullopt);
+	auto [md_1, md_2, md_3] = mp.create_devices(dt::gpu, dt::gpu, dt::gpu);
 
-	auto [mp_0, mp_1] = mpf.create_platforms(std::nullopt, std::nullopt);
-	mp_0.create_devices(dt::cpu, dt::gpu);
-	auto md = mp_1.create_devices(dt::gpu, dt::gpu, dt::cpu)[1];
-
-	celerity::detail::device_config d_cfg{1, 1};
-	celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
-
-	auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1});
-	CHECK(device == md);
+	auto selector = [md_2 = md_2](const mock_device& d) { return d.get_id() == md_2.get_id() ? -1 : 1; };
+	const auto selected = pick_devices(h_cfg, selector, std::vector<mock_platform>{mp});
+	CHECK(selected == std::vector<mock_device>{md_1, md_3});
 }
 
-TEST_CASE_METHOD(
-    celerity::test_utils::mpi_fixture, "pick_device attempts to select a unique device from a single platform for each local node", "[device-selection]") {
-	celerity::detail::config cfg(nullptr, nullptr);
+TEST_CASE("pick_devices throws if no devices are available", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	auto [mp] = create_mock_platforms(std::nullopt);
 
-	SECTION("preferring GPUs over other device types") {
-		mock_platform_factory mpf;
-
-		const size_t node_count = 4;
-		const size_t local_rank = 3;
-
-		auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-		mp_0.create_devices(dt::cpu);
-		auto md = mp_1.create_devices(dt::gpu, dt::gpu, dt::gpu, dt::gpu)[local_rank];
-		mp_2.create_devices(dt::accelerator, dt::accelerator, dt::accelerator, dt::accelerator);
-
-		celerity::detail::host_config h_cfg{node_count, local_rank};
-		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-		CHECK(device == md);
+	SECTION("from the start") {
+		const auto selector = [](const mock_device&) { return -1; };
+		CHECK_THROWS_WITH(pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp}), "Device selection failed: No devices available");
+		CHECK_THROWS_WITH(pick_devices(h_cfg, selector, std::vector<mock_platform>{mp}), "Device selection failed: No devices available");
 	}
 
-	SECTION("falling back to other device types when an insufficient number of GPUs is available") {
-		celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
-
-		mock_platform_factory mpf;
-
-		const size_t node_count = 4;
-		const size_t local_rank = 2;
-
-		auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-		mp_0.create_devices(dt::cpu);
-		mp_1.create_devices(dt::gpu, dt::gpu, dt::gpu);
-		auto md = mp_2.create_devices(dt::accelerator, dt::accelerator, dt::accelerator, dt::accelerator)[local_rank];
-
-		celerity::detail::host_config h_cfg{node_count, local_rank};
-		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-		CHECK(device == md);
+	SECTION("if all are ignored due to missing aspects") {
+		auto [md_1] = mp.create_devices(dt::gpu);
+		md_1.set_aspect(sycl::aspect::usm_device_allocations, false);
+		CHECK_THROWS_WITH(pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp}), "Device selection failed: No eligible devices found");
+		auto [md_2] = mp.create_devices(dt::cpu);
+		md_2.set_aspect(sycl::aspect::usm_device_allocations, false);
+		CHECK_THROWS_WITH(pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp}), "Device selection failed: No eligible devices found");
 	}
 
-	SECTION("falling back to a single GPU for all nodes if an insufficient number of GPUs and other device types is available") {
-		celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
-
-		mock_platform_factory mpf;
-
-		auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-		mp_0.create_devices(dt::cpu);
-		auto md = mp_1.create_devices(dt::gpu)[0];
-		mp_2.create_devices(dt::accelerator, dt::accelerator, dt::accelerator);
-
-		const size_t node_count = 4;
-		const size_t local_rank = GENERATE(0, 3);
-
-		celerity::detail::host_config h_cfg{node_count, local_rank};
-		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-		CHECK(device == md);
-	}
-
-	SECTION("falling back to a single device of any type for all nodes if an insufficient number of GPUs or other device types is available") {
-		celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
-
-		mock_platform_factory mpf;
-
-		auto [mp_0, mp_1] = mpf.create_platforms(std::nullopt, std::nullopt);
-		auto md = mp_0.create_devices(dt::cpu)[0];
-		mp_1.create_devices(dt::accelerator, dt::accelerator, dt::accelerator);
-
-		const size_t node_count = 4;
-		const size_t local_rank = GENERATE(0, 3);
-
-		celerity::detail::host_config h_cfg{node_count, local_rank};
-		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1});
-		CHECK(device == md);
+	SECTION("if all are discarded by selector") {
+		auto [md_1] = mp.create_devices(dt::gpu);
+		const auto selector = [](const mock_device&) { return -1; };
+		CHECK_THROWS_WITH(pick_devices(h_cfg, selector, std::vector<mock_platform>{mp}), "Device selection failed: No eligible devices found");
 	}
 }
 
-TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints expected info/warn messages", "[device-selection]") {
-	celerity::test_utils::allow_max_log_level(celerity::detail::log_level::err);
+TEST_CASE("pick_devices attempts to evenly distributed devices if there is more than one local node", "[device-selection]") {
+	struct distribution {
+		size_t num_devices;
+		std::vector<size_t> devices_per_node;
+	};
 
-	celerity::detail::config cfg(nullptr, nullptr);
-	SECTION("when device pointer is specified by user") {
-		mock_platform tp(68, "My platform");
-		auto td = tp.create_devices(dt::gpu, type_and_name{dt::gpu, "My device"}, dt::gpu)[1];
+	const std::vector<distribution> distributions = {
+	    {1, {1}},             //
+	    {2, {1, 1}},          //
+	    {3, {2, 1}},          //
+	    {4, {2, 2}},          //
+	    {5, {2, 2, 1}},       //
+	    {7, {3, 2, 2}},       //
+	    {9, {2, 2, 2, 2, 1}}, //
+	    {13, {3, 3, 3, 2, 2}} //
+	};
 
-		auto device = pick_device(cfg, td, std::vector<mock_platform>{tp});
-		CHECK(celerity::test_utils::log_contains_substring(
-		    celerity::detail::log_level::info, "Using platform 'My platform', device 'My device' (specified by user)"));
+	test_utils::allow_max_log_level(log_level::warn);
+
+	for(const auto& dist : distributions) {
+		auto [mp] = create_mock_platforms(std::nullopt);
+		for(size_t i = 0; i < dist.num_devices; ++i) {
+			mp.create_devices(dt::gpu);
+		}
+
+		std::unordered_set<std::pair<size_t, size_t>, utils::pair_hash> unique_devices;
+		for(size_t i = 0; i < dist.devices_per_node.size(); ++i) {
+			const host_config h_cfg{dist.devices_per_node.size(), i};
+			const auto selected = pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp});
+			REQUIRE_LOOP(selected.size() == dist.devices_per_node[i]);
+			for(const auto& d : selected) {
+				const auto unique_id = std::pair{d.get_platform().get_id(), d.get_id()};
+				REQUIRE_LOOP(unique_devices.count(unique_id) == 0);
+				unique_devices.insert(unique_id);
+			}
+		}
 	}
 
-	SECTION("when CELERITY_DEVICES is set") {
-		mock_platform_factory mpf;
+	CHECK(test_utils::log_contains_exact(log_level::warn, "Celerity detected more than one node (MPI rank) on this host, which is not recommended. Will "
+	                                                      "attempt to distribute local devices evenly across nodes."));
+}
 
-		auto [mp_0, mp_1] = mpf.create_platforms(std::nullopt, "My platform");
-		mp_0.create_devices(dt::cpu);
-		mp_1.create_devices(dt::gpu, type_and_name{dt::gpu, "My device"});
+TEST_CASE("pick_devices distributes devices in round-robin fashion if there are fewer than local nodes", "[device-selection]") {
+	auto [mp] = create_mock_platforms(std::nullopt);
+	auto devices = mp.create_devices(dt::gpu, dt::gpu, dt::gpu);
 
-		celerity::detail::device_config d_cfg{1, 1};
-		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
+	const size_t num_ranks = GENERATE(4, 5, 6);
 
-		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1});
-		CHECK(celerity::test_utils::log_contains_substring(
-		    celerity::detail::log_level::info, "Using platform 'My platform', device 'My device' (set by CELERITY_DEVICES: platform 1, device 1)"));
+	test_utils::allow_max_log_level(log_level::warn);
+
+	for(size_t i = 0; i < num_ranks; ++i) {
+		const host_config h_cfg{num_ranks, i};
+		const auto selected = pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp});
+		REQUIRE(selected.size() == 1);
+		CHECK(selected[0] == devices[i % 3]);
+		CHECK(test_utils::log_contains_exact(
+		    log_level::warn, fmt::format("Found fewer devices (3) than local nodes ({}), multiple nodes will use the same device(s).", num_ranks)));
+	}
+}
+
+TEST_CASE("pick_devices prints device and platform information", "[device-selection]") {
+	const host_config h_cfg{1, 0};
+	mock_platform mp(68, "My platform");
+	auto mds = mp.create_devices(type_and_name{dt::gpu, "My first device"}, type_and_name{dt::gpu, "My second device"});
+
+	SECTION("when devices are provided by user") {
+		pick_devices(h_cfg, std::vector<mock_device>{mds[0], mds[1]}, std::vector<mock_platform>{mp});
+		CHECK(test_utils::log_contains_exact(log_level::info, "Using platform \"My platform\", device \"My first device\" as D0 (specified by user)"));
+		CHECK(test_utils::log_contains_exact(log_level::info, "Using platform \"My platform\", device \"My second device\" as D1 (specified by user)"));
 	}
 
 	SECTION("when automatically selecting a device") {
-		mock_platform_factory mpf;
-
-		auto [mp_0, mp_1] = mpf.create_platforms(std::nullopt, "My platform");
-		mp_0.create_devices(dt::cpu);
-		mp_1.create_devices(type_and_name{dt::gpu, "My device"}, dt::gpu);
-
-		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1});
-		CHECK(celerity::test_utils::log_contains_substring(
-		    celerity::detail::log_level::info, "Using platform 'My platform', device 'My device' (automatically selected platform 1, device 0)"));
+		pick_devices(h_cfg, auto_select_devices{}, std::vector<mock_platform>{mp});
+		CHECK(test_utils::log_contains_exact(log_level::info, "Using platform \"My platform\", device \"My first device\" as D0 (automatically selected)"));
+		CHECK(test_utils::log_contains_exact(log_level::info, "Using platform \"My platform\", device \"My second device\" as D1 (automatically selected)"));
 	}
 
-	SECTION("when it can't find a platform with a sufficient number of GPUs") {
-		mock_platform_factory mpf;
-
-		auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-		mp_0.create_devices(dt::cpu);
-		mp_1.create_devices(dt::gpu, dt::gpu, dt::gpu);
-		mp_2.create_devices(dt::accelerator, dt::accelerator, dt::accelerator, dt::accelerator);
-
-		const size_t node_count = 4;
-		const size_t local_rank = 3;
-
-		celerity::detail::host_config h_cfg{node_count, local_rank};
-		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-		CHECK(celerity::test_utils::log_contains_substring(
-		    celerity::detail::log_level::warn, "No suitable platform found that can provide 4 GPU devices, and CELERITY_DEVICES not set"));
-	}
-
-	SECTION("when it can't find a platform with a sufficient number of devices of any type") {
-		mock_platform_factory mpf;
-		auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-
-		mp_0.create_devices(dt::cpu);
-		mp_1.create_devices(dt::gpu);
-		mp_2.create_devices(dt::accelerator, dt::accelerator, dt::accelerator);
-
-		const size_t node_count = 4;
-		const size_t local_rank = 3;
-
-		celerity::detail::host_config h_cfg{node_count, local_rank};
-		celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-		auto device = pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-		CHECK(celerity::test_utils::log_contains_substring(
-		    celerity::detail::log_level::warn, "No suitable platform found that can provide 4 devices, and CELERITY_DEVICES not set"));
-	}
-
-	SECTION("when CELERITY_DEVICES contains an invalid platform id") {
-		mock_platform_factory mpf;
-
-		auto [mp_0, mp_1] = mpf.create_platforms(std::nullopt, std::nullopt);
-		mp_0.create_devices(dt::cpu);
-		mp_1.create_devices(dt::gpu, dt::gpu);
-
-		celerity::detail::device_config d_cfg{3, 0};
-		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
-		CHECK_THROWS_WITH(pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1}),
-		    "Invalid platform id 3: Only 2 platforms available");
-	}
-
-	SECTION("when CELERITY_DEVICES contains an invalid device id") {
-		mock_platform_factory mpf;
-
-		auto [mp_0, mp_1] = mpf.create_platforms(std::nullopt, std::nullopt);
-		mp_0.create_devices(dt::cpu);
-		mp_1.create_devices(dt::gpu, dt::gpu);
-
-		celerity::detail::device_config d_cfg{1, 5};
-		celerity::detail::config_testspy::set_mock_device_cfg(cfg, d_cfg);
-
-		CHECK_THROWS_WITH(pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{mp_0, mp_1}),
-		    "Invalid device id 5: Only 2 devices available on platform 1");
-	}
-
-	SECTION("when no device was selected") {
-		CHECK_THROWS_WITH(
-		    pick_device(cfg, celerity::detail::auto_select_device{}, std::vector<mock_platform>{}), "Automatic device selection failed: No device available");
+	SECTION("when a device selector is provided") {
+		const auto selector = [mds](const mock_device&) { return 100; };
+		pick_devices(h_cfg, selector, std::vector<mock_platform>{mp});
+		CHECK(test_utils::log_contains_exact(log_level::info, "Using platform \"My platform\", device \"My first device\" as D0 (via user-provided selector)"));
+		CHECK(
+		    test_utils::log_contains_exact(log_level::info, "Using platform \"My platform\", device \"My second device\" as D1 (via user-provided selector)"));
 	}
 }
 
-TEST_CASE_METHOD(celerity::test_utils::runtime_fixture, "pick_device supports passing a device selector function", "[device-selection]") {
-	std::vector<sycl::device> devices = sycl::device::get_devices(sycl::info::device_type::gpu);
-	if(devices.size() < 2) { SKIP("Platforms must have 2 or more devices"); }
+enum class mock_backend_type { generic1, generic2, specialized1, specialized2 };
 
-	auto device_idx = GENERATE(0, 1);
-	CAPTURE(device_idx);
-	sycl::device device = devices[device_idx];
-	CAPTURE(device);
-
-	auto device_selector = [device](const sycl::device& d) -> int { return d == device ? 2 : 1; };
-
-	celerity::distr_queue q(device_selector);
-
-	auto& dq = celerity::detail::runtime::get_instance().get_device_queue();
-	CHECK(dq.get_sycl_queue().get_device() == device);
-}
-
-TEST_CASE("pick_device correctly selects according to device selector score", "[device-selection]") {
-	mock_platform_factory mpf;
-
-	auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-	mp_0.create_devices(dt::cpu);
-	mp_1.create_devices(dt::gpu, dt::gpu, dt::gpu, dt::gpu);
-	auto md = mp_2.create_devices(dt::accelerator, dt::accelerator, dt::accelerator, dt::accelerator)[1];
-
-	auto device_selector = [md](const mock_device& d) -> int { return d == md ? 2 : 1; };
-
-	celerity::detail::config cfg(nullptr, nullptr);
-	auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-	CHECK(device == md);
-}
-
-TEST_CASE("pick_device selects a unique device for each local node according to device selector score", "[device-selection]") {
-	mock_platform_factory mpf;
-
-	auto [mp_0, mp_1] = mpf.create_platforms(std::nullopt, std::nullopt);
-	mp_0.create_devices(dt::cpu);
-	mp_1.create_devices(dt::gpu, dt::gpu, dt::gpu);
-
-	mock_platform mp_2(2, "My platform");
-	auto md = mp_2.create_devices(dt::gpu, dt::gpu, dt::accelerator, dt::accelerator, dt::accelerator, type_and_name{dt::accelerator, "My device"})[5];
-
-	const size_t node_count = 4;
-	const size_t local_rank = 3;
-
-	celerity::detail::host_config h_cfg{node_count, local_rank};
-	celerity::detail::config cfg(nullptr, nullptr);
-	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-	auto device_selector = [](const mock_device& d) -> int { return d.get_type() == dt::accelerator ? 2 : 1; };
-
-	auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-	CHECK(celerity::test_utils::log_contains_substring(
-	    celerity::detail::log_level::info, "Using platform 'My platform', device 'My device' (device selector specified: platform 2, device 3)"));
-	CHECK(device == md);
-}
-
-TEST_CASE("pick_device selects the highest scoring device for all nodes if an insufficient number of total devices is available", "[device-selection]") {
-	celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
-
-	mock_platform_factory mpf;
-
-	auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-	mp_0.create_devices(dt::cpu);
-	mp_1.create_devices(dt::gpu);
-	auto md = mp_2.create_devices(dt::accelerator)[0];
-
-	const size_t node_count = 4;
-	const size_t local_rank = 3;
-
-	celerity::detail::host_config h_cfg{node_count, local_rank};
-	celerity::detail::config cfg(nullptr, nullptr);
-	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-	auto device_selector = [md](const mock_device& d) -> int { return d == md ? 2 : 1; };
-
-	auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-	CHECK(celerity::test_utils::log_contains_substring(
-	    celerity::detail::log_level::warn, "No suitable platform found that can provide 4 devices that match the specified device selector"));
-	CHECK(device == md);
-}
-
-TEST_CASE("pick_device warns when highest scoring devices span multiple platforms", "[device-selection]") {
-	celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
-
-	mock_platform_factory mpf;
-
-	auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-	mp_0.create_devices(dt::cpu);
-	mp_1.create_devices(dt::accelerator, dt::gpu, dt::gpu, dt::gpu);
-	mp_2.create_devices(dt::gpu, dt::accelerator, dt::accelerator, dt::accelerator);
-
-	const size_t node_count = 4;
-	const size_t local_rank = GENERATE(0, 3);
-
-	celerity::detail::host_config h_cfg{node_count, local_rank};
-	celerity::detail::config cfg(nullptr, nullptr);
-	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-	auto device_selector = [](const mock_device& d) -> int { return d.get_type() == dt::accelerator ? 2 : 1; };
-
-	auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-	INFO("Platform id" << device.get_platform().get_id() << " device id " << device.get_id());
-	CHECK(celerity::test_utils::log_contains_substring(
-	    celerity::detail::log_level::warn, "Selected devices are of different type and/or do not belong to the same platform"));
-
-	if(local_rank == 0) {
-		CHECK(device.get_platform() == mp_1);
-	} else {
-		CHECK(device.get_platform() == mp_2);
+template <>
+struct fmt::formatter<mock_backend_type> : fmt::formatter<std::string_view> {
+	format_context::iterator format(const mock_backend_type type, format_context& ctx) const {
+		const auto repr = [=]() -> std::string_view {
+			switch(type) {
+			case mock_backend_type::generic1: return "generic#1";
+			case mock_backend_type::generic2: return "generic#2";
+			case mock_backend_type::specialized1: return "SPECIALIZED#1";
+			case mock_backend_type::specialized2: return "SPECIALIZED#2";
+			default: utils::unreachable();
+			}
+		}();
+		return std::copy(repr.begin(), repr.end(), ctx.out());
 	}
-}
+};
 
-TEST_CASE("pick_device warns when highest scoring devices are of different types", "[device-selection]") {
-	celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
+struct mock_backend_enumerator {
+	using backend_type = mock_backend_type;
+	using device_type = mock_device;
 
-	mock_platform_factory mpf;
+	std::vector<backend_type> available;
+	std::unordered_map<mock_device, std::vector<backend_type>> compatible;
 
-	auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-	mp_0.create_devices(dt::cpu);
-	auto md = mp_1.create_devices(dt::accelerator, dt::gpu, dt::gpu, dt::gpu)[0];
-	mp_2.create_devices(dt::accelerator, dt::gpu, dt::gpu, dt::gpu);
+	std::vector<backend_type> compatible_backends(const mock_device& device) const { return compatible.at(device); }
 
-	const size_t node_count = 4;
-	const size_t local_rank = 0;
+	std::vector<backend_type> available_backends() const { return available; }
 
-	celerity::detail::host_config h_cfg{node_count, local_rank};
-	celerity::detail::config cfg(nullptr, nullptr);
-	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
+	bool is_specialized(backend_type type) const { return type == mock_backend_type::specialized1 || type == mock_backend_type::specialized2; }
 
-	auto device_selector = [](const mock_device& d) -> int { return d.get_type() == dt::accelerator ? 2 : 1; };
-
-	auto device = pick_device(cfg, device_selector, std::vector<mock_platform>{mp_0, mp_1, mp_2});
-	INFO("Platform id" << device.get_platform().get_id() << " device id " << device.get_id());
-	CHECK(celerity::test_utils::log_contains_substring(
-	    celerity::detail::log_level::warn, "Selected devices are of different type and/or do not belong to the same platform"));
-	CHECK(device == md);
-}
-
-TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device does not consider devices with a negative selector score", "[device-selection]") {
-	celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn); // pick_device warns
-
-	celerity::detail::config cfg(nullptr, nullptr);
-	mock_platform_factory mpf;
-
-	auto [mp_0, mp_1, mp_2] = mpf.create_platforms(std::nullopt, std::nullopt, std::nullopt);
-	mp_0.create_devices(dt::cpu);
-	mp_1.create_devices(dt::gpu, dt::gpu, dt::gpu);
-	mp_2.create_devices(dt::gpu);
-
-	const size_t node_count = 4;
-	const size_t local_rank = 2;
-
-	celerity::detail::host_config h_cfg{node_count, local_rank};
-	celerity::detail::config_testspy::set_mock_host_cfg(cfg, h_cfg);
-
-	auto device_selector = [](const mock_device& d) -> int { return d.get_type() == dt::accelerator ? 1 : -1; };
-	CHECK_THROWS_WITH(
-	    pick_device(cfg, device_selector, std::vector<mock_platform>{mp_0, mp_1, mp_2}), "Device selection with device selector failed: No device available");
-}
-
-TEST_CASE_METHOD(celerity::test_utils::mpi_fixture, "pick_device prints information about device backend") {
-	using namespace celerity;
-	using namespace celerity::detail;
-
-	config cfg(nullptr, nullptr);
-
-	const auto devices = sycl::device::get_devices();
-	std::optional<sycl::device> generic_device;
-	std::optional<sycl::device> cuda_device;
-
-	for(const auto& d : devices) {
-		if(backend::get_type(d) == backend::type::cuda) {
-			cuda_device = d;
-		} else {
-			generic_device = d;
+	int get_priority(backend_type type) const {
+		switch(type) {
+		case mock_backend_type::generic1: return 1;
+		case mock_backend_type::generic2: return 0;
+		case mock_backend_type::specialized1: return 3;
+		case mock_backend_type::specialized2: return 2;
+		default: utils::unreachable();
 		}
 	}
+};
 
-	SECTION("warns when using generic backend") {
-		if(!generic_device.has_value()) {
-			SKIP("No generic device available");
-		} else {
-			celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
-			pick_device(cfg, *generic_device, std::vector<sycl::platform>{});
-			CHECK(celerity::test_utils::log_contains_substring(celerity::detail::log_level::warn,
-			    fmt::format("No backend specialization available for selected platform '{}', falling back to generic. Performance may be degraded.",
-			        generic_device->get_platform().get_info<sycl::info::platform::name>())));
-		}
-	}
+TEST_CASE("select_backend picks highest-priority available specialized backend", "[device-selection]") {
+	test_utils::allow_max_log_level(log_level::warn);
 
-	SECTION("informs user when using specialized backend") {
-		if(!cuda_device.has_value() || !backend_detail::is_enabled_v<backend::type::cuda>) {
-			SKIP("No CUDA device available or CUDA backend not enabled");
-		} else {
-			pick_device(cfg, *cuda_device, std::vector<sycl::platform>{});
-			CHECK(celerity::test_utils::log_contains_substring(celerity::detail::log_level::debug,
-			    fmt::format("Using CUDA backend for selected platform '{}'.", cuda_device->get_platform().get_info<sycl::info::platform::name>())));
-		}
-	}
+	mock_platform platform(0, "platform");
+	std::vector<mock_device> devices{
+	    mock_device(0, platform, type_and_name{sycl::info::device_type::gpu, "gpu0"}),
+	    mock_device(1, platform, type_and_name{sycl::info::device_type::gpu, "gpu1"}),
+	};
+	mock_backend_enumerator enumerator{{mock_backend_type::generic1, mock_backend_type::generic2, mock_backend_type::specialized2},
+	    {
+	        {devices.at(0), {mock_backend_type::generic1, mock_backend_type::specialized1, mock_backend_type::specialized2}},
+	        {devices.at(1), {mock_backend_type::generic1, mock_backend_type::specialized1, mock_backend_type::specialized2}},
+	    }};
 
-	SECTION("warns when specialized backend is not enabled") {
-		if(!cuda_device.has_value() || backend_detail::is_enabled_v<backend::type::cuda>) {
-			SKIP("No CUDA device available or CUDA backend is enabled");
-		} else {
-			celerity::test_utils::allow_max_log_level(celerity::detail::log_level::warn);
-			pick_device(cfg, *cuda_device, std::vector<sycl::platform>{});
-			CHECK(celerity::test_utils::log_contains_substring(celerity::detail::log_level::warn,
-			    fmt::format("Selected platform '{}' is compatible with specialized CUDA backend, but it has not been compiled.",
-			        cuda_device->get_platform().get_info<sycl::info::platform::name>())));
-		}
-	}
+	auto backend = select_backend(enumerator, devices);
+	CHECK(backend == mock_backend_type::specialized2);
+	CHECK(test_utils::log_contains_exact(log_level::warn,
+	    fmt::format("All selected devices are compatible with specialized {} backend, but it has not been compiled. Performance may be degraded.",
+	        mock_backend_type::specialized1)));
+	CHECK(test_utils::log_contains_exact(log_level::debug, fmt::format("Using {} backend for the selected devices.", mock_backend_type::specialized2)));
+}
+
+TEST_CASE("select_backend picks highest-priority available generic backend if there is no common specialization", "[device-selection]") {
+	test_utils::allow_max_log_level(log_level::warn);
+
+	mock_platform platform(0, "platform");
+	std::vector<mock_device> devices{
+	    mock_device(0, platform, type_and_name{sycl::info::device_type::gpu, "gpu0"}),
+	    mock_device(1, platform, type_and_name{sycl::info::device_type::gpu, "gpu1"}),
+	};
+	mock_backend_enumerator enumerator{
+	    {mock_backend_type::generic1, mock_backend_type::generic2, mock_backend_type::specialized1, mock_backend_type::specialized2},
+	    {
+	        {devices.at(0), {mock_backend_type::generic1, mock_backend_type::generic2, mock_backend_type::specialized1}},
+	        {devices.at(1), {mock_backend_type::generic1, mock_backend_type::generic2, mock_backend_type::specialized2}},
+	    }};
+
+	auto backend = select_backend(enumerator, devices);
+	CHECK(backend == mock_backend_type::generic1);
+	CHECK(test_utils::log_contains_exact(
+	    log_level::warn, fmt::format("No common backend specialization available for all selected devices, falling back to {}. Performance may be degraded.",
+	                         mock_backend_type::generic1)));
+}
+
+TEST_CASE("select_backend picks a generic backend if no compatible specialization was compiled", "[device-selection]") {
+	test_utils::allow_max_log_level(log_level::warn);
+
+	mock_platform platform(0, "platform");
+	std::vector<mock_device> devices{
+	    mock_device(0, platform, type_and_name{sycl::info::device_type::gpu, "gpu0"}),
+	    mock_device(1, platform, type_and_name{sycl::info::device_type::gpu, "gpu1"}),
+	};
+	mock_backend_enumerator enumerator{{mock_backend_type::generic1, mock_backend_type::generic2},
+	    {
+	        {devices.at(0), {mock_backend_type::generic2, mock_backend_type::specialized1, mock_backend_type::specialized2}},
+	        {devices.at(1), {mock_backend_type::generic2, mock_backend_type::specialized1, mock_backend_type::specialized2}},
+	    }};
+
+	auto backend = select_backend(enumerator, devices);
+	CHECK(backend == mock_backend_type::generic2);
+	CHECK(test_utils::log_contains_exact(log_level::warn,
+	    fmt::format("All selected devices are compatible with specialized {} backend, but it has not been compiled. Performance may be degraded.",
+	        mock_backend_type::specialized1)));
+	CHECK(test_utils::log_contains_exact(log_level::warn,
+	    fmt::format("All selected devices are compatible with specialized {} backend, but it has not been compiled. Performance may be degraded.",
+	        mock_backend_type::specialized2)));
+	CHECK(test_utils::log_contains_exact(
+	    log_level::warn, fmt::format("No common backend specialization available for all selected devices, falling back to {}. Performance may be degraded.",
+	                         mock_backend_type::generic2)));
 }


### PR DESCRIPTION
This upstreams the new device selection logic developed by @psalz for the old multi-GPU Celerity branch alongside modifications I made for the new IDAG backend logic.

While the old single-device selection logic remains in place until the IDAG execution PR, its tests are already replaced here to streamline the merge process.