### PR TITLE
Bump minimum hipSYCL and DPC++ versions

### DIFF
--- a/.github/workflows/build_matrix.json
+++ b/.github/workflows/build_matrix.json
@@ -1,12 +1,11 @@
 {
     "NOTE": "Make sure to keep this in sync with docs/platform-support.md and benchmark.yml. Also ensure that the 'ubuntu-version' between 'HEAD' and 'latest' builds remains the same.",
     "default": [
-        { "sycl": "dpcpp", "sycl-version": "61e51015", "ubuntu-version": "20.04", "platform": "intel", "build-type": "Debug" },
+        { "sycl": "dpcpp", "sycl-version": "89327e0a", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
-        { "sycl": "hipsycl", "sycl-version": "d2bd9fc7", "ubuntu-version": "20.04", "platform": "nvidia", "build-type": "Debug" },
-        { "sycl": "hipsycl", "sycl-version": "d2bd9fc7", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Debug" },
-        { "sycl": "hipsycl", "sycl-version": "d2bd9fc7", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Release" },
+        { "sycl": "hipsycl", "sycl-version": "2636e1ff", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Debug" },
+        { "sycl": "hipsycl", "sycl-version": "2636e1ff", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Release" },
         { "sycl": "hipsycl", "sycl-version": "latest", "ubuntu-version": "23.04", "platform": "nvidia", "build-type": "Debug" },
         { "sycl": "hipsycl", "sycl-version": "latest", "ubuntu-version": "23.04", "platform": "nvidia", "build-type": "Release" },
         { "sycl": "simsycl", "sycl-version": "HEAD", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -4,20 +4,30 @@ title: Officially Supported Platforms
 sidebar_label: Platform Support
 ---
 
-The most recent version of Celerity aims to support the following environments:
+The most recent version of Celerity aims to support the following environments.
 
-* hipSYCL ≥ revision [`d2bd9fc7`](https://github.com/illuhad/hipSYCL/commit/d2bd9fc7), with
+## SYCL Implementations
+
+* hipSYCL ≥ revision [`2636e1ff`](https://github.com/illuhad/hipSYCL/commit/2636e1ff), with
   * CUDA ≥ 11.0
-  * Clang ≥ 10.0 for CUDA &lt; 12.0, Clang ≥ 16.0 for CUDA ≥ 12.0
+  * Clang ≥ 14.0 for CUDA &lt; 12.0, Clang ≥ 16.0 for CUDA ≥ 12.0
   * on NVIDIA hardware with compute capability ≥ 7.0
   * or on CPUs via OpenMP
-* DPC++ ≥ revision [`61e51015`](https://github.com/intel/llvm/commit/61e51015)
-  * [Intel Compute Runtime](https://github.com/intel/compute-runtime) ≥ 23.22.26516.18
-  * [oneAPI Level Zero](https://github.com/oneapi-src/level-zero) ≥ 1.9.9
+* DPC++ ≥ revision [`89327e0a`](https://github.com/intel/llvm/commit/89327e0a)
+  * [Intel Compute Runtime](https://github.com/intel/compute-runtime) ≥ 24.13.29138.7
+  * [oneAPI Level Zero](https://github.com/oneapi-src/level-zero) ≥ 1.17.0
   * on integrated and dedicated Intel GPUs
 * SimSYCL [HEAD](https://github.com/celerity/SimSYCL)
 
 ComputeCpp is no longer supported since its discontinuation.
+
+## MPI Implementations
+
+Even though we primarily test with OpenMPI, Celerity should be compatible with any MPI 2 implementation.
+
+> Note that the latest version of Celerity breaks with OpenMPI < 4.0.2 due to
+> [a known bug around `mpi_assert_allow_overtaking`](https://docs.open-mpi.org/en/main/release-notes/changelog/v4.0.x.html#open-mpi-version-4-0-2).
+> Make sure to upgrade your version of OpenMPI if you're currently running 4.0.1 or older.
 
 ## Continuously Tested Configurations
 
@@ -25,12 +35,11 @@ We automatically verify Celerity's build process and test suites against a selec
 
 Those are (CRT = Intel Compute Runtime, L0 = oneAPI Level Zero):
 
-| SYCL       | SYCL version                                                                                   | OS           | GPU             | Build type     |
+| SYCL       | SYCL version                                                                               | OS           | GPU             | Build type     |
 |------------|--------------------------------------------------------------------------------------------|--------------|-----------------|----------------|
-| DPC++      | [`61e51015`](https://github.com/intel/llvm/commit/61e51015) (CRT 23.22.26516.18, L0 1.9.9) | Ubuntu 20.04 | Intel Arc 770   | Debug          |
-| DPC++      | [`HEAD`](https://github.com/intel/llvm/) (CRT 23.22.26516.18, L0 1.11.0)                   | Ubuntu 22.04 | Intel Arc 770   | Debug, Release |
-| hipSYCL    | [`d2bd9fc7`](https://github.com/illuhad/hipSYCL/commit/d2bd9fc7) (Clang 10, CUDA 11.0.3)   | Ubuntu 20.04 | NVIDIA RTX 2070 | Debug          |
-| hipSYCL    | [`d2bd9fc7`](https://github.com/illuhad/hipSYCL/commit/d2bd9fc7) (Clang 14, CUDA 11.8.0)   | Ubuntu 22.04 | NVIDIA RTX 2070 | Debug, Release |
+| DPC++      | [`89327e0a`](https://github.com/intel/llvm/commit/89327e0a) (CRT 24.13.29138.7, L0 1.17.0) | Ubuntu 22.04 | Intel Arc A770  | Debug          |
+| DPC++      | [`HEAD`](https://github.com/intel/llvm/) (CRT 24.13.29138.7, L0 1.17.0)                    | Ubuntu 22.04 | Intel Arc A770  | Debug, Release |
+| hipSYCL    | [`2636e1ff`](https://github.com/illuhad/hipSYCL/commit/d2bd9fc7) (Clang 14, CUDA 11.8.0)   | Ubuntu 22.04 | NVIDIA RTX 2070 | Debug, Release |
 | hipSYCL    | [`HEAD`](https://github.com/illuhad/hipSYCL) (Clang 16, CUDA 12.2.0)\*                     | Ubuntu 23.04 | NVIDIA RTX 2070 | Debug, Release |
 | SimSYCL    | [`HEAD`](https://github.com/celerity/SimSYCL) (GCC 11.4)                                   | Ubuntu 22.04 | (None)          | Debug, Release |
 

--- a/include/item.h
+++ b/include/item.h
@@ -29,25 +29,6 @@ namespace detail {
 		return nd_item<Dims>{sycl_item, global_range, global_offset, chunk_offset, group_range, group_offset};
 	}
 
-
-	// SYCL 1.2.1: group::get_id(), SYCL 2020: group::get_group_id()
-	// hipSYCL switched from the 1.2.1 interface between releases, so we currently don't have a reliable CELERITY_WORKAROUND_LESS_OR_EQUAL macro for this.
-
-	template <typename Group, typename Enable = void>
-	struct sycl_group_has_get_group_id : public std::false_type {};
-
-	template <typename Group>
-	struct sycl_group_has_get_group_id<Group, std::void_t<decltype(std::declval<Group>().get_group_id())>> : public std::true_type {};
-
-	template <int Dims>
-	celerity::id<Dims> get_sycl_group_id(const sycl::group<Dims>& grp) {
-		if constexpr(sycl_group_has_get_group_id<sycl::group<Dims>>::value) {
-			return grp.get_group_id();
-		} else {
-			return grp.get_id();
-		}
-	}
-
 	template <int Dims>
 	inline sycl::nd_item<std::max(1, Dims)>& get_sycl_item(nd_item<Dims>& nd_item) {
 		return nd_item.m_sycl_item;
@@ -288,7 +269,7 @@ class nd_item {
 	explicit nd_item(const sycl::nd_item<std::max(1, Dims)>& sycl_item, const range<Dims>& global_range, const id<Dims>& global_offset,
 	    const id<Dims>& chunk_offset, const range<Dims>& group_range, const id<Dims>& group_offset)
 	    : m_sycl_item(sycl_item), m_global_id(chunk_offset + detail::id_cast<Dims>(celerity::id(sycl_item.get_global_id()))), m_global_offset(global_offset),
-	      m_global_range(global_range), m_group_id(group_offset + detail::id_cast<Dims>(detail::get_sycl_group_id(sycl_item.get_group()))),
+	      m_global_range(global_range), m_group_id(group_offset + detail::id_cast<Dims>(celerity::id(sycl_item.get_group().get_group_id()))),
 	      m_group_range(group_range) {}
 };
 


### PR DESCRIPTION
The IDAG runtime needs updates to both the minimum hipSYCL and the minimum DPC++ version for proper reduction support and various bugfixes.

This PR bumps both versions and adjusts documentation accordingly, also mentioning the recently found OpenMPI < 4.0.2 bug which is already relevant when running `mpi_tests` today. An older workaround on `sycl::item` still required for the old pinned version of hipSYCL is now obsolete and is also removed.