### PR TITLE
[IDAG] Add new threading facilities

### DIFF
--- a/include/async_event.h
+++ b/include/async_event.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <cassert>
+#include <chrono>
 #include <memory>
+#include <optional>
 #include <type_traits>
-
 
 namespace celerity::detail {
 
@@ -19,7 +20,14 @@ class async_event_impl {
 
 	/// If this function returns true once, the implementation must guarantee that it will always do so in the future.
 	/// The event is expected to be cheap to poll repeatedly, and the operation must proceed in the background even while not being polled.
-	virtual bool is_complete() const = 0;
+	virtual bool is_complete() = 0;
+
+	/// There is only one instruction type which returns a result, namely alloc_instruction returning a pointer to the allocated memory, i.e. a void*. Having a
+	/// void* return type on async_event_impl is somewhat leaky, but we don't gain much by wrapping it in a std::any.
+	virtual void* get_result() { return nullptr; }
+
+	/// Returns the time execution time as measured if profiling was enabled in the issuing component. Requires `is_complete()` to be true.
+	virtual std::optional<std::chrono::nanoseconds> get_native_execution_time() { return std::nullopt; }
 };
 
 /// `async_event` implementation that is immediately complete. Used to report synchronous completion of some operations within an otherwise asynchronous
@@ -27,7 +35,12 @@ class async_event_impl {
 class complete_event final : public async_event_impl {
   public:
 	complete_event() = default;
-	bool is_complete() const override { return true; }
+	explicit complete_event(void* const result) : m_result(result) {}
+	bool is_complete() override { return true; }
+	void* get_result() override { return m_result; }
+
+  private:
+	void* m_result = nullptr;
 };
 
 /// Type-erased event signalling completion of events at the executor layer. These may wrap SYCL events, asynchronous MPI requests, or similar.
@@ -40,6 +53,16 @@ class [[nodiscard]] async_event {
 	bool is_complete() const {
 		assert(m_impl != nullptr);
 		return m_impl->is_complete();
+	}
+
+	void* get_result() const {
+		assert(m_impl != nullptr);
+		return m_impl->get_result();
+	}
+
+	std::optional<std::chrono::nanoseconds> get_native_execution_time() const {
+		assert(m_impl != nullptr);
+		return m_impl->get_native_execution_time();
 	}
 
   private:
@@ -55,5 +78,6 @@ async_event make_async_event(CtorParams&&... ctor_args) {
 
 /// Shortcut to create an `async_event(complete_event)`.
 inline async_event make_complete_event() { return make_async_event<complete_event>(); }
+inline async_event make_complete_event(void* const result) { return make_async_event<complete_event>(result); }
 
 } // namespace celerity::detail

--- a/include/double_buffered_queue.h
+++ b/include/double_buffered_queue.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <vector>
+
+namespace celerity::detail {
+
+/// Clang as of 17.0.0 does not expose std::hardware_destructive_interference_size because it has issues around -march / -mcpu flags among others
+/// (see discussion at https://discourse.llvm.org/t/rfc-c-17-hardware-constructive-destructive-interference-size/48674).
+/// To keep it simple we conservatively pick an alignment of 128 bytes to avoid false sharing across all relevant architectures.
+/// Aarch64 and PowerPC64 have 128-byte cache lines; and x86_64 prefetches 64-byte cache lines in pairs starting from Sandy Bridge
+/// (see https://github.com/crossbeam-rs/crossbeam/blob/e7b5922e/crossbeam-utils/src/cache_padded.rs for a detailed enumeration by architecture).
+constexpr size_t hardware_destructive_interference_size = 128;
+
+/// (Thread-safe) multi-producer single-consumer queue that uses double-buffering to avoid lock contention and keep dequeueing latency as low as possible.
+template <typename T>
+class double_buffered_queue {
+  public:
+	/// Push a single element to the queue. Instead of frequently pushing multiple elements, consider using a vector<T> as the element type.
+	void push(T v) {
+		{
+			std::lock_guard lock(m_write.mutex);
+			// This push might allocate, which is the reason why double_buffered_queue retains ownership of both queues in order to re-use allocated memory and
+			// keep the lock duration as short as possible.
+			m_write.queue.push_back(std::move(v));
+			// Notify the reader that it is worth taking the lock
+			m_write.queue_nonempty.store(true, std::memory_order_relaxed);
+		}
+		m_write.resume.notify_one();
+	}
+
+	/// Returns all elements pushed to the queue since the last `pop_all`. The returned reference is valid until the next call to `pop_all`.
+	[[nodiscard]] std::vector<T>& pop_all() {
+		m_read.queue.clear();
+		if(m_write.queue_nonempty.load(std::memory_order_relaxed) /* opportunistic */) {
+			std::lock_guard lock(m_write.mutex);
+			swap(m_read.queue, m_write.queue);
+			// m_read.queue was cleared before the swap, so m_write.queue is empty now
+			m_write.queue_nonempty.store(false, std::memory_order_relaxed);
+		}
+		return m_read.queue;
+	}
+
+	/// After this function returns, the result of `pop_all` is non-empty as long as there is only a single reader thread.
+	void wait_while_empty() {
+		if(!m_write.queue_nonempty.load(std::memory_order_relaxed) /* opportunistic */) {
+			std::unique_lock lock(m_write.mutex);
+			m_write.resume.wait(lock, [&] { return m_write.queue_nonempty.load(std::memory_order_relaxed); });
+		}
+	}
+
+  private:
+	/// Aligned group 1: The write-queue and its associated synchronization primitives will move between threads on push, pop, and wait.
+	struct alignas(hardware_destructive_interference_size) write_end {
+		std::mutex mutex;
+		std::condition_variable resume;
+		std::vector<T> queue;
+		std::atomic<bool> queue_nonempty{false};
+	} m_write;
+
+	/// Aligned group 2: Reader thread can continue to concurrently access read_queue even while a writer thread pushes to write_queue.
+	struct alignas(hardware_destructive_interference_size) read_end {
+		std::vector<T> queue;
+	} m_read;
+};
+
+} // namespace celerity::detail

--- a/include/thread_queue.h
+++ b/include/thread_queue.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include "async_event.h"
+#include "double_buffered_queue.h"
+#include "named_threads.h"
+#include "utils.h"
+
+#include <chrono>
+#include <future>
+#include <thread>
+#include <type_traits>
+#include <variant>
+
+namespace celerity::detail {
+
+/// A single-thread job queue accepting functors and returning events that conditionally forward job results.
+class thread_queue {
+  public:
+	/// Constructs a null thread queue that cannot receive jobs.
+	thread_queue() = default;
+
+	/// Spawns a new thread queue with the given thread name. If `enable_profiling` is set to `true`, completed events from this thread queue will report a
+	/// non-nullopt duration.
+	explicit thread_queue(std::string thread_name, const bool enable_profiling = false) : m_impl(new impl(std::move(thread_name), enable_profiling)) {}
+
+	// thread_queue is movable, but not copyable.
+	thread_queue(const thread_queue&) = delete;
+	thread_queue(thread_queue&&) = default;
+	thread_queue& operator=(const thread_queue&) = delete;
+	thread_queue& operator=(thread_queue&&) = default;
+
+	/// Destruction will await all submitted and pending jobs.
+	~thread_queue() {
+		if(m_impl != nullptr) {
+			m_impl->queue.push(job{} /* termination */);
+			m_impl->thread.join();
+		}
+	}
+
+	/// Submit a job to the thread queue.
+	/// `fn` must take no arguments and return either `void` or a type convertible to `void *`, which will be forwarded as the result into the event.
+	template <typename Fn>
+	async_event submit(Fn&& fn) {
+		static_assert(std::is_void_v<std::invoke_result_t<std::decay_t<Fn>>> || std::is_convertible_v<std::invoke_result_t<std::decay_t<Fn>>, void*>,
+		    "job function must return either void or a pointer convertible to void*");
+		assert(m_impl != nullptr);
+		job job(std::forward<Fn>(fn));
+		auto evt = make_async_event<thread_queue::event>(job.promise.get_future());
+		m_impl->queue.push(std::move(job));
+		return evt;
+	}
+
+  private:
+	friend struct thread_queue_testspy;
+
+	/// The object passed through std::future from queue thread to owner thread
+	struct completion {
+		void* result = nullptr;
+		std::optional<std::chrono::nanoseconds> execution_time;
+	};
+
+	struct job {
+		std::function<void*()> fn;
+		std::promise<completion> promise;
+
+		job() = default; // empty (default-constructed) fn signals termination
+
+		/// Constructor overload for `fn` returning `void`.
+		template <typename Fn, std::enable_if_t<std::is_void_v<std::invoke_result_t<std::decay_t<Fn>>>, int> = 0>
+		job(Fn&& fn) : fn([fn = std::forward<Fn>(fn)]() mutable { return std::invoke(fn), nullptr; }) {}
+
+		/// Constructor overload for `fn` returning `void*`.
+		template <typename Fn, std::enable_if_t<std::is_convertible_v<std::invoke_result_t<std::decay_t<Fn>>, void*>, int> = 0>
+		job(Fn&& fn) : fn([fn = std::forward<Fn>(fn)]() mutable { return std::invoke(fn); }) {}
+	};
+
+	class event : public async_event_impl {
+	  public:
+		explicit event(std::future<completion> future) : m_state(std::move(future)) {}
+
+		bool is_complete() override { return get_completed() != nullptr; }
+
+		void* get_result() override {
+			const auto completed = get_completed();
+			assert(completed);
+			return completed->result;
+		}
+
+		std::optional<std::chrono::nanoseconds> get_native_execution_time() override {
+			const auto completed = get_completed();
+			assert(completed);
+			return completed->execution_time;
+		}
+
+	  private:
+		// As the result from std::future can only be retrieved once and std::shared_future is not functionally necessary here, we replace the future by its
+		// completion as soon as the first query succeeds.
+		std::variant<std::future<completion>, completion> m_state;
+
+		completion* get_completed() {
+			if(const auto completed = std::get_if<completion>(&m_state)) return completed;
+			if(auto& future = std::get<std::future<completion>>(m_state); future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+				return &m_state.emplace<completion>(future.get());
+			}
+			return nullptr;
+		}
+	};
+
+	// pimpl'd to keep thread_queue movable
+	struct impl {
+		double_buffered_queue<job> queue;
+		const bool enable_profiling;
+		std::thread thread;
+
+		explicit impl(std::string name, const bool enable_profiling) : enable_profiling(enable_profiling), thread(&impl::thread_main, this, std::move(name)) {}
+
+		void execute(job& job) const {
+			std::chrono::steady_clock::time_point start;
+			if(enable_profiling) { start = std::chrono::steady_clock::now(); }
+
+			completion completion;
+			completion.result = job.fn();
+
+			if(enable_profiling) {
+				const auto end = std::chrono::steady_clock::now();
+				completion.execution_time = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+			}
+			job.promise.set_value(completion);
+		}
+
+		void loop() {
+			for(;;) {
+				queue.wait_while_empty();
+				for(auto& job : queue.pop_all()) {
+					if(!job.fn) return;
+					execute(job);
+				}
+			}
+		}
+
+		void thread_main(const std::string& name) {
+			set_thread_name(get_current_thread_handle(), name);
+
+			try {
+				loop();
+			} catch(std::exception& e) { //
+				utils::panic("exception in {}: {}", name, e.what());
+			} catch(...) { //
+				utils::panic("exception in {}", name);
+			}
+		}
+	};
+
+	std::unique_ptr<impl> m_impl;
+};
+
+} // namespace celerity::detail

--- a/src/mpi_communicator.cc
+++ b/src/mpi_communicator.cc
@@ -26,14 +26,14 @@ class mpi_event final : public async_event_impl {
 		MPI_Wait(&m_req, MPI_STATUS_IGNORE);
 	}
 
-	bool is_complete() const override {
+	bool is_complete() override {
 		int flag = -1;
 		MPI_Test(&m_req, &flag, MPI_STATUS_IGNORE);
 		return flag != 0;
 	}
 
   private:
-	mutable MPI_Request m_req;
+	MPI_Request m_req;
 };
 
 constexpr int pilot_exchange_tag = mpi_support::TAG_COMMUNICATOR;

--- a/src/receive_arbiter.cc
+++ b/src/receive_arbiter.cc
@@ -17,7 +17,7 @@ class region_receive_event final : public async_event_impl {
   public:
 	explicit region_receive_event(const stable_region_request& rr) : m_request(rr) {}
 
-	bool is_complete() const override { return m_request.expired(); }
+	bool is_complete() override { return m_request.expired(); }
 
   private:
 	weak_region_request m_request;
@@ -29,7 +29,7 @@ class subregion_receive_event final : public async_event_impl {
 	explicit subregion_receive_event(const stable_region_request& rr, const region<3>& awaited_subregion)
 	    : m_request(rr), m_awaited_region(awaited_subregion) {}
 
-	bool is_complete() const override {
+	bool is_complete() override {
 		const auto rr = m_request.lock();
 		return rr == nullptr || region_intersection(rr->incomplete_region, m_awaited_region).empty();
 	}
@@ -44,7 +44,7 @@ class gather_receive_event final : public async_event_impl {
   public:
 	explicit gather_receive_event(const stable_gather_request& gr) : m_request(gr) {}
 
-	bool is_complete() const override { return m_request.expired(); }
+	bool is_complete() override { return m_request.expired(); }
 
   private:
 	weak_gather_request m_request;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_TARGETS
   backend_tests
   buffer_manager_tests
   debug_naming_tests
+  double_buffered_queue_tests
   graph_generation_tests
   graph_gen_granularity_tests
   graph_gen_reduction_tests
@@ -54,6 +55,7 @@ set(TEST_TARGETS
   task_graph_tests
   task_ring_buffer_tests
   test_utils_tests
+  thread_queue_tests
   utils_tests
   device_selection_tests
 )

--- a/test/double_buffered_queue_tests.cc
+++ b/test/double_buffered_queue_tests.cc
@@ -1,0 +1,97 @@
+#include "double_buffered_queue.h"
+#include "test_utils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace celerity;
+using namespace celerity::detail;
+
+TEST_CASE("double_buffered_queue works in a single-thread setup", "[double_buffered_queue]") {
+	double_buffered_queue<int> dbq;
+	CHECK(dbq.pop_all().empty());
+	dbq.push(0);
+	CHECK(dbq.pop_all() == std::vector{0});
+	dbq.push(1);
+	dbq.push(2);
+	CHECK(dbq.pop_all() == std::vector{1, 2});
+	dbq.push(3);
+	dbq.push(4);
+	dbq.push(5);
+	dbq.wait_while_empty();
+	CHECK(dbq.pop_all() == std::vector{3, 4, 5});
+	CHECK(dbq.pop_all().empty());
+}
+
+TEST_CASE("double_buffered_queue provides ordered communication between threads", "[double_buffered_queue]") {
+	double_buffered_queue<int> dbq;
+
+	std::mutex m;
+	int state = 0;
+	std::condition_variable cv;
+
+	const auto post_state = [&](int new_state) {
+		CELERITY_DEBUG("post {}", new_state);
+		std::lock_guard lock(m);
+		state = new_state;
+		cv.notify_all();
+	};
+
+	const auto await_state = [&](int target_state) {
+		CELERITY_DEBUG("await {}", target_state);
+		std::unique_lock lock(m);
+		cv.wait(lock, [&] { return state == target_state; });
+	};
+
+	std::thread producer([&] {
+		dbq.push(1);
+		dbq.push(2);
+		dbq.push(3);
+
+		await_state(1);
+		dbq.push(4);
+
+		await_state(2);
+		dbq.push(5);
+
+		await_state(3);
+		post_state(4);
+
+		await_state(5);
+		dbq.push(6);
+		dbq.push(7);
+		post_state(6);
+	});
+
+	std::thread consumer([&] {
+		dbq.wait_while_empty();
+		for(;;) {
+			const auto& got = dbq.pop_all();
+			CHECK(std::is_sorted(got.begin(), got.end()));
+			if(got.back() == 3) break;
+		}
+
+		post_state(1);
+		dbq.wait_while_empty();
+		CHECK(dbq.pop_all() == std::vector{4});
+
+		post_state(2);
+		for(;;) {
+			const auto& got = dbq.pop_all();
+			if(!got.empty()) {
+				CHECK(got == std::vector{5});
+				break;
+			}
+		}
+
+		post_state(3);
+		await_state(4);
+		CHECK(dbq.pop_all().empty());
+
+		post_state(5);
+		await_state(6);
+		CHECK(dbq.pop_all() == std::vector{6, 7});
+	});
+
+	producer.join();
+	consumer.join();
+}

--- a/test/receive_arbiter_tests.cc
+++ b/test/receive_arbiter_tests.cc
@@ -65,7 +65,7 @@ class mock_recv_communicator : public communicator {
 	class mock_event final : public async_event_impl {
 	  public:
 		explicit mock_event(const completion_flag& flag) : m_flag(flag) {}
-		bool is_complete() const override { return *m_flag; }
+		bool is_complete() override { return *m_flag; }
 
 	  private:
 		completion_flag m_flag;

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -14,6 +14,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <celerity.h>
 
+#include "async_event.h"
 #include "command.h"
 #include "command_graph.h"
 #include "device_queue.h"
@@ -456,6 +457,11 @@ namespace test_utils {
 	template <int Dims>
 	detail::box<Dims> truncate_box(const detail::box<3>& b3) {
 		return detail::box<Dims>(truncate_id<Dims>(b3.get_min()), truncate_id<Dims>(b3.get_max()));
+	}
+
+	inline void* await(const celerity::detail::async_event& evt) {
+		while(!evt.is_complete()) {}
+		return evt.get_result();
 	}
 
 } // namespace test_utils

--- a/test/thread_queue_tests.cc
+++ b/test/thread_queue_tests.cc
@@ -1,0 +1,61 @@
+#include "named_threads.h"
+#include "test_utils.h"
+#include "thread_queue.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace celerity;
+using namespace celerity::detail;
+
+namespace celerity::detail {
+
+struct thread_queue_testspy {
+	static std::thread& get_thread(thread_queue& tq) { return tq.m_impl->thread; }
+};
+
+} // namespace celerity::detail
+
+#if CELERITY_DETAIL_HAS_NAMED_THREADS
+
+TEST_CASE("thread_queue sets its thread name", "[thread_queue]") {
+	thread_queue tq("funny-name");
+	test_utils::await(tq.submit([] {})); // wait for thread to enter loop
+	auto& thread = thread_queue_testspy::get_thread(tq);
+	CHECK(get_thread_name(thread.native_handle()) == "funny-name");
+}
+
+#endif
+
+TEST_CASE("thread_queue forwards job results", "[thread_queue]") {
+	thread_queue tq("cy-test");
+
+	auto evt1 = tq.submit([] {});
+	auto evt2 = tq.submit([] { return nullptr; });
+	auto evt3 = tq.submit([] { return reinterpret_cast<void*>(16); });
+	auto evt4 = tq.submit([] { return reinterpret_cast<int*>(64); });
+
+	CHECK(test_utils::await(evt1) == nullptr);
+	CHECK(evt1.get_native_execution_time() == std::nullopt);
+
+	CHECK(test_utils::await(evt2) == nullptr);
+	CHECK(evt2.get_native_execution_time() == std::nullopt);
+
+	CHECK(test_utils::await(evt3) == reinterpret_cast<void*>(16));
+	CHECK(evt3.get_native_execution_time() == std::nullopt);
+
+	CHECK(test_utils::await(evt4) == reinterpret_cast<void*>(64));
+	CHECK(evt4.get_native_execution_time() == std::nullopt);
+}
+
+TEST_CASE("thread_queue reports execution times when profiling is enabled", "[thread_queue]") {
+	thread_queue tq("cy-test", true /* enable profiling */);
+
+	auto evt1 = tq.submit([] {});
+	auto evt2 = tq.submit([] { std::this_thread::sleep_for(std::chrono::milliseconds(99)); });
+
+	test_utils::await(evt1);
+	test_utils::await(evt2);
+
+	CHECK(evt1.get_native_execution_time().has_value());
+	CHECK(evt2.get_native_execution_time().value() >= std::chrono::milliseconds(99));
+}


### PR DESCRIPTION
This PR upstreams and tests two threading facilities required for IDAG execution: The in-order `thread_queue` and the `double_buffered_queue` for fast communication between threads.

- `async_event` gains the ability to return results from async operations (in practice always pointers = results from `sycl::malloc`, which is why I opted to make the result typpe `void*` instead of `std::any`)
- `thread_queue` takes functors as submissions and returns `async_events` while providing timing/profiling capabilities for host task, host copy and allocation operations. This will replace the CTPL thread pool, which would require a lot of boilerplate to keep in while providing little benefit, because with OoO dispatch, we don't have a need for pools with > 1 thread anymore.
- `double_buffered_queue` generalizes the queueing mechanism that's currently in place between main- and scheduler thread and ensures the consumer is contended as little as possible. This is a stand-alone component now because it will also be used between scheduler and executor threads.

I do realize there's a staggering number of things called queue now.