### PR TITLE
[IDAG] Optimal nd-memory copy primitives

### DIFF
--- a/include/nd_memory.h
+++ b/include/nd_memory.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "grid.h"
+#include "ranges.h"
+
+#include <string.h>
+
+namespace celerity::detail {
+
+/// Describes a box-shaped copy operation between two box-shaped allocations in terms of linear offsets and strides.
+struct nd_copy_layout {
+	struct stride_dimension {
+		size_t source_stride = 1; ///< by how many bytes to advance the source pointer after one step in this dimension.
+		size_t dest_stride = 1;   ///< by how many bytes to advance the destination pointer after one step in this dimension.
+		size_t count = 1;         ///< how many iterations to perform in this dimension.
+
+		friend bool operator==(const stride_dimension& lhs, const stride_dimension& rhs) {
+			return lhs.source_stride == rhs.source_stride && lhs.dest_stride == rhs.dest_stride && lhs.count == rhs.count;
+		}
+
+		friend bool operator!=(const stride_dimension& lhs, const stride_dimension& rhs) { return !(lhs == rhs); }
+	};
+
+	size_t offset_in_source = 0; ///< offset in the source allocation, in bytes, of the first chunk to copy.
+	size_t offset_in_dest = 0;   ///< offset in the destination allocation, in bytes, of the first chunk to copy.
+	int num_complex_strides = 0; ///< number of strides which are not contiguous in either source or destination.
+	stride_dimension strides[2]; ///< in the 3D / 2-complex case, strides[0] is the outer and strides[1] the inner stride.
+	size_t contiguous_size = 0;  ///< number of contiguous bytes in the last dimension.
+
+	friend bool operator==(const nd_copy_layout& lhs, const nd_copy_layout& rhs) {
+		return lhs.offset_in_source == rhs.offset_in_source && lhs.offset_in_dest == rhs.offset_in_dest && lhs.contiguous_size == rhs.contiguous_size
+		       && lhs.num_complex_strides == rhs.num_complex_strides && lhs.strides[0] == rhs.strides[0] && lhs.strides[1] == rhs.strides[1];
+	}
+
+	friend bool operator!=(const nd_copy_layout& lhs, const nd_copy_layout& rhs) { return !(lhs == rhs); }
+};
+
+/// Computes the minimum number of complex strides required to describe a box-shaped copy between box-shaped allocations.
+inline nd_copy_layout layout_nd_copy(const range<3>& source_range, const range<3>& dest_range, const id<3>& offset_in_source, const id<3>& offset_in_dest,
+    const range<3>& copy_range, size_t elem_size) {
+	assert(all_true(offset_in_source + copy_range <= source_range));
+	assert(all_true(offset_in_dest + copy_range <= dest_range));
+
+	if(copy_range.size() == 0) return {};
+
+	nd_copy_layout layout;
+	layout.offset_in_source = get_linear_index(source_range, offset_in_source) * elem_size;
+	layout.offset_in_dest = get_linear_index(dest_range, offset_in_dest) * elem_size;
+	layout.contiguous_size = elem_size;
+	size_t* current_range = &layout.contiguous_size; // we first maximize the contiguous range, then the range of the 0th / 1st stride.
+	size_t next_source_stride = elem_size;
+	size_t next_dest_stride = elem_size;
+	bool contiguous = true; // when false, the next-higher non-trivial dimension must insert a stride
+	for(int d = 2; d >= 0; --d) {
+		if(!contiguous && copy_range[d] != 1) { // if range is 1, we can postpone (and possibly avoid) inserting a stride
+			++layout.num_complex_strides;
+			layout.strides[1] = layout.strides[0];
+			layout.strides[0] = {next_source_stride, next_dest_stride, 1};
+			current_range = &layout.strides[0].count;
+			contiguous = true;
+		}
+		next_source_stride *= source_range[d];
+		next_dest_stride *= dest_range[d];
+		*current_range *= copy_range[d];
+		if(source_range[d] != copy_range[d] || dest_range[d] != copy_range[d]) { contiguous = false; }
+	}
+
+	return layout;
+}
+
+/// For every contiguous chunk in an nd-copy, invoke `f(byte_offset_in_source, byte_offset_in_dest, chunk_bytes)`.
+template <typename F>
+inline void for_each_contiguous_chunk(const nd_copy_layout& layout, F&& f) {
+	if(layout.contiguous_size == 0) return;
+
+	// nd_copy_layout is defined such that we can ignore num_complex_strides in this loop and will perform exactly one iteration for every non-complex stride.
+	size_t source_offset_0 = layout.offset_in_source;
+	size_t dest_offset_0 = layout.offset_in_dest;
+	for(size_t i = 0; i < layout.strides[0].count; ++i) {
+		size_t source_offset_1 = source_offset_0;
+		size_t dest_offset_1 = dest_offset_0;
+		for(size_t j = 0; j < layout.strides[1].count; ++j) {
+			f(source_offset_1, dest_offset_1, layout.contiguous_size);
+			source_offset_1 += layout.strides[1].source_stride;
+			dest_offset_1 += layout.strides[1].dest_stride;
+		}
+		source_offset_0 += layout.strides[0].source_stride;
+		dest_offset_0 += layout.strides[0].dest_stride;
+	}
+}
+
+/// From allocation `source_base` sized `source_range` starting at `offset_in_source`, to allocation `dest_base` sized `dest_range` starting at to
+/// `offset_in_dest`, copy `copy_range` elements of `elem_size` bytes.
+inline void nd_copy_host(const void* const source_base, void* const dest_base, const range<3>& source_range, const range<3>& dest_range,
+    const id<3>& offset_in_source, const id<3>& offset_in_dest, const range<3>& copy_range, const size_t elem_size) //
+{
+	const auto layout = layout_nd_copy(source_range, dest_range, offset_in_source, offset_in_dest, copy_range, elem_size);
+	for_each_contiguous_chunk(layout, [&](const size_t chunk_offset_in_source, const size_t chunk_offset_in_dest, const size_t chunk_size) {
+		memcpy(static_cast<std::byte*>(dest_base) + chunk_offset_in_dest, static_cast<const std::byte*>(source_base) + chunk_offset_in_source, chunk_size);
+	});
+}
+
+/// From allocation `source_base` spanning `source_box` to allocation `dest_base` spanning `dest_box`, copy `copy_box` elements of `elem_size` bytes.
+inline void nd_copy_host(
+    const void* const source_base, void* const dest_base, const box<3>& source_box, const box<3>& dest_box, const box<3>& copy_box, const size_t elem_size) //
+{
+	assert(source_box.covers(copy_box));
+	assert(dest_box.covers(copy_box));
+	nd_copy_host(source_base, dest_base, source_box.get_range(), dest_box.get_range(), copy_box.get_offset() - source_box.get_offset(),
+	    copy_box.get_offset() - dest_box.get_offset(), copy_box.get_range(), elem_size);
+}
+
+/// From allocation `source_base` spanning `source_box` to allocation `dest_base` spanning `dest_box`, copy `copy_region` elements of `elem_size` bytes.
+inline void nd_copy_host(const void* const source_base, void* const dest_base, const box<3>& source_box, const box<3>& dest_box, const region<3>& copy_region,
+    const size_t elem_size) //
+{
+	for(const auto& copy_box : copy_region.get_boxes()) {
+		nd_copy_host(source_base, dest_base, source_box, dest_box, copy_box, elem_size);
+	}
+}
+
+} // namespace celerity::detail

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_TARGETS
   instruction_graph_misc_tests
   instruction_graph_p2p_tests
   instruction_graph_reduction_tests
+  nd_memory_tests
   out_of_order_engine_tests
   print_graph_tests
   region_map_tests

--- a/test/copy_test_utils.h
+++ b/test/copy_test_utils.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "grid.h"
+
+#include <vector>
+
+namespace celerity::test_utils {
+
+struct copy_test_layout {
+	detail::box<3> source_box;
+	detail::box<3> dest_box;
+	detail::box<3> copy_box;
+};
+
+inline constexpr range<3> copy_test_max_range{8, 8, 8}; // default range 4 in each dimension, plus potentially 2x2 padding
+
+inline std::vector<copy_test_layout> generate_copy_test_layouts() {
+	enum padding { none = 0b00, left = 0b01, right = 0b10, both = 0b11 };
+	constexpr size_t padding_width = 2;
+	const std::vector<padding> no_padding = {none};
+	const std::vector<padding> all_paddings = {none, left, right, both};
+
+	std::vector<copy_test_layout> layouts;
+	for(int dims = 0; dims < 3; ++dims) {
+		id<3> copy_min{3, 4, 5};
+		id<3> copy_max{7, 8, 9};
+		for(int d = dims; d < 3; ++d) {
+			copy_min[d] = 0;
+			copy_max[d] = 1;
+		}
+
+		for(const auto source_padding_x : dims > 0 ? all_paddings : no_padding) {
+			for(const auto dest_padding_x : dims > 0 ? all_paddings : no_padding) {
+				for(const auto source_padding_y : dims > 1 ? all_paddings : no_padding) {
+					for(const auto dest_padding_y : dims > 1 ? all_paddings : no_padding) {
+						for(const auto source_padding_z : dims > 2 ? all_paddings : no_padding) {
+							for(const auto dest_padding_z : dims > 2 ? all_paddings : no_padding) {
+								id<3> source_min = copy_min;
+								id<3> source_max = copy_max;
+								id<3> dest_min = copy_min;
+								id<3> dest_max = copy_max;
+								const padding source_padding[] = {source_padding_x, source_padding_y, source_padding_z};
+								const padding dest_padding[] = {dest_padding_x, dest_padding_y, dest_padding_z};
+								for(int d = 0; d < dims; ++d) {
+									if((source_padding[d] & left) != 0) { source_min[d] -= padding_width; }
+									if((source_padding[d] & right) != 0) { source_max[d] += padding_width; }
+									if((dest_padding[d] & left) != 0) { dest_min[d] -= padding_width; }
+									if((dest_padding[d] & right) != 0) { dest_max[d] += padding_width; }
+								}
+								layouts.push_back({
+								    detail::box<3>{source_min, source_max},
+								    detail::box<3>{dest_min, dest_max},
+								    detail::box<3>{copy_min, copy_max},
+								});
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return layouts;
+}
+
+} // namespace celerity::test_utils

--- a/test/nd_memory_tests.cc
+++ b/test/nd_memory_tests.cc
@@ -1,0 +1,90 @@
+#include "nd_memory.h"
+
+#include "copy_test_utils.h"
+#include "test_utils.h"
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+using namespace celerity;
+using namespace celerity::detail;
+
+TEST_CASE("layout_nd_copy selects the minimum number of strides", "[memory]") {
+	// empty
+	CHECK(layout_nd_copy({1, 1, 1}, {1, 2, 3}, {0, 0, 0}, {0, 0, 0}, {0, 1, 1}, 1) == nd_copy_layout{0, 0, 0, {}, 0});
+	CHECK(layout_nd_copy({1, 1, 1}, {1, 2, 3}, {0, 0, 0}, {0, 0, 0}, {0, 1, 1}, 4) == nd_copy_layout{0, 0, 0, {}, 0});
+
+	// all contiguous
+	CHECK(layout_nd_copy({1, 1, 1}, {1, 1, 1}, {0, 0, 0}, {0, 0, 0}, {1, 1, 1}, 1) == nd_copy_layout{0, 0, 0, {}, 1});
+	CHECK(layout_nd_copy({1, 1, 1}, {1, 1, 1}, {0, 0, 0}, {0, 0, 0}, {1, 1, 1}, 4) == nd_copy_layout{0, 0, 0, {}, 4});
+	CHECK(layout_nd_copy({1, 3, 1}, {1, 1, 1}, {0, 2, 0}, {0, 0, 0}, {1, 1, 1}, 1) == nd_copy_layout{2, 0, 0, {}, 1});
+	CHECK(layout_nd_copy({1, 1, 1}, {1, 3, 1}, {0, 0, 0}, {0, 2, 0}, {1, 1, 1}, 1) == nd_copy_layout{0, 2, 0, {}, 1});
+	CHECK(layout_nd_copy({5, 3, 2}, {1, 1, 2}, {0, 0, 0}, {0, 0, 0}, {1, 1, 2}, 1) == nd_copy_layout{0, 0, 0, {}, 2});
+	CHECK(layout_nd_copy({5, 3, 2}, {1, 1, 2}, {2, 1, 0}, {0, 0, 0}, {1, 1, 2}, 1) == nd_copy_layout{14, 0, 0, {}, 2});
+	CHECK(layout_nd_copy({1, 1, 2}, {5, 3, 2}, {0, 0, 0}, {2, 1, 0}, {1, 1, 2}, 1) == nd_copy_layout{0, 14, 0, {}, 2});
+	CHECK(layout_nd_copy({5, 1, 3}, {2, 1, 3}, {0, 0, 0}, {0, 0, 0}, {2, 1, 3}, 1) == nd_copy_layout{0, 0, 0, {}, 6});
+	CHECK(layout_nd_copy({5, 2, 3}, {7, 2, 3}, {2, 0, 0}, {1, 0, 0}, {2, 2, 3}, 1) == nd_copy_layout{12, 6, 0, {}, 12});
+	CHECK(layout_nd_copy({5, 2, 3}, {7, 2, 3}, {2, 0, 0}, {1, 0, 0}, {2, 2, 3}, 2) == nd_copy_layout{24, 12, 0, {}, 24});
+	CHECK(layout_nd_copy({5, 2, 3}, {4, 2, 3}, {0, 0, 0}, {0, 0, 0}, {2, 2, 3}, 1) == nd_copy_layout{0, 0, 0, {}, 12});
+	CHECK(layout_nd_copy({5, 2, 3}, {4, 2, 3}, {0, 0, 0}, {0, 0, 0}, {2, 2, 3}, 4) == nd_copy_layout{0, 0, 0, {}, 48});
+
+	// one stride
+	CHECK(layout_nd_copy({1, 2, 3}, {1, 2, 1}, {0, 0, 0}, {0, 0, 0}, {1, 2, 1}, 1) == nd_copy_layout{0, 0, 1, {{3, 1, 2}}, 1});
+	CHECK(layout_nd_copy({1, 2, 3}, {1, 2, 1}, {0, 0, 1}, {0, 0, 0}, {1, 2, 1}, 1) == nd_copy_layout{1, 0, 1, {{3, 1, 2}}, 1});
+	CHECK(layout_nd_copy({1, 2, 3}, {1, 2, 1}, {0, 0, 1}, {0, 0, 0}, {1, 2, 1}, 4) == nd_copy_layout{4, 0, 1, {{12, 4, 2}}, 4});
+	CHECK(layout_nd_copy({5, 2, 3}, {4, 2, 1}, {0, 0, 0}, {0, 0, 0}, {2, 1, 1}, 1) == nd_copy_layout{0, 0, 1, {{6, 2, 2}}, 1});
+	CHECK(layout_nd_copy({4, 3, 2}, {4, 3, 2}, {0, 0, 0}, {0, 0, 0}, {2, 2, 2}, 1) == nd_copy_layout{0, 0, 1, {{6, 6, 2}}, 4});
+	CHECK(layout_nd_copy({4, 3, 2}, {4, 3, 2}, {0, 0, 0}, {0, 0, 0}, {2, 2, 2}, 4) == nd_copy_layout{0, 0, 1, {{24, 24, 2}}, 16});
+	CHECK(layout_nd_copy({4, 5, 2}, {4, 5, 2}, {0, 0, 0}, {0, 0, 0}, {2, 4, 2}, 1) == nd_copy_layout{0, 0, 1, {{10, 10, 2}}, 8});
+	CHECK(layout_nd_copy({4, 5, 6}, {4, 5, 6}, {0, 0, 0}, {0, 0, 0}, {2, 4, 6}, 1) == nd_copy_layout{0, 0, 1, {{30, 30, 2}}, 24});
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {0, 0, 0}, {0, 0, 0}, {1, 3, 1}, 1) == nd_copy_layout{0, 0, 1, {{3, 3, 3}}, 1});
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {0, 0, 0}, {0, 0, 0}, {1, 2, 2}, 1) == nd_copy_layout{0, 0, 1, {{3, 3, 2}}, 2});
+	CHECK(layout_nd_copy({4, 1, 4}, {4, 1, 4}, {0, 0, 0}, {0, 0, 0}, {2, 1, 2}, 1) == nd_copy_layout{0, 0, 1, {{4, 4, 2}}, 2});
+	CHECK(layout_nd_copy({4, 1, 4}, {4, 1, 4}, {0, 0, 0}, {0, 0, 0}, {2, 1, 2}, 4) == nd_copy_layout{0, 0, 1, {{16, 16, 2}}, 8});
+
+	// two strides
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {0, 0, 0}, {0, 0, 0}, {2, 2, 2}, 1) == nd_copy_layout{0, 0, 2, {{9, 9, 2}, {3, 3, 2}}, 2});
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {0, 0, 0}, {0, 0, 0}, {2, 2, 2}, 4) == nd_copy_layout{0, 0, 2, {{36, 36, 2}, {12, 12, 2}}, 8});
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {1, 0, 0}, {0, 0, 0}, {2, 2, 2}, 1) == nd_copy_layout{9, 0, 2, {{9, 9, 2}, {3, 3, 2}}, 2});
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {1, 1, 0}, {0, 0, 0}, {2, 2, 2}, 1) == nd_copy_layout{12, 0, 2, {{9, 9, 2}, {3, 3, 2}}, 2});
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {0, 0, 0}, {1, 0, 0}, {2, 2, 2}, 1) == nd_copy_layout{0, 9, 2, {{9, 9, 2}, {3, 3, 2}}, 2});
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {0, 0, 0}, {1, 1, 0}, {2, 2, 2}, 1) == nd_copy_layout{0, 12, 2, {{9, 9, 2}, {3, 3, 2}}, 2});
+	CHECK(layout_nd_copy({2, 3, 4}, {3, 6, 5}, {0, 0, 0}, {0, 0, 0}, {2, 3, 4}, 1) == nd_copy_layout{0, 0, 2, {{12, 30, 2}, {4, 5, 3}}, 4});
+	CHECK(layout_nd_copy({3, 3, 3}, {3, 3, 3}, {1, 0, 0}, {0, 0, 0}, {2, 2, 2}, 2) == nd_copy_layout{18, 0, 2, {{18, 18, 2}, {6, 6, 2}}, 4});
+}
+
+void dumb_nd_copy_host(
+    const void* const source_base, void* const dest_base, const box<3>& source_box, const box<3>& dest_box, const box<3>& copy_box, const size_t elem_size) //
+{
+	REQUIRE(source_box.covers(copy_box));
+	REQUIRE(dest_box.covers(copy_box));
+
+	id<3> i;
+	for(i[0] = copy_box.get_min()[0]; i[0] < copy_box.get_max()[0]; ++i[0]) {
+		for(i[1] = copy_box.get_min()[1]; i[1] < copy_box.get_max()[1]; ++i[1]) {
+			for(i[2] = copy_box.get_min()[2]; i[2] < copy_box.get_max()[2]; ++i[2]) {
+				const auto offset_in_source = get_linear_index(source_box.get_range(), i - source_box.get_offset()) * elem_size;
+				const auto offset_in_dest = get_linear_index(dest_box.get_range(), i - dest_box.get_offset()) * elem_size;
+				memcpy(static_cast<std::byte*>(dest_base) + offset_in_dest, static_cast<const std::byte*>(source_base) + offset_in_source, elem_size);
+			}
+		}
+	}
+}
+
+TEST_CASE("nd_copy_host works correctly in all source- and destination layouts", "[memory]") {
+	for(const auto& [source_box, dest_box, copy_box] : test_utils::generate_copy_test_layouts()) {
+		CAPTURE(source_box, dest_box, copy_box);
+
+		std::vector<int> source(source_box.get_area());
+		std::iota(source.begin(), source.end(), 1);
+
+		std::vector<int> expected_dest(dest_box.get_area());
+		dumb_nd_copy_host(source.data(), expected_dest.data(), source_box, dest_box, copy_box, sizeof(int));
+
+		std::vector<int> dest(dest_box.get_area());
+		nd_copy_host(source.data(), dest.data(), source_box, dest_box, copy_box, sizeof(int));
+
+		CHECK(dest == expected_dest);
+	}
+}


### PR DESCRIPTION
This PR proposes to merge the nd-memory copy layouting mechanism used by the IDAG executor. It is set to replace `memcpy_strided_host` and the host-side portion of `memcpy_strided_device` that is currently implemented in `buffer_storage`.

Unlike the current implementation, it always detects when a copy between higher-dimensional allocations is "accidentally contiguous" (i.e. can fulfilled by a single memcpy) or when a copy between 3D allocations is "accidentally 2D". The unit contains a full implementation of host-to-host copies (which perform the minimum number of memcpys possible) and the means to implement optimized dispatch to `cudaMemcpy*D` (for this, see [cuda_backend.cc in the IDAG branch](https://github.com/fknorr/celerity-runtime/blob/ed402792e94b0db69fa79c618b7bf80f6c585e7f/src/backend/cuda_backend.cc#L23)).