### PR TITLE
[IDAG] Backends & Execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,8 +199,10 @@ set(SOURCES
   src/device_queue.cc
   src/legacy_executor.cc
   src/distributed_graph_generator.cc
+  src/dry_run_executor.cc
   src/graph_serializer.cc
   src/grid.cc
+  src/live_executor.cc
   src/instruction_graph_generator.cc
   src/mpi_communicator.cc
   src/out_of_order_engine.cc
@@ -277,6 +279,9 @@ target_link_libraries(celerity_runtime PUBLIC
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/legacy_backend)
 target_link_libraries(celerity_runtime PUBLIC celerity_legacy_backends)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src/backend)
+target_link_libraries(celerity_runtime PUBLIC celerity_backends)
 
 # Deprecated feature flags
 set(CELERITY_FEATURE_SIMPLE_SCALAR_REDUCTIONS ${CELERITY_FEATURE_SCALAR_REDUCTIONS})
@@ -373,7 +378,7 @@ install(
   DESTINATION include/celerity/vendor
 )
 install(
-  TARGETS celerity_runtime celerity_legacy_backends
+  TARGETS celerity_runtime celerity_backends celerity_legacy_backends
   EXPORT install_exports
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "async_event.h"
+#include "closure_hydrator.h"
+#include "launcher.h"
+#include "types.h"
+
+#include <vector>
+
+#include <sycl/sycl.hpp>
+
+namespace celerity::detail {
+
+class communicator;
+struct system_info;
+
+/// The backend is responsible for asynchronously allocating device- and device-accessible host memory, copying data between host and device allocations, and
+/// launching host tasks and device kernels. Asynchronous work must be explicitly assigned to in-order queue ids as assigned by `out_of_order_engine`.
+class backend {
+  public:
+	backend() = default;
+	backend(const backend&) = delete;
+	backend(backend&&) = delete;
+	backend& operator=(const backend&) = delete;
+	backend& operator=(backend&&) = delete;
+	virtual ~backend() = default;
+
+	/// Returns metadata about the system as it appears to the backend implementation.
+	virtual const system_info& get_system_info() const = 0;
+
+	/// Synchronously allocates device-accessible host memory. This is slow and meant for debugging purposes only.
+	virtual void* debug_alloc(size_t size) = 0;
+
+	/// Synchronously frees device-accessible host memory. This is slow and meant for debugging purposes only.
+	virtual void debug_free(void* ptr) = 0;
+
+	/// Schedules the allocation of device-accessible host memory with the specified size and alignment. The operation will complete in-order with respect to
+	/// any other asynchronous `alloc` and `free` operation on the same backend.
+	virtual async_event enqueue_host_alloc(size_t size, size_t alignment) = 0;
+
+	/// Schedules the allocation of device memory with the specified size and alignment. The operation will complete in-order with respect to any other
+	/// asynchronous `alloc` and `free` operation on the same backend.
+	virtual async_event enqueue_device_alloc(device_id memory_device, size_t size, size_t alignment) = 0;
+
+	/// Schedules the release of memory allocated via `enqueue_host_alloc`. The operation will complete in-order with respect to any other asynchronous `alloc`
+	/// and `free` operation on the same backend.
+	virtual async_event enqueue_host_free(void* ptr) = 0;
+
+	/// Schedules the release of memory allocated via `enqueue_device_alloc`. The operation will complete in-order with respect to any other asynchronous
+	/// `alloc` and `free` operation on the same backend.
+	virtual async_event enqueue_device_free(device_id memory_device, void* ptr) = 0;
+
+	/// Enqueues the asynchronous execution of a host task in a background thread identified by `host_lane`. The operation will complete in-order with respect
+	/// to any other asynchronous host operation on `host_lane`.
+	virtual async_event enqueue_host_task(size_t host_lane, const host_task_launcher& launcher, std::vector<closure_hydrator::accessor_info> accessor_infos,
+	    const box<3>& execution_range, const communicator* collective_comm) = 0;
+
+	/// Enqueues the asynchronous execution of a kernel in an in-order device queue identified by `device` and `device_lane`. The operation will complete
+	/// in-order with respect to any other asynchronous device operation on `device` and `device_lane`.
+	virtual async_event enqueue_device_kernel(device_id device, size_t device_lane, const device_kernel_launcher& launcher,
+	    std::vector<closure_hydrator::accessor_info> accessor_infos, const box<3>& execution_range, const std::vector<void*>& reduction_ptrs) = 0;
+
+	/// Enqueues an n-dimensional copy between two host allocations (both either device-accessible or user-allocated). The operation will complete
+	/// in-order with respect to any other asynchronous host operation on `host_lane`.
+	virtual async_event enqueue_host_copy(size_t host_lane, const void* source_base, void* dest_base, const box<3>& source_box, const box<3>& dest_box,
+	    const region<3>& copy_region, size_t elem_size) = 0;
+
+	/// Enqueues an n-dimensional copy between two device-accessible allocations (at least one device-native). The operation will complete in-order with respect
+	/// to any other asynchronous device operation on `device` and `device_lane`.
+	virtual async_event enqueue_device_copy(device_id device, size_t device_lane, const void* source_base, void* dest_base, const box<3>& source_box,
+	    const box<3>& dest_box, const region<3>& copy_region, size_t elem_size) = 0;
+};
+
+} // namespace celerity::detail

--- a/include/backend/sycl_backend.h
+++ b/include/backend/sycl_backend.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "async_event.h"
+
+#include "backend/backend.h"
+
+#include <fmt/format.h>
+
+namespace celerity::detail::sycl_backend_detail {
+
+class sycl_event final : public async_event_impl {
+  public:
+	sycl_event() = default;
+	sycl_event(sycl::event last, bool enable_profiling) : m_first(enable_profiling ? std::optional(last) : std::nullopt), m_last(std::move(last)) {}
+	sycl_event(std::optional<sycl::event> first, sycl::event last) : m_first(std::move(first)), m_last(std::move(last)) {}
+
+	bool is_complete() override;
+
+	std::optional<std::chrono::nanoseconds> get_native_execution_time() override;
+
+  private:
+	std::optional<sycl::event> m_first; // set iff profiling is enabled - can be a copy of m_last.
+	sycl::event m_last;
+};
+
+/// Ensure that all operations previously submitted to the SYCL queue begin executing even when not explicitly awaited.
+void flush(sycl::queue& queue);
+
+#if CELERITY_DETAIL_ENABLE_DEBUG
+inline constexpr uint8_t uninitialized_memory_pattern = 0xff; // floats and doubles filled with this pattern show up as "-nan"
+#endif
+
+} // namespace celerity::detail::sycl_backend_detail
+
+namespace celerity::detail {
+
+/// Backend implementation which sources all allocations from SYCL and dispatches device kernels to SYCL in-order queues.
+///
+/// This abstract class implements all `backend` functions except copies, which not subject to platform-dependent specialization.
+class sycl_backend : public backend {
+  public:
+	explicit sycl_backend(const std::vector<sycl::device>& devices, bool enable_profiling);
+	sycl_backend(const sycl_backend&) = delete;
+	sycl_backend(sycl_backend&&) = delete;
+	sycl_backend& operator=(const sycl_backend&) = delete;
+	sycl_backend& operator=(sycl_backend&&) = delete;
+	~sycl_backend() override;
+
+	const system_info& get_system_info() const override;
+
+	void* debug_alloc(size_t size) override;
+
+	void debug_free(void* ptr) override;
+
+	async_event enqueue_host_alloc(size_t size, size_t alignment) override;
+
+	async_event enqueue_device_alloc(device_id device, size_t size, size_t alignment) override;
+
+	async_event enqueue_host_free(void* ptr) override;
+
+	async_event enqueue_device_free(device_id device, void* ptr) override;
+
+	async_event enqueue_host_task(size_t host_lane, const host_task_launcher& launcher, std::vector<closure_hydrator::accessor_info> accessor_infos,
+	    const box<3>& execution_range, const communicator* collective_comm) override;
+
+	async_event enqueue_device_kernel(device_id device, size_t device_lane, const device_kernel_launcher& launcher,
+	    std::vector<closure_hydrator::accessor_info> accessor_infos, const box<3>& execution_range, const std::vector<void*>& reduction_ptrs) override;
+
+	async_event enqueue_host_copy(size_t host_lane, const void* const source_base, void* const dest_base, const box<3>& source_box, const box<3>& dest_box,
+	    const region<3>& copy_region, const size_t elem_size) override;
+
+  protected:
+	sycl::queue& get_device_queue(device_id device, size_t lane);
+
+	system_info& get_system_info(); // mutable system_info is filled by sycl_cuda_backend constructor
+
+	bool is_profiling_enabled() const;
+
+  private:
+	struct impl;
+	std::unique_ptr<impl> m_impl;
+};
+
+/// Generic implementation of `sycl_backend` providing a fallback implementation for device copies that might be inefficient in the 2D / 3D case.
+class sycl_generic_backend final : public sycl_backend {
+  public:
+	sycl_generic_backend(const std::vector<sycl::device>& devices, bool enable_profiling);
+
+	async_event enqueue_device_copy(device_id device, size_t device_lane, const void* const source_base, void* const dest_base, const box<3>& source_box,
+	    const box<3>& dest_box, const region<3>& copy_region, const size_t elem_size) override;
+};
+
+#if CELERITY_DETAIL_BACKEND_CUDA_ENABLED
+/// CUDA specialized implementation of `sycl_backend` that uses native CUDA operations for 2D / 3D copies.
+class sycl_cuda_backend final : public sycl_backend {
+  public:
+	sycl_cuda_backend(const std::vector<sycl::device>& devices, bool enable_profiling);
+
+	async_event enqueue_device_copy(device_id device, size_t device_lane, const void* const source_base, void* const dest_base, const box<3>& source_box,
+	    const box<3>& dest_box, const region<3>& copy_region, const size_t elem_size) override;
+};
+#endif
+
+/// We differentiate between non-specialized and specialized Celerity SYCL backends.
+enum class sycl_backend_type { generic, cuda };
+
+/// Enumerates the SYCL backends devices are compatible with and that Celerity has been compiled with.
+/// This type implements the (nameless) concept accepted by `pick_devices`.
+struct sycl_backend_enumerator {
+	using backend_type = sycl_backend_type;
+	using device_type = sycl::device;
+
+	/// Lists the backend types a device is compatible with, even if Celerity has not been compiled with that backend.
+	std::vector<backend_type> compatible_backends(const sycl::device& device) const;
+
+	/// Lists the backend types Celerity has been compiled with.
+	std::vector<backend_type> available_backends() const;
+
+	/// Queries whether a given backend type is specialized (for diagnostics only).
+	bool is_specialized(backend_type type) const;
+
+	/// Returns a priority value for each backend type, where the highest-priority compatible backend type should offer the best performance.
+	int get_priority(backend_type type) const;
+};
+
+/// Creates a SYCL backend instance of the specified type with the devices listed. Requires that Celerity has been compiled with the given backend and all
+/// devices are compatible with it. If `enable_profiling` is true, events for asynchronous operations will report native execution times.
+std::unique_ptr<backend> make_sycl_backend(const sycl_backend_type type, const std::vector<sycl::device>& devices, bool enable_profiling);
+
+} // namespace celerity::detail

--- a/include/command.h
+++ b/include/command.h
@@ -6,6 +6,7 @@
 #include "intrusive_graph.h"
 #include "mpi_support.h"
 #include "ranges.h"
+#include "reduction.h"
 #include "task.h"
 #include "types.h"
 

--- a/include/dense_map.h
+++ b/include/dense_map.h
@@ -14,7 +14,11 @@ class dense_map : private std::vector<Value> {
 
   public:
 	dense_map() = default;
+
 	explicit dense_map(const size_t size) : vector(size) {}
+
+	template <typename InputIterator>
+	explicit dense_map(const InputIterator begin, const InputIterator end) : vector(begin, end) {}
 
 	using vector::begin, vector::end, vector::cbegin, vector::cend, vector::empty, vector::size, vector::resize;
 

--- a/include/distributed_graph_generator.h
+++ b/include/distributed_graph_generator.h
@@ -5,6 +5,7 @@
 
 #include "command_graph.h"
 #include "ranges.h"
+#include "reduction.h"
 #include "region_map.h"
 #include "types.h"
 

--- a/include/dry_run_executor.h
+++ b/include/dry_run_executor.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "double_buffered_queue.h"
+#include "executor.h"
+
+#include <thread>
+#include <variant>
+
+namespace celerity::detail {
+
+/// Executor implementation selected when Celerity performs a dry run, that is, graph generation for debugging purposes without actually allocating memory,
+/// launching kernels or issuing data transfers.
+///
+/// `dry_run_executor` still executes horizon-, epoch- and fence instructions to guarantee forward progress in the user application.
+class dry_run_executor final : public executor {
+  public:
+	/// `dlg` (optional) receives notifications about reached horizons and epochs from the executor thread.
+	explicit dry_run_executor(delegate* dlg);
+
+	dry_run_executor(const dry_run_executor&) = delete;
+	dry_run_executor(dry_run_executor&&) = delete;
+	dry_run_executor& operator=(const dry_run_executor&) = delete;
+	dry_run_executor& operator=(dry_run_executor&&) = delete;
+
+	~dry_run_executor() override;
+
+	void track_user_allocation(allocation_id aid, void* ptr) override;
+	void track_host_object_instance(host_object_id hoid, std::unique_ptr<host_object_instance> instance) override;
+	void track_reducer(reduction_id rid, std::unique_ptr<reducer> reducer) override;
+
+	void submit(std::vector<const instruction*> instructions, std::vector<outbound_pilot> pilots) override;
+
+  private:
+	using host_object_transfer = std::pair<host_object_id, std::unique_ptr<host_object_instance>>;
+	using submission = std::variant<std::vector<const instruction*>, host_object_transfer>;
+
+	double_buffered_queue<submission> m_submission_queue;
+	std::thread m_thread;
+
+	void thread_main(delegate* dlg);
+};
+
+} // namespace celerity::detail

--- a/include/executor.h
+++ b/include/executor.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "types.h"
+
+#include <memory>
+
+namespace celerity::detail {
+
+struct host_object_instance;
+class instruction;
+struct outbound_pilot;
+class reducer;
+
+/// An executor processes receives and processes an instruction stream to process in a background thread.
+class executor {
+  public:
+	/// Implement this as the owner of an executor to receive callbacks on completed horizons and epochs.
+	class delegate {
+	  protected:
+		delegate() = default;
+		delegate(const delegate&) = default;
+		delegate(delegate&&) = default;
+		delegate& operator=(const delegate&) = default;
+		delegate& operator=(delegate&&) = default;
+		~delegate() = default; // do not allow destruction through base pointer
+
+	  public:
+		/// Called from the executor thread as soon as a horizon_instruction has finished executing.
+		virtual void horizon_reached(task_id tid) = 0;
+
+		/// Called from the executor thread as soon as an epoch_instruction has finished executing.
+		virtual void epoch_reached(task_id tid) = 0;
+	};
+
+	executor() = default;
+	executor(const executor&) = delete;
+	executor(executor&&) = delete;
+	executor& operator=(const executor&) = delete;
+	executor& operator=(executor&&) = delete;
+
+	/// Waits until an epoch with `epoch_action::shutdown` has executed and the executor thread has exited.
+	virtual ~executor() = default;
+
+	/// Informs the executor about the runtime address of an allocation on user_memory_id. Must be called before submitting any instruction referring to the
+	/// allocation id in question. User allocations are later removed from executor tracking as they appear in an instruction_garbage list attached to a horizon
+	/// or epoch instruction.
+	virtual void track_user_allocation(allocation_id aid, void* ptr) = 0;
+
+	/// Transfer ownership of a host object instance to the executor. The executor will later destroy this instance when executing a matching
+	/// destroy_host_object_instruction.
+	virtual void track_host_object_instance(host_object_id hoid, std::unique_ptr<host_object_instance> instance) = 0;
+
+	/// Informs the executor about the runtime behavior of a reduction. Will be used by any fill_identity_instruction and reduce_instruction later submitted on
+	/// the same reduction_id. Reducer instances are removed from executor tracking and destroyed when they later appear in an instruction_garbage list attached
+	/// to a horizon or epoch instruction.
+	virtual void track_reducer(reduction_id rid, std::unique_ptr<reducer> reducer) = 0;
+
+	/// Submits a list of instructions to execute once their dependencies have been fulfilled, and a list of outbound pilots to be transmitted to their
+	/// recipients as soon as possible. Instructions must be in topological order of dependencies, as must be the concatenation of all vectors passed to
+	/// subsequent invocations of this function.
+	virtual void submit(std::vector<const instruction*> instructions, std::vector<outbound_pilot> pilots) = 0;
+};
+
+} // namespace celerity::detail

--- a/include/handler.h
+++ b/include/handler.h
@@ -18,6 +18,7 @@
 #include "item.h"
 #include "range_mapper.h"
 #include "ranges.h"
+#include "reduction.h"
 #include "reduction_manager.h"
 #include "task.h"
 #include "types.h"

--- a/include/host_object.h
+++ b/include/host_object.h
@@ -44,6 +44,17 @@ class host_object_manager {
 	std::unordered_set<host_object_id> m_objects;
 };
 
+/// Host objects that own their instance (i.e. not host_object<T&> nor host_object<void>) wrap it in a type deriving from this struct in order to pass it to
+/// the executor for (virtual) destruction from within the instruction graph.
+struct host_object_instance {
+	host_object_instance() = default;
+	host_object_instance(const host_object_instance&) = delete;
+	host_object_instance(host_object_instance&&) = delete;
+	host_object_instance& operator=(host_object_instance&&) = delete;
+	host_object_instance& operator=(const host_object_instance&) = delete;
+	virtual ~host_object_instance() = default;
+};
+
 // Base for `state` structs in all host_object specializations: registers and unregisters host_objects with the host_object_manager.
 struct host_object_tracker : public lifetime_extending_state {
 	detail::host_object_id id{};

--- a/include/instruction_graph.h
+++ b/include/instruction_graph.h
@@ -57,7 +57,7 @@ struct instruction_id_less {
 	bool operator()(const std::unique_ptr<instruction>& lhs, const std::unique_ptr<instruction>& rhs) const { return lhs->get_id() < rhs->get_id(); }
 };
 
-/// Creates a new (MPI) collective group by cloning an existing one. The instuction is issued whenever the first host task on a new collective_group is
+/// Creates a new (MPI) collective group by cloning an existing one. The instruction is issued whenever the first host task on a new collective_group is
 /// compiled, and itself is a collective operation.
 class clone_collective_group_instruction : public matchbox::implement_acceptor<instruction, clone_collective_group_instruction> {
   public:

--- a/include/live_executor.h
+++ b/include/live_executor.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "double_buffered_queue.h"
+#include "executor.h"
+
+#include <memory>
+#include <optional>
+#include <thread>
+#include <variant>
+
+namespace celerity::detail::live_executor_detail {
+
+struct instruction_pilot_batch {
+	std::vector<const instruction*> instructions;
+	std::vector<outbound_pilot> pilots;
+};
+struct user_allocation_transfer {
+	allocation_id aid;
+	void* ptr = nullptr;
+};
+struct host_object_transfer {
+	host_object_id hoid = 0;
+	std::unique_ptr<host_object_instance> instance;
+};
+struct reducer_transfer {
+	reduction_id rid = 0;
+	std::unique_ptr<reducer> reduction;
+};
+using submission = std::variant<instruction_pilot_batch, user_allocation_transfer, host_object_transfer, reducer_transfer>;
+
+} // namespace celerity::detail::live_executor_detail
+
+namespace celerity::detail {
+
+class communicator;
+struct system_info;
+class backend;
+
+/// Executor implementation for a normal (non-dry) run of a Celerity application. Internal instruction dependencies are resolved by means of an
+/// out_of_order_engine and receive_arbiter, and the resulting operations dispatched to a `backend` and `communicator` implementation.
+class live_executor final : public executor {
+  public:
+	struct policy_set {
+		std::optional<std::chrono::milliseconds> progress_warning_timeout = std::chrono::seconds(3);
+	};
+
+	/// Operations are dispatched to `backend` and `root_comm` or one of its clones.
+	/// `dlg` (optional) receives notifications about reached horizons and epochs from the executor thread.
+	explicit live_executor(
+	    std::unique_ptr<backend> backend, std::unique_ptr<communicator> root_comm, delegate* dlg, const policy_set& policy = default_policy_set());
+
+	live_executor(const live_executor&) = delete;
+	live_executor(live_executor&&) = delete;
+	live_executor& operator=(const live_executor&) = delete;
+	live_executor& operator=(live_executor&&) = delete;
+
+	~live_executor() override;
+
+	void track_user_allocation(allocation_id aid, void* ptr) override;
+	void track_host_object_instance(host_object_id hoid, std::unique_ptr<host_object_instance> instance) override;
+	void track_reducer(reduction_id rid, std::unique_ptr<reducer> reducer) override;
+
+	void submit(std::vector<const instruction*> instructions, std::vector<outbound_pilot> pilots) override;
+
+  private:
+	friend struct executor_testspy;
+
+	std::unique_ptr<communicator> m_root_comm; // created and destroyed outside of executor thread
+	double_buffered_queue<live_executor_detail::submission> m_submission_queue;
+	std::thread m_thread;
+
+	void thread_main(std::unique_ptr<backend> backend, delegate* dlg, const policy_set& policy);
+
+	/// Default-constructs a `policy_set` - this must be a function because we can't use the implicit default constructor of `policy_set`, which has member
+	/// initializers, within its surrounding class (Clang diagnostic).
+	constexpr static policy_set default_policy_set() { return {}; }
+};
+
+} // namespace celerity::detail

--- a/include/print_utils.h
+++ b/include/print_utils.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "backend/sycl_backend.h"
 #include "grid.h"
 #include "intrusive_graph.h"
 #include "ranges.h"
 #include "types.h"
+
+#include <chrono>
 
 #include <fmt/format.h>
 
@@ -164,5 +167,45 @@ struct fmt::formatter<celerity::detail::transfer_id> {
 			out = fmt::format_to(out, "T{}.B{}", tid, bid);
 		}
 		return ctx.out();
+	}
+};
+
+template <>
+struct fmt::formatter<celerity::detail::sycl_backend_type> : fmt::formatter<std::string_view> {
+	format_context::iterator format(const celerity::detail::sycl_backend_type type, format_context& ctx) const {
+		const auto repr = [=]() -> std::string_view {
+			switch(type) {
+			case celerity::detail::sycl_backend_type::generic: return "generic";
+			case celerity::detail::sycl_backend_type::cuda: return "CUDA";
+			default: abort();
+			}
+		}();
+		return std::copy(repr.begin(), repr.end(), ctx.out());
+	}
+};
+
+namespace celerity::detail {
+
+/// Wrap a `std::chrono::duration` in this to auto-format it as seconds, milliseconds, microseconds, or nanoseconds.
+struct as_sub_second {
+	template <typename Rep, typename Period>
+	as_sub_second(const std::chrono::duration<Rep, Period>& duration) : seconds(std::chrono::duration_cast<std::chrono::duration<double>>(duration)) {}
+	std::chrono::duration<double> seconds;
+};
+
+} // namespace celerity::detail
+
+template <>
+struct fmt::formatter<celerity::detail::as_sub_second> : fmt::formatter<double> {
+	format_context::iterator format(const celerity::detail::as_sub_second ss, format_context& ctx) const {
+		std::string_view unit = " s";
+		double unit_time = ss.seconds.count();
+		if(unit_time != 0.0) {
+			if(std::abs(unit_time) < 1.0) { unit_time *= 1000.0, unit = " ms"; }
+			if(std::abs(unit_time) < 1.0) { unit_time *= 1000.0, unit = " µs"; }
+			if(std::abs(unit_time) < 1.0) { unit_time *= 1000.0, unit = " ns"; }
+		}
+		auto out = fmt::formatter<double>::format(unit_time, ctx);
+		return std::copy(unit.begin(), unit.end(), out);
 	}
 };

--- a/include/reduction.h
+++ b/include/reduction.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "types.h"
+
+#include <memory>
+#include <numeric>
+
+namespace celerity::detail {
+
+/// Type-erased runtime reduction operation. Used to prepare and complete reductions on host memory in the executor.
+class reducer {
+  public:
+	virtual ~reducer() = default;
+
+	/// Reduces `src_count` values starting at `src` and stores the result in `dest`. Operand size is implicit.
+	virtual void reduce(void* dest, const void* src, size_t src_count) const = 0;
+
+	/// Fills `count` values starting at `dest` with the reduction's identity value. `dest` is considered uninitialized, operand size is implicit.
+	virtual void fill_identity(void* dest, size_t count) const = 0;
+
+  protected:
+	reducer() = default;
+	reducer(const reducer&) = default;
+	reducer(reducer&&) = default;
+	reducer& operator=(const reducer&) = default;
+	reducer& operator=(reducer&&) = default;
+};
+
+template <typename Scalar, typename BinaryOp>
+class reducer_impl final : public reducer {
+  public:
+	reducer_impl(const BinaryOp& op, const Scalar& identity) : m_op(op), m_identity(identity) {}
+
+	void reduce(void* const dest, const void* const src, const size_t src_count) const override {
+		const auto v_dest = static_cast<Scalar*>(dest);
+		const auto v_src = static_cast<const Scalar*>(src);
+		*v_dest = std::reduce(v_src, v_src + src_count, m_identity, m_op);
+	}
+
+	void fill_identity(void* const dest, const size_t count) const override { //
+		std::uninitialized_fill_n(static_cast<Scalar*>(dest), count, m_identity);
+	}
+
+  private:
+	BinaryOp m_op;
+	Scalar m_identity;
+};
+
+template <typename Scalar, typename BinaryOp>
+std::unique_ptr<reducer> make_reducer(const BinaryOp& op, const Scalar& identity) {
+	return std::make_unique<reducer_impl<Scalar, BinaryOp>>(op, identity);
+}
+
+/// Graph-level metadata on reductions.
+struct reduction_info {
+	reduction_id rid = 0;
+	buffer_id bid = 0;
+	bool init_from_buffer = false;
+};
+
+} // namespace celerity::detail

--- a/include/system_info.h
+++ b/include/system_info.h
@@ -25,7 +25,7 @@ struct device_info {
 	/// Before accessing any memory on a device, instruction_graph_generator will prepare a corresponding allocation on its `native_memory`. Multiple
 	/// devices can share the same native memory. No attempts at reading from peer or shared memory to elide copies are currently made, but could be in the
 	/// future.
-	memory_id native_memory;
+	memory_id native_memory = -1;
 };
 
 /// Information about a single memory in the local system.

--- a/include/task.h
+++ b/include/task.h
@@ -14,6 +14,7 @@
 #include "launcher.h"
 #include "lifetime_extending_state.h"
 #include "range_mapper.h"
+#include "reduction.h"
 #include "types.h"
 
 namespace celerity {

--- a/include/types.h
+++ b/include/types.h
@@ -65,12 +65,6 @@ enum class side_effect_order { sequential };
 
 namespace celerity::detail {
 
-struct reduction_info {
-	reduction_id rid = 0;
-	buffer_id bid = 0;
-	bool init_from_buffer = false;
-};
-
 inline constexpr node_id master_node_id = 0;
 
 /// Uniquely identifies an allocation across all memories on the local node. This is the instruction-graph equivalent of a USM pointer.

--- a/include/utils.h
+++ b/include/utils.h
@@ -150,6 +150,8 @@ std::string escape_for_dot_label(std::string str);
 /// Print the buffer id as either 'B1' or 'B1 "name"' (if `name` is non-empty)
 std::string make_buffer_debug_label(const buffer_id bid, const std::string& name = "");
 
+std::string make_task_debug_label(const task_type tt, const task_id tid, const std::string& debug_name, bool title_case = false);
+
 [[noreturn]] void unreachable();
 
 enum class panic_solution {
@@ -198,6 +200,12 @@ bool contains(const Container& container, const Key& key) {
 	} else {
 		return std::find(begin(container), end(container), key) != end(container);
 	}
+}
+
+template <typename Container, typename Predicate>
+void erase_if(Container& container, const Predicate& predicate) {
+	using std::begin, std::end;
+	container.erase(std::remove_if(begin(container), end(container), predicate), end(container));
 }
 
 } // namespace celerity::detail::utils

--- a/include/workaround.h
+++ b/include/workaround.h
@@ -20,6 +20,12 @@
 #define CELERITY_WORKAROUND_HIPSYCL 0
 #endif
 
+#if defined(CELERITY_SIMSYCL)
+#define CELERITY_WORKAROUND_SIMSYCL 1
+#else
+#define CELERITY_WORKAROUND_SIMSYCL 0
+#endif
+
 #define CELERITY_WORKAROUND_VERSION_LESS_OR_EQUAL_1(major) (CELERITY_WORKAROUND_VERSION_MAJOR <= major)
 #define CELERITY_WORKAROUND_VERSION_LESS_OR_EQUAL_2(major, minor)                                                                                              \
 	(CELERITY_WORKAROUND_VERSION_MAJOR < major) || (CELERITY_WORKAROUND_VERSION_MAJOR == major && CELERITY_WORKAROUND_VERSION_MINOR <= minor)

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -1,0 +1,45 @@
+set(CUDA_OR_CUDA_TOOLKIT_FOUND FALSE)
+if(NOT CELERITY_SYCL_IMPL STREQUAL "SimSYCL")
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.17")
+    find_package(CUDAToolkit)
+    set(CUDA_OR_CUDA_TOOLKIT_FOUND ${CUDAToolkit_FOUND})
+  else()
+    find_package(CUDA)
+    set(CUDA_OR_CUDA_TOOLKIT_FOUND ${CUDA_FOUND})
+  endif()
+  # find_package(LevelZero QUIET) # TODO: Need find module?
+  # find_package(ROCM QUIET) # TODO: Need find module?
+
+  option(CELERITY_ENABLE_CUDA_BACKEND "Enable optimized code paths for CUDA backends" ${CUDA_OR_CUDA_TOOLKIT_FOUND})
+else()
+  set(CELERITY_ENABLE_CUDA_BACKEND FALSE)
+endif()
+
+if(CELERITY_ENABLE_CUDA_BACKEND AND NOT CUDA_OR_CUDA_TOOLKIT_FOUND)
+  # Run find_package again to emit error message
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.17")
+    find_package(CUDAToolkit REQUIRED)
+  else()
+    find_package(CUDA REQUIRED)
+  endif()
+endif()
+
+add_library(celerity_backends STATIC sycl_backend.cc sycl_generic_backend.cc)
+set_property(TARGET celerity_backends PROPERTY CXX_STANDARD ${CELERITY_CXX_STANDARD})
+# We link against the RT here to get all of its transitive properties (circular linking is allowed for static libraries).
+target_link_libraries(celerity_backends PRIVATE celerity_runtime)
+add_sycl_to_target(TARGET celerity_backends SOURCES)
+
+if(CELERITY_ENABLE_CUDA_BACKEND)
+  target_sources(celerity_backends PRIVATE sycl_cuda_backend.cc)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.17")
+    target_link_libraries(celerity_backends PUBLIC CUDA::cudart)
+  else()
+    target_link_libraries(celerity_backends PUBLIC ${CUDA_LIBRARIES})
+    target_include_directories(celerity_backends PUBLIC ${CUDA_INCLUDE_DIRS})
+  endif()
+  target_compile_definitions(celerity_backends PUBLIC "CELERITY_DETAIL_BACKEND_CUDA_ENABLED=1")
+  message(STATUS "CUDA backend enabled")
+else()
+  target_compile_definitions(celerity_backends PUBLIC "CELERITY_DETAIL_BACKEND_CUDA_ENABLED=0")
+endif()

--- a/src/backend/sycl_backend.cc
+++ b/src/backend/sycl_backend.cc
@@ -1,0 +1,280 @@
+#include "backend/sycl_backend.h"
+
+#include "closure_hydrator.h"
+#include "communicator.h"
+#include "dense_map.h"
+#include "log.h"
+#include "nd_memory.h"
+#include "ranges.h"
+#include "system_info.h"
+#include "thread_queue.h"
+#include "types.h"
+
+namespace celerity::detail::sycl_backend_detail {
+
+bool sycl_event::is_complete() { return m_last.get_info<sycl::info::event::command_execution_status>() == sycl::info::event_command_status::complete; }
+
+std::optional<std::chrono::nanoseconds> sycl_event::get_native_execution_time() {
+	if(!m_first.has_value()) return std::nullopt; // avoid the cost of throwing + catching a sycl exception by when profiling is disabled
+	return std::chrono::nanoseconds(m_last.get_profiling_info<sycl::info::event_profiling::command_end>() //
+	                                - m_first->get_profiling_info<sycl::info::event_profiling::command_start>());
+}
+
+void flush(sycl::queue& queue) {
+#if CELERITY_WORKAROUND(HIPSYCL)
+	// hipSYCL does not guarantee that command groups are actually scheduled until an explicit await operation, which we cannot insert without
+	// blocking the executor loop (see https://github.com/illuhad/hipSYCL/issues/599). Instead, we explicitly flush the queue to be able to continue
+	// using our polling-based approach.
+	queue.get_context().AdaptiveCpp_runtime()->dag().flush_async();
+#else
+	(void)queue;
+#endif
+}
+
+// LCOV_EXCL_START
+void report_errors(const sycl::exception_list& errors) {
+	if(errors.size() == 0) return;
+
+	std::vector<std::string> what;
+	for(const auto& e : errors) {
+		try {
+			std::rethrow_exception(e);
+		} catch(sycl::exception& e) { //
+			what.push_back(e.what());
+		} catch(std::exception& e) { //
+			what.push_back(e.what());
+		} catch(...) { //
+			what.push_back("unknown exception");
+		}
+	}
+
+	utils::panic("asynchronous SYCL error(s): {}", fmt::join(what, "; "));
+}
+// LCOV_EXCL_STOP
+
+} // namespace celerity::detail::sycl_backend_detail
+
+namespace celerity::detail {
+
+struct sycl_backend::impl {
+	struct device_state {
+		sycl::device sycl_device;
+		sycl::context sycl_context;
+		std::vector<sycl::queue> queues;
+
+		device_state() = default;
+		explicit device_state(const sycl::device& dev) : sycl_device(dev), sycl_context(sycl_device) {}
+	};
+
+	struct host_state {
+		sycl::context sycl_context;
+		thread_queue alloc_queue;
+		std::vector<thread_queue> queues; // TODO naming vs alloc_queue?
+
+		// pass devices to ensure the sycl_context receives the correct platform
+		explicit host_state(const std::vector<sycl::device>& all_devices, bool enable_profiling)
+		    // DPC++ requires exactly one CUDA device here, but for allocation the sycl_context mostly means "platform".
+		    // - TODO assert that all devices belong to the same platform + backend here
+		    // - TODO test Celerity on a (SimSYCL) system without GPUs
+		    : sycl_context(all_devices.at(0)), //
+		      alloc_queue("cy-alloc", enable_profiling) {}
+	};
+
+	system_info system;
+	dense_map<device_id, device_state> devices; // thread-safe for read access (not resized after construction)
+	host_state host;
+	bool enable_profiling;
+
+	impl(const std::vector<sycl::device>& devices, const bool enable_profiling)
+	    : devices(devices.begin(), devices.end()), host(devices, enable_profiling), enable_profiling(enable_profiling) //
+	{
+		// For now, we assume distinct memories per device. TODO some targets, (OpenMP emulated devices), might deviate from that.
+		system.devices.resize(devices.size());
+		system.memories.resize(2 + devices.size()); //  user + host + device memories
+		system.memories[user_memory_id].copy_peers.set(user_memory_id);
+		system.memories[host_memory_id].copy_peers.set(host_memory_id);
+		system.memories[host_memory_id].copy_peers.set(user_memory_id);
+		system.memories[user_memory_id].copy_peers.set(host_memory_id);
+		for(device_id did = 0; did < devices.size(); ++did) {
+			const memory_id mid = first_device_memory_id + did;
+			system.devices[did].native_memory = mid;
+			system.memories[mid].copy_peers.set(mid);
+			system.memories[mid].copy_peers.set(host_memory_id);
+			system.memories[host_memory_id].copy_peers.set(mid);
+			// device-to-device copy capabilities are added in cuda_backend constructor
+		}
+	}
+
+	template <typename F>
+	async_event submit_alloc(F&& f) {
+#if CELERITY_WORKAROUND(SIMSYCL)
+		// SimSYCL is not thread safe => skip alloc_queue and complete allocations in executor thread.
+		if constexpr(std::is_void_v<std::invoke_result_t<F>>) {
+			return f(), make_complete_event();
+		} else {
+			return make_complete_event(f());
+		}
+#else
+		return host.alloc_queue.submit(std::forward<F>(f));
+#endif
+	}
+
+	thread_queue& get_host_queue(const size_t lane) {
+		assert(lane <= host.queues.size());
+		if(lane == host.queues.size()) { host.queues.emplace_back(fmt::format("cy-host-{}", lane), enable_profiling); }
+		return host.queues[lane];
+	}
+
+	sycl::queue& get_device_queue(const device_id did, const size_t lane) {
+		auto& device = devices[did];
+		assert(lane <= device.queues.size());
+		if(lane == device.queues.size()) {
+			const auto properties = enable_profiling ? sycl::property_list{sycl::property::queue::enable_profiling{}, sycl::property::queue::in_order{}}
+			                                         : sycl::property_list{sycl::property::queue::in_order{}};
+			device.queues.emplace_back(device.sycl_device, sycl::async_handler(sycl_backend_detail::report_errors), properties);
+		}
+		return device.queues[lane];
+	}
+};
+
+sycl_backend::sycl_backend(const std::vector<sycl::device>& devices, const bool enable_profiling) : m_impl(new impl(devices, enable_profiling)) {}
+
+sycl_backend::~sycl_backend() = default;
+
+const system_info& sycl_backend::get_system_info() const { return m_impl->system; }
+
+void* sycl_backend::debug_alloc(const size_t size) {
+	const auto ptr = sycl::malloc_host(size, m_impl->host.sycl_context);
+#if CELERITY_DETAIL_ENABLE_DEBUG
+	memset(ptr, static_cast<int>(sycl_backend_detail::uninitialized_memory_pattern), size);
+#endif
+	return ptr;
+}
+
+void sycl_backend::debug_free(void* const ptr) { sycl::free(ptr, m_impl->host.sycl_context); }
+
+async_event sycl_backend::enqueue_host_alloc(const size_t size, const size_t alignment) {
+	return m_impl->submit_alloc([this, size, alignment] {
+		const auto ptr = sycl::aligned_alloc_host(alignment, size, m_impl->host.sycl_context);
+#if CELERITY_DETAIL_ENABLE_DEBUG
+		memset(ptr, static_cast<int>(sycl_backend_detail::uninitialized_memory_pattern), size);
+#endif
+		return ptr;
+	});
+}
+
+async_event sycl_backend::enqueue_device_alloc(const device_id device, const size_t size, const size_t alignment) {
+	return m_impl->submit_alloc([this, device, size, alignment] {
+		auto& d = m_impl->devices[device];
+		const auto ptr = sycl::aligned_alloc_device(alignment, size, d.sycl_device, d.sycl_context);
+#if CELERITY_DETAIL_ENABLE_DEBUG
+		sycl::queue(d.sycl_context, d.sycl_device, sycl::async_handler(sycl_backend_detail::report_errors), sycl::property::queue::in_order{})
+		    .fill(ptr, sycl_backend_detail::uninitialized_memory_pattern, size)
+		    .wait();
+#endif
+		return ptr;
+	});
+}
+
+async_event sycl_backend::enqueue_host_free(void* const ptr) {
+	return m_impl->submit_alloc([this, ptr] { sycl::free(ptr, m_impl->host.sycl_context); });
+}
+
+async_event sycl_backend::enqueue_device_free(const device_id device, void* const ptr) {
+	return m_impl->submit_alloc([this, device, ptr] { sycl::free(ptr, m_impl->devices[device].sycl_context); });
+}
+
+async_event sycl_backend::enqueue_host_task(size_t host_lane, const host_task_launcher& launcher, std::vector<closure_hydrator::accessor_info> accessor_infos,
+    const box<3>& execution_range, const communicator* collective_comm) //
+{
+	auto& hydrator = closure_hydrator::get_instance();
+	hydrator.arm(target::host_task, std::move(accessor_infos));
+	auto launch_hydrated = hydrator.hydrate<target::host_task>(launcher);
+	return m_impl->get_host_queue(host_lane).submit([=, launch_hydrated = std::move(launch_hydrated)] { launch_hydrated(execution_range, collective_comm); });
+}
+
+async_event sycl_backend::enqueue_device_kernel(const device_id device, const size_t lane, const device_kernel_launcher& launch,
+    std::vector<closure_hydrator::accessor_info> accessor_infos, const box<3>& execution_range, const std::vector<void*>& reduction_ptrs) //
+{
+	auto& queue = m_impl->get_device_queue(device, lane);
+	auto event = queue.submit([&](sycl::handler& sycl_cgh) {
+		auto& hydrator = closure_hydrator::get_instance();
+		hydrator.arm(target::device, std::move(accessor_infos));
+		const auto launch_hydrated = hydrator.hydrate<target::device>(sycl_cgh, launch);
+		launch_hydrated(sycl_cgh, execution_range, reduction_ptrs);
+	});
+	sycl_backend_detail::flush(queue);
+	return make_async_event<sycl_backend_detail::sycl_event>(std::move(event), m_impl->enable_profiling);
+}
+
+async_event sycl_backend::enqueue_host_copy(size_t host_lane, const void* const source_base, void* const dest_base, const box<3>& source_box,
+    const box<3>& dest_box, const region<3>& copy_region, const size_t elem_size) //
+{
+	return m_impl->get_host_queue(host_lane).submit([=] { nd_copy_host(source_base, dest_base, source_box, dest_box, copy_region, elem_size); });
+}
+
+sycl::queue& sycl_backend::get_device_queue(device_id device, size_t lane) { return m_impl->get_device_queue(device, lane); }
+
+system_info& sycl_backend::get_system_info() { return m_impl->system; }
+
+bool sycl_backend::is_profiling_enabled() const { return m_impl->enable_profiling; }
+
+std::vector<sycl_backend_type> sycl_backend_enumerator::compatible_backends(const sycl::device& device) const {
+	std::vector<backend_type> backends{backend_type::generic};
+#if CELERITY_WORKAROUND(HIPSYCL) && defined(SYCL_EXT_HIPSYCL_BACKEND_CUDA)
+	if(device.get_backend() == sycl::backend::cuda) { backends.push_back(sycl_backend_type::cuda); }
+#elif CELERITY_WORKAROUND(DPCPP)
+	if(device.get_backend() == sycl::backend::ext_oneapi_cuda) { backends.push_back(sycl_backend_type::cuda); }
+#endif
+	assert(std::is_sorted(backends.begin(), backends.end()));
+	return backends;
+}
+
+std::vector<sycl_backend_type> sycl_backend_enumerator::available_backends() const {
+	std::vector<backend_type> backends{backend_type::generic};
+#if CELERITY_DETAIL_BACKEND_CUDA_ENABLED
+	backends.push_back(sycl_backend_type::cuda);
+#endif
+	assert(std::is_sorted(backends.begin(), backends.end()));
+	return backends;
+}
+
+bool sycl_backend_enumerator::is_specialized(backend_type type) const {
+	switch(type) {
+	case backend_type::generic: return false;
+	case backend_type::cuda: return true;
+	default: utils::unreachable(); // LCOV_EXCL_LINE
+	}
+}
+
+int sycl_backend_enumerator::get_priority(backend_type type) const {
+	switch(type) {
+	case backend_type::generic: return 0;
+	case backend_type::cuda: return 1;
+	default: utils::unreachable(); // LCOV_EXCL_LINE
+	}
+}
+
+} // namespace celerity::detail
+
+namespace celerity::detail {
+
+std::unique_ptr<backend> make_sycl_backend(const sycl_backend_type type, const std::vector<sycl::device>& devices, const bool enable_profiling) {
+	assert(std::all_of(
+	    devices.begin(), devices.end(), [=](const sycl::device& d) { return utils::contains(sycl_backend_enumerator{}.compatible_backends(d), type); }));
+
+	switch(type) {
+	case sycl_backend_type::generic: //
+		return std::make_unique<sycl_generic_backend>(devices, enable_profiling);
+
+	case sycl_backend_type::cuda:
+#if CELERITY_DETAIL_BACKEND_CUDA_ENABLED
+		return std::make_unique<sycl_cuda_backend>(devices, enable_profiling);
+#else
+		utils::panic("CUDA backend has not been compiled");
+#endif
+	}
+	utils::unreachable(); // LCOV_EXCL_LINE
+}
+
+} // namespace celerity::detail

--- a/src/backend/sycl_cuda_backend.cc
+++ b/src/backend/sycl_cuda_backend.cc
@@ -1,0 +1,212 @@
+#include "backend/sycl_backend.h"
+
+#include <cuda_runtime.h>
+
+#include "log.h"
+#include "nd_memory.h"
+#include "ranges.h"
+#include "system_info.h"
+#include "utils.h"
+#include "workaround.h"
+
+
+#define CELERITY_STRINGIFY2(f) #f
+#define CELERITY_STRINGIFY(f) CELERITY_STRINGIFY2(f)
+#define CELERITY_CUDA_CHECK(f, ...)                                                                                                                            \
+	if(const auto cuda_check_result = (f)(__VA_ARGS__); cuda_check_result != cudaSuccess) {                                                                    \
+		utils::panic(CELERITY_STRINGIFY(f) ": {}", cudaGetErrorString(cuda_check_result));                                                                     \
+	}
+
+namespace celerity::detail::cuda_backend_detail {
+
+void nd_copy_device_async(const cudaStream_t stream, const void* const source_base, void* const dest_base, const range<3>& source_range,
+    const range<3>& dest_range, const id<3>& offset_in_source, const id<3>& offset_in_dest, const range<3>& copy_range, const size_t elem_size) //
+{
+	const auto layout = layout_nd_copy(source_range, dest_range, offset_in_source, offset_in_dest, copy_range, elem_size);
+	if(layout.contiguous_size == 0) return;
+
+	if(layout.num_complex_strides == 0) {
+		CELERITY_CUDA_CHECK(cudaMemcpyAsync, static_cast<std::byte*>(dest_base) + layout.offset_in_dest,
+		    static_cast<const std::byte*>(source_base) + layout.offset_in_source, layout.contiguous_size, cudaMemcpyDefault, stream);
+	} else if(layout.num_complex_strides == 1) {
+		CELERITY_CUDA_CHECK(cudaMemcpy2DAsync, static_cast<std::byte*>(dest_base) + layout.offset_in_dest, layout.strides[0].dest_stride,
+		    static_cast<const std::byte*>(source_base) + layout.offset_in_source, layout.strides[0].source_stride, layout.contiguous_size,
+		    layout.strides[0].count, cudaMemcpyDefault, stream);
+	} else {
+		assert(layout.num_complex_strides == 2);
+		// Arriving in the 3D case means no dimensionality reduction was possible, and cudaMemcpy3D is more closely aligned to the parameters to
+		// nd_copy_device_async than to nd_copy_layout, so we don't compute cudaMemcpy3DParms from `layout`.
+		cudaMemcpy3DParms parms = {};
+		parms.srcPos = make_cudaPos(offset_in_source[2] * elem_size, offset_in_source[1], offset_in_source[0]);
+		parms.srcPtr = make_cudaPitchedPtr(
+		    const_cast<void*>(source_base), source_range[2] * elem_size, source_range[2], source_range[1]); // NOLINT cppcoreguidelines-pro-type-const-cast
+		parms.dstPos = make_cudaPos(offset_in_dest[2] * elem_size, offset_in_dest[1], offset_in_dest[0]);
+		parms.dstPtr = make_cudaPitchedPtr(dest_base, dest_range[2] * elem_size, dest_range[2], dest_range[1]);
+		parms.extent = {copy_range[2] * elem_size, copy_range[1], copy_range[0]};
+		parms.kind = cudaMemcpyDefault;
+		CELERITY_CUDA_CHECK(cudaMemcpy3DAsync, &parms, stream);
+	}
+}
+
+void nd_copy_device_async(cudaStream_t stream, const void* const source_base, void* const dest_base, const box<3>& source_box, const box<3>& dest_box,
+    const box<3>& copy_box, const size_t elem_size) //
+{
+	assert(source_box.covers(copy_box));
+	assert(dest_box.covers(copy_box));
+	nd_copy_device_async(stream, source_base, dest_base, source_box.get_range(), dest_box.get_range(), copy_box.get_offset() - source_box.get_offset(),
+	    copy_box.get_offset() - dest_box.get_offset(), copy_box.get_range(), elem_size);
+}
+
+void nd_copy_device_async(cudaStream_t stream, const void* const source_base, void* const dest_base, const box<3>& source_box, const box<3>& dest_box,
+    const region<3>& copy_region, const size_t elem_size) //
+{
+	for(const auto& copy_box : copy_region.get_boxes()) {
+		nd_copy_device_async(stream, source_base, dest_base, source_box, dest_box, copy_box, elem_size);
+	}
+}
+
+// DPC++ dos not have a custom-enqueue primitive, but implements get_native(queue), so we call cudaMemcpy* directly from the executor thread and record native
+// CUDA events instead of wrapped SYCL events. Doing this has several downsides:
+//   - DPC++'s queue does not learn about our submission, and so we do not get back a SYCL event and querying for the last submission will return nonsense.
+//   - There are no real thread-safety guarantees. DPC++ currently does not submit kernels from background threads, but if it ever starts doing so, this will
+//     break more-or-less silently.
+// There is an open GitHub issue on the matter: https://github.com/intel/llvm/issues/13706
+#if defined(CELERITY_DPCPP)
+
+struct cuda_native_event_deleter {
+	void operator()(const cudaEvent_t evt) const { CELERITY_CUDA_CHECK(cudaEventDestroy, evt); }
+};
+
+using unique_cuda_native_event = std::unique_ptr<std::remove_pointer_t<cudaEvent_t>, cuda_native_event_deleter>;
+
+unique_cuda_native_event record_native_event(const cudaStream_t stream, bool enable_profiling) {
+	cudaEvent_t event;
+	CELERITY_CUDA_CHECK(cudaEventCreateWithFlags, &event, enable_profiling ? cudaEventDefault : cudaEventDisableTiming);
+	CELERITY_CUDA_CHECK(cudaEventRecord, event, stream);
+	return unique_cuda_native_event(event);
+}
+
+class cuda_event final : public async_event_impl {
+  public:
+	cuda_event(unique_cuda_native_event after) : m_after(std::move(after)) {}
+	cuda_event(unique_cuda_native_event before, unique_cuda_native_event after) : m_before(std::move(before)), m_after(std::move(after)) {}
+
+	bool is_complete() override {
+		switch(const auto result = cudaEventQuery(m_after.get())) {
+		case cudaSuccess: return true;
+		case cudaErrorNotReady: return false;
+		default: utils::panic("cudaEventQuery: {}", cudaGetErrorString(result));
+		}
+	}
+
+	std::optional<std::chrono::nanoseconds> get_native_execution_time() override {
+		assert(is_complete());
+		if(m_before == nullptr) return std::nullopt;
+		float ms = NAN;
+		CELERITY_CUDA_CHECK(cudaEventElapsedTime, &ms, m_before.get(), m_after.get());
+		return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<float, std::milli>(ms));
+	}
+
+  private:
+	unique_cuda_native_event m_before; // not null iff profiling is enabled
+	unique_cuda_native_event m_after;
+};
+
+#endif // defined(CELERITY_DPCPP)
+
+bool can_enable_peer_access(const int id_device, const int id_peer) {
+	// RTX 30xx and 40xx GPUs do not support peer access, but Nvidia Driver < 550 incorrectly reports that it does, causing kernel panics when enabling it
+	cudaDeviceProp props{};
+	CELERITY_CUDA_CHECK(cudaGetDeviceProperties, &props, id_device);
+	std::string_view device_name(props.name);
+	if(device_name.find("RTX 30") != std::string::npos || device_name.find("RTX 40") != std::string::npos) {
+		CELERITY_DEBUG("Overriding CUDA reporting of peer access capabilities for \"{}\"", device_name);
+		return false;
+	}
+
+	int can_access = -1;
+	CELERITY_CUDA_CHECK(cudaDeviceCanAccessPeer, &can_access, id_device, id_peer);
+	assert(can_access == 0 || can_access == 1);
+	return can_access != 0;
+}
+
+void enable_peer_access(const int id_device, const int id_peer) {
+	int id_before = -1;
+	CELERITY_CUDA_CHECK(cudaGetDevice, &id_before);
+	CELERITY_CUDA_CHECK(cudaSetDevice, id_device);
+	const auto enabled = cudaDeviceEnablePeerAccess(id_peer, 0);
+	if(enabled != cudaSuccess && enabled != cudaErrorPeerAccessAlreadyEnabled) { utils::panic("cudaDeviceEnablePeerAccess: {}", cudaGetErrorString(enabled)); }
+	CELERITY_CUDA_CHECK(cudaSetDevice, id_before);
+}
+
+} // namespace celerity::detail::cuda_backend_detail
+
+namespace celerity::detail::sycl_backend_detail {
+
+async_event nd_copy_device_cuda(sycl::queue& queue, const void* const source_base, void* const dest_base, const box<3>& source_box, const box<3>& dest_box,
+    const region<3>& copy_region, const size_t elem_size, bool enable_profiling) //
+{
+#if defined(__HIPSYCL__)
+	// hipSYCL provides first-class custom backend op submission without a host round-trip like sycl::queue::host_task would require.
+	auto event = queue.AdaptiveCpp_enqueue_custom_operation([=](sycl::interop_handle handle) {
+		const auto stream = handle.get_native_queue<sycl::backend::cuda>();
+		cuda_backend_detail::nd_copy_device_async(stream, source_base, dest_base, source_box, dest_box, copy_region, elem_size);
+	});
+	sycl_backend_detail::flush(queue);
+	return make_async_event<sycl_event>(std::move(event), enable_profiling);
+#elif defined(CELERITY_DPCPP)
+	// With DPC++, we must submit from the executor thread - see the comment on cuda_native_event above.
+	const auto stream = sycl::get_native<sycl::backend::ext_oneapi_cuda>(queue);
+	auto before = enable_profiling ? cuda_backend_detail::record_native_event(stream, enable_profiling) : nullptr;
+	cuda_backend_detail::nd_copy_device_async(stream, source_base, dest_base, source_box, dest_box, copy_region, elem_size);
+	auto after = cuda_backend_detail::record_native_event(stream, enable_profiling);
+	return make_async_event<cuda_backend_detail::cuda_event>(std::move(before), std::move(after));
+#else
+#error Unavailable for this SYCL implementation
+#endif
+}
+
+#if defined(CELERITY_DPCPP)
+constexpr sycl::backend sycl_cuda_backend = sycl::backend::ext_oneapi_cuda;
+#else
+constexpr sycl::backend sycl_cuda_backend = sycl::backend::cuda;
+#endif
+
+} // namespace celerity::detail::sycl_backend_detail
+
+namespace celerity::detail {
+
+sycl_cuda_backend::sycl_cuda_backend(const std::vector<sycl::device>& devices, const bool enable_profiling) : sycl_backend(devices, enable_profiling) {
+	// CUDA permits cudaMemcpy between devices that are not peer-enabled, but will implicitly stage the copy through host memory, which wreaks havoc on stream
+	// parallelism (see https://forums.developer.nvidia.com/t/queueing-device-to-device-peer-memcpy-stalls-concurrent-copy-operations/295894). We therefore
+	// choose not to consider such GPUs to be copy-peers. There is potential to improve performance by partially overlapping the corresponding D2H and H2D
+	// copies, but this must be expressible in the IDAG (TODO).
+	for(device_id i = 0; i < devices.size(); ++i) {
+		for(device_id j = i + 1; j < devices.size(); ++j) {
+			const int id_i = sycl::get_native<sycl_backend_detail::sycl_cuda_backend>(devices[i]);
+			const int id_j = sycl::get_native<sycl_backend_detail::sycl_cuda_backend>(devices[j]);
+
+			// system_info mandates that copy_peers is reflexive
+			if(cuda_backend_detail::can_enable_peer_access(id_i, id_j) && cuda_backend_detail::can_enable_peer_access(id_j, id_i)) {
+				cuda_backend_detail::enable_peer_access(id_i, id_j);
+				cuda_backend_detail::enable_peer_access(id_j, id_i);
+
+				const memory_id mid_i = first_device_memory_id + i;
+				const memory_id mid_j = first_device_memory_id + j;
+				get_system_info().memories[mid_i].copy_peers.set(mid_j);
+				get_system_info().memories[mid_j].copy_peers.set(mid_i);
+			} else {
+				CELERITY_DEBUG("CUDA does not provide peer access between D{} and D{}, device-to-device copies will be staged in host memory", i, j);
+			}
+		}
+	}
+}
+
+async_event sycl_cuda_backend::enqueue_device_copy(device_id device, size_t device_lane, const void* const source_base, void* const dest_base,
+    const box<3>& source_box, const box<3>& dest_box, const region<3>& copy_region, const size_t elem_size) //
+{
+	return sycl_backend_detail::nd_copy_device_cuda(
+	    get_device_queue(device, device_lane), source_base, dest_base, source_box, dest_box, copy_region, elem_size, is_profiling_enabled());
+}
+
+} // namespace celerity::detail

--- a/src/backend/sycl_generic_backend.cc
+++ b/src/backend/sycl_generic_backend.cc
@@ -1,0 +1,46 @@
+#include "backend/sycl_backend.h"
+
+#include "log.h"
+#include "nd_memory.h"
+#include "ranges.h"
+#include "types.h"
+
+namespace celerity::detail::sycl_backend_detail {
+
+async_event nd_copy_device_generic(sycl::queue& queue, const void* const source_base, void* const dest_base, const box<3>& source_box, const box<3>& dest_box,
+    const region<3>& copy_region, const size_t elem_size, bool enable_profiling) //
+{
+	// We remember the first and last submission event to report completion time spanning the entire region copy
+	std::optional<sycl::event> first;
+	sycl::event last;
+	for(const auto& copy_box : copy_region.get_boxes()) {
+		assert(source_box.covers(copy_box));
+		assert(dest_box.covers(copy_box));
+		const auto layout = layout_nd_copy(source_box.get_range(), dest_box.get_range(), copy_box.get_offset() - source_box.get_offset(),
+		    copy_box.get_offset() - dest_box.get_offset(), copy_box.get_range(), elem_size);
+		for_each_contiguous_chunk(layout, [&](const size_t chunk_offset_in_source, const size_t chunk_offset_in_dest, const size_t chunk_size) {
+			last = queue.memcpy(
+			    static_cast<std::byte*>(dest_base) + chunk_offset_in_dest, static_cast<const std::byte*>(source_base) + chunk_offset_in_source, chunk_size);
+			if(enable_profiling && !first.has_value()) { first = last; }
+		});
+	}
+	flush(queue);
+	return make_async_event<sycl_event>(std::move(first), std::move(last));
+}
+
+} // namespace celerity::detail::sycl_backend_detail
+
+namespace celerity::detail {
+
+sycl_generic_backend::sycl_generic_backend(const std::vector<sycl::device>& devices, bool enable_profiling) : sycl_backend(devices, enable_profiling) {
+	if(devices.size() > 1) { CELERITY_DEBUG("Generic backend does not support peer memory access, device-to-device copies will be staged in host memory"); }
+}
+
+async_event sycl_generic_backend::enqueue_device_copy(const device_id device, const size_t device_lane, const void* const source_base, void* const dest_base,
+    const box<3>& source_box, const box<3>& dest_box, const region<3>& copy_region, const size_t elem_size) //
+{
+	auto& queue = get_device_queue(device, device_lane);
+	return sycl_backend_detail::nd_copy_device_generic(queue, source_base, dest_base, source_box, dest_box, copy_region, elem_size, is_profiling_enabled());
+}
+
+} // namespace celerity::detail

--- a/src/dry_run_executor.cc
+++ b/src/dry_run_executor.cc
@@ -1,0 +1,83 @@
+#include "dry_run_executor.h"
+#include "host_object.h"
+#include "instruction_graph.h"
+#include "log.h"
+#include "named_threads.h"
+
+
+namespace celerity::detail {
+
+dry_run_executor::dry_run_executor(delegate* const dlg) : m_thread(&dry_run_executor::thread_main, this, dlg) {
+	set_thread_name(m_thread.native_handle(), "cy-executor");
+}
+
+dry_run_executor::~dry_run_executor() { m_thread.join(); }
+
+void dry_run_executor::track_user_allocation(const allocation_id aid, void* const ptr) {
+	(void)aid; // ignore
+	(void)ptr; // ignore (allocation is owned by user)
+}
+
+void dry_run_executor::track_host_object_instance(const host_object_id hoid, std::unique_ptr<host_object_instance> instance) {
+	m_submission_queue.push(std::pair{hoid, std::move(instance)});
+}
+
+void dry_run_executor::track_reducer(reduction_id rid, std::unique_ptr<reducer> reducer) {
+	(void)rid;     // ignore
+	(void)reducer; // destroy immediately
+}
+
+void dry_run_executor::submit(std::vector<const instruction*> instructions, std::vector<outbound_pilot> pilots) {
+	m_submission_queue.push(std::move(instructions));
+	(void)pilots; // ignore;
+}
+
+void dry_run_executor::thread_main(delegate* const dlg) {
+	// For simplicity we keep all executor state within this function.
+	std::unordered_map<host_object_id, std::unique_ptr<host_object_instance>> host_object_instances;
+	bool shutdown = false;
+
+	const auto issue = [&](const instruction* instr) {
+		matchbox::match(
+		    *instr, //
+		    [&](const destroy_host_object_instruction& dhoinstr) {
+			    assert(host_object_instances.count(dhoinstr.get_host_object_id()) != 0);
+			    host_object_instances.erase(dhoinstr.get_host_object_id());
+		    },
+		    [&](const epoch_instruction& einstr) {
+			    // task_manager doesn't expect us to actually execute the init epoch (TODO)
+			    if(dlg != nullptr && einstr.get_epoch_task_id() != 0) { dlg->epoch_reached(einstr.get_epoch_task_id()); }
+			    shutdown |= einstr.get_epoch_action() == epoch_action::shutdown;
+		    },
+		    [&](const fence_instruction& finstr) {
+			    CELERITY_WARN("Encountered a \"fence\" command while \"CELERITY_DRY_RUN_NODES\" is set. "
+			                  "The result of this operation will not match the expected output of an actual run.");
+			    finstr.get_promise()->fulfill();
+		    },
+		    [&](const horizon_instruction& hinstr) { //
+			    if(dlg != nullptr) { dlg->horizon_reached(hinstr.get_horizon_task_id()); }
+		    },
+		    [&](const auto& /* any other instr */) { /* ignore */ });
+	};
+
+	while(!shutdown) {
+		m_submission_queue.wait_while_empty();
+
+		for(auto& submission : m_submission_queue.pop_all()) {
+			matchbox::match(
+			    submission, //
+			    [&](std::vector<const instruction*>& instrs) {
+				    for(const auto instr : instrs) {
+					    issue(instr);
+				    }
+			    },
+			    [&](host_object_transfer& hot) { //
+				    host_object_instances.insert(std::move(hot));
+			    });
+		}
+	}
+
+	assert(host_object_instances.empty());
+}
+
+} // namespace celerity::detail

--- a/src/legacy_backend/backend.cc
+++ b/src/legacy_backend/backend.cc
@@ -15,7 +15,7 @@ type get_type(const sycl::device& device) {
 type get_effective_type(const sycl::device& device) {
 	[[maybe_unused]] const auto b = get_type(device);
 
-#if defined(CELERITY_DETAIL_BACKEND_CUDA_ENABLED)
+#if CELERITY_DETAIL_BACKEND_CUDA_ENABLED
 	if(b == type::cuda) return b;
 #endif
 

--- a/src/live_executor.cc
+++ b/src/live_executor.cc
@@ -1,0 +1,610 @@
+#include "live_executor.h"
+#include "backend/backend.h"
+#include "closure_hydrator.h"
+#include "communicator.h"
+#include "host_object.h"
+#include "instruction_graph.h"
+#include "named_threads.h"
+#include "out_of_order_engine.h"
+#include "receive_arbiter.h"
+#include "system_info.h"
+#include "types.h"
+#include "utils.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <matchbox.hh>
+
+namespace celerity::detail::live_executor_detail {
+
+#if CELERITY_ACCESSOR_BOUNDARY_CHECK
+struct boundary_check_info {
+	struct accessor_info {
+		detail::buffer_id buffer_id = 0;
+		std::string buffer_name;
+		box<3> accessible_box;
+	};
+
+	detail::task_type task_type;
+	detail::task_id task_id;
+	std::string task_name;
+
+	oob_bounding_box* illegal_access_bounding_boxes = nullptr;
+	std::vector<accessor_info> accessors;
+
+	boundary_check_info(detail::task_type tt, detail::task_id tid, const std::string& task_name) : task_type(tt), task_id(tid), task_name(task_name) {}
+};
+#endif
+
+struct async_instruction_state {
+	const instruction* instr = nullptr;
+	async_event event;
+	CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(std::unique_ptr<boundary_check_info> oob_info;) // unique_ptr: oob_info is optional and rather large
+};
+
+struct executor_impl {
+	const std::unique_ptr<detail::backend> backend;
+	communicator* const root_communicator;
+	double_buffered_queue<submission>* const submission_queue;
+	live_executor::delegate* const delegate;
+	const live_executor::policy_set policy;
+
+	receive_arbiter recv_arbiter{*root_communicator};
+	out_of_order_engine engine{backend->get_system_info()};
+
+	bool expecting_more_submissions = true; ///< shutdown epoch has not been executed yet
+	std::vector<async_instruction_state> in_flight_async_instructions;
+	std::unordered_map<allocation_id, void*> allocations{{null_allocation_id, nullptr}}; ///< obtained from alloc_instruction or track_user_allocation
+	std::unordered_map<host_object_id, std::unique_ptr<host_object_instance>> host_object_instances; ///< passed in through track_host_object_instance
+	std::unordered_map<collective_group_id, std::unique_ptr<communicator>> cloned_communicators;     ///< transitive clones of root_communicator
+	std::unordered_map<reduction_id, std::unique_ptr<reducer>> reducers; ///< passed in through track_reducer, erased on epochs / horizons
+
+	std::optional<std::chrono::steady_clock::time_point> last_progress_timestamp; ///< last successful call to check_progress
+	bool made_progress = false;                                                   ///< progress was made since `last_progress_timestamp`
+	bool progress_warning_emitted = false;                                        ///< no progress was made since warning was emitted
+
+	executor_impl(std::unique_ptr<detail::backend> backend, communicator* root_comm, double_buffered_queue<submission>& submission_queue,
+	    live_executor::delegate* dlg, const live_executor::policy_set& policy);
+
+	void run();
+	void poll_in_flight_async_instructions();
+	void poll_submission_queue();
+	void try_issue_one_instruction();
+	void retire_async_instruction(async_instruction_state& async);
+	void check_progress();
+
+	// Instruction types that complete synchronously within the executor.
+	void issue(const clone_collective_group_instruction& ccginstr);
+	void issue(const split_receive_instruction& srinstr);
+	void issue(const fill_identity_instruction& fiinstr);
+	void issue(const reduce_instruction& rinstr);
+	void issue(const fence_instruction& finstr);
+	void issue(const destroy_host_object_instruction& dhoinstr);
+	void issue(const horizon_instruction& hinstr);
+	void issue(const epoch_instruction& einstr);
+
+	template <typename Instr>
+	auto dispatch(const Instr& instr, const out_of_order_engine::assignment& assignment)
+	    // SFINAE: there is a (synchronous) `issue` overload above for the concrete Instr type
+	    -> decltype(issue(instr));
+
+	// Instruction types that complete asynchronously via async_event, outside the executor.
+	void issue_async(const alloc_instruction& ainstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+	void issue_async(const free_instruction& finstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+	void issue_async(const copy_instruction& cinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+	void issue_async(const device_kernel_instruction& dkinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+	void issue_async(const host_task_instruction& htinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+	void issue_async(const send_instruction& sinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+	void issue_async(const receive_instruction& rinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+	void issue_async(const await_receive_instruction& arinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+	void issue_async(const gather_receive_instruction& grinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async);
+
+	template <typename Instr>
+	auto dispatch(const Instr& instr, const out_of_order_engine::assignment& assignment)
+	    // SFINAE: there is an `issue_async` overload above for the concrete Instr type
+	    -> decltype(issue_async(instr, assignment, std::declval<async_instruction_state&>()));
+
+	std::vector<closure_hydrator::accessor_info> make_accessor_infos(const buffer_access_allocation_map& amap) const;
+
+#if CELERITY_ACCESSOR_BOUNDARY_CHECK
+	std::unique_ptr<boundary_check_info> attach_boundary_check_info(std::vector<closure_hydrator::accessor_info>& accessor_infos,
+	    const buffer_access_allocation_map& amap, task_type tt, task_id tid, const std::string& task_name) const;
+#endif
+
+	void collect(const instruction_garbage& garbage);
+};
+
+executor_impl::executor_impl(std::unique_ptr<detail::backend> backend, communicator* const root_comm, double_buffered_queue<submission>& submission_queue,
+    live_executor::delegate* const dlg, const live_executor::policy_set& policy)
+    : backend(std::move(backend)), root_communicator(root_comm), submission_queue(&submission_queue), delegate(dlg), policy(policy) {}
+
+void executor_impl::run() {
+	closure_hydrator::make_available();
+
+	for(;;) {
+		if(engine.is_idle()) {
+			if(!expecting_more_submissions) break; // shutdown complete
+			submission_queue->wait_while_empty();  // we are stalled on the scheduler, suspend thread
+			last_progress_timestamp.reset();       // do not treat suspension as being stuck
+		}
+
+		recv_arbiter.poll_communicator();
+		poll_in_flight_async_instructions();
+		poll_submission_queue();
+		try_issue_one_instruction(); // potentially expensive, so only issue one per loop to continue checking for async completion in between
+		check_progress();
+	}
+
+	assert(in_flight_async_instructions.empty());
+	// check that for each alloc_instruction, we executed a corresponding free_instruction
+	assert(std::all_of(allocations.begin(), allocations.end(),
+	    [](const std::pair<allocation_id, void*>& p) { return p.first == null_allocation_id || p.first.get_memory_id() == user_memory_id; }));
+	// check that for each track_host_object_instance, we executed a destroy_host_object_instruction
+	assert(host_object_instances.empty());
+
+	closure_hydrator::teardown();
+}
+
+void executor_impl::poll_in_flight_async_instructions() {
+	utils::erase_if(in_flight_async_instructions, [&](async_instruction_state& async) {
+		if(!async.event.is_complete()) return false;
+		retire_async_instruction(async);
+		made_progress = true;
+		return true;
+	});
+}
+
+void executor_impl::poll_submission_queue() {
+	for(auto& submission : submission_queue->pop_all()) {
+		matchbox::match(
+		    submission,
+		    [&](const instruction_pilot_batch& batch) {
+			    for(const auto incoming_instr : batch.instructions) {
+				    engine.submit(incoming_instr);
+			    }
+			    for(const auto& pilot : batch.pilots) {
+				    root_communicator->send_outbound_pilot(pilot);
+			    }
+		    },
+		    [&](const user_allocation_transfer& uat) {
+			    assert(uat.aid != null_allocation_id);
+			    assert(uat.aid.get_memory_id() == user_memory_id);
+			    assert(allocations.count(uat.aid) == 0);
+			    allocations.emplace(uat.aid, uat.ptr);
+		    },
+		    [&](host_object_transfer& hot) {
+			    assert(host_object_instances.count(hot.hoid) == 0);
+			    host_object_instances.emplace(hot.hoid, std::move(hot.instance));
+		    },
+		    [&](reducer_transfer& rt) {
+			    assert(reducers.count(rt.rid) == 0);
+			    reducers.emplace(rt.rid, std::move(rt.reduction));
+		    });
+	}
+}
+
+void executor_impl::retire_async_instruction(async_instruction_state& async) {
+#if CELERITY_ACCESSOR_BOUNDARY_CHECK
+	if(async.oob_info != nullptr) {
+		const auto& oob_info = *async.oob_info;
+		for(size_t i = 0; i < oob_info.accessors.size(); ++i) {
+			if(const auto oob_box = oob_info.illegal_access_bounding_boxes[i].into_box(); !oob_box.empty()) {
+				const auto& accessor_info = oob_info.accessors[i];
+				CELERITY_ERROR("Out-of-bounds access detected in {}: accessor {} attempted to access buffer {} indicies between {} and outside the "
+				               "declared range {}.",
+				    utils::make_task_debug_label(oob_info.task_type, oob_info.task_id, oob_info.task_name), i,
+				    utils::make_buffer_debug_label(accessor_info.buffer_id, accessor_info.buffer_name), oob_box, accessor_info.accessible_box);
+			}
+		}
+		if(oob_info.illegal_access_bounding_boxes != nullptr /* i.e. there was at least one accessor */) {
+			backend->debug_free(oob_info.illegal_access_bounding_boxes);
+		}
+	}
+#endif
+
+	if(spdlog::should_log(spdlog::level::trace)) {
+		if(const auto native_time = async.event.get_native_execution_time(); native_time.has_value()) {
+			CELERITY_TRACE("[executor] retired I{} after {:.2f}", async.instr->get_id(), as_sub_second(*native_time));
+		} else {
+			CELERITY_TRACE("[executor] retired I{}", async.instr->get_id());
+		}
+	}
+
+	if(utils::isa<alloc_instruction>(async.instr)) {
+		const auto ainstr = utils::as<alloc_instruction>(async.instr);
+		const auto ptr = async.event.get_result();
+		assert(ptr != nullptr && "backend allocation returned nullptr");
+		const auto aid = ainstr->get_allocation_id();
+		CELERITY_TRACE("[executor] {} allocated as {}", aid, ptr);
+		assert(allocations.count(aid) == 0);
+		allocations.emplace(aid, ptr);
+	}
+
+	engine.complete_assigned(async.instr);
+}
+
+template <typename Instr>
+auto executor_impl::dispatch(const Instr& instr, const out_of_order_engine::assignment& assignment)
+    // SFINAE: there is a (synchronous) `issue` overload above for the concrete Instr type
+    -> decltype(issue(instr)) //
+{
+	assert(assignment.target == out_of_order_engine::target::immediate);
+	assert(!assignment.lane.has_value());
+	issue(instr); // completes immediately
+	engine.complete_assigned(&instr);
+}
+
+template <typename Instr>
+auto executor_impl::dispatch(const Instr& instr, const out_of_order_engine::assignment& assignment)
+    // SFINAE: there is an `issue_async` overload above for the concrete Instr type
+    -> decltype(issue_async(instr, assignment, std::declval<async_instruction_state&>())) //
+{
+	auto& async = in_flight_async_instructions.emplace_back();
+	async.instr = assignment.instruction;
+	issue_async(instr, assignment, async); // stores event in `async` and completes asynchronously
+}
+
+void executor_impl::try_issue_one_instruction() {
+	auto assignment = engine.assign_one();
+	if(!assignment.has_value()) return;
+
+	matchbox::match(*assignment->instruction, [&](const auto& instr) { dispatch(instr, *assignment); });
+	made_progress = true;
+}
+
+void executor_impl::check_progress() {
+	if(!policy.progress_warning_timeout.has_value()) return;
+
+	if(made_progress) {
+		last_progress_timestamp = std::chrono::steady_clock::now();
+		progress_warning_emitted = false;
+		made_progress = false;
+	} else if(last_progress_timestamp.has_value()) {
+		// being stuck either means a deadlock in the user application, or a bug in Celerity.
+		const auto elapsed_since_last_progress = std::chrono::steady_clock::now() - *last_progress_timestamp;
+		if(elapsed_since_last_progress > *policy.progress_warning_timeout && !progress_warning_emitted) {
+			std::string instr_list;
+			for(auto& in_flight : in_flight_async_instructions) {
+				if(!instr_list.empty()) instr_list += ", ";
+				fmt::format_to(std::back_inserter(instr_list), "I{}", in_flight.instr->get_id());
+			}
+			CELERITY_WARN("[executor] no progress for {:.2f}, might be stuck. Active instructions: {}", as_sub_second(elapsed_since_last_progress),
+			    in_flight_async_instructions.empty() ? "none" : instr_list);
+			progress_warning_emitted = true;
+		}
+	}
+}
+
+void executor_impl::issue(const clone_collective_group_instruction& ccginstr) {
+	const auto original_cgid = ccginstr.get_original_collective_group_id();
+	assert(original_cgid != non_collective_group_id);
+	assert(original_cgid == root_collective_group_id || cloned_communicators.count(original_cgid) != 0);
+
+	const auto new_cgid = ccginstr.get_new_collective_group_id();
+	assert(new_cgid != non_collective_group_id && new_cgid != root_collective_group_id);
+	assert(cloned_communicators.count(new_cgid) == 0);
+
+	CELERITY_TRACE("[executor] I{}: clone collective group CG{} -> CG{}", ccginstr.get_id(), original_cgid, new_cgid);
+
+	const auto original_communicator = original_cgid == root_collective_group_id ? root_communicator : cloned_communicators.at(original_cgid).get();
+	cloned_communicators.emplace(new_cgid, original_communicator->collective_clone());
+}
+
+
+void executor_impl::issue(const split_receive_instruction& srinstr) {
+	CELERITY_TRACE("[executor] I{}: split receive {} {}x{} bytes into {} ({}),", srinstr.get_id(), srinstr.get_transfer_id(), srinstr.get_requested_region(),
+	    srinstr.get_element_size(), srinstr.get_dest_allocation_id(), srinstr.get_allocated_box());
+
+	const auto allocation = allocations.at(srinstr.get_dest_allocation_id());
+	recv_arbiter.begin_split_receive(
+	    srinstr.get_transfer_id(), srinstr.get_requested_region(), allocation, srinstr.get_allocated_box(), srinstr.get_element_size());
+}
+
+void executor_impl::issue(const fill_identity_instruction& fiinstr) {
+	CELERITY_TRACE("[executor] I{}: fill identity {} x{} values for R{}", fiinstr.get_id(), fiinstr.get_allocation_id(), fiinstr.get_num_values(),
+	    fiinstr.get_reduction_id());
+
+	const auto allocation = allocations.at(fiinstr.get_allocation_id());
+	const auto& reduction = *reducers.at(fiinstr.get_reduction_id());
+	reduction.fill_identity(allocation, fiinstr.get_num_values());
+}
+
+void executor_impl::issue(const reduce_instruction& rinstr) {
+	CELERITY_TRACE("[executor] I{}: reduce {} x{} values into {} for R{}", rinstr.get_id(), rinstr.get_source_allocation_id(), rinstr.get_num_source_values(),
+	    rinstr.get_dest_allocation_id(), rinstr.get_reduction_id());
+
+	const auto gather_allocation = allocations.at(rinstr.get_source_allocation_id());
+	const auto dest_allocation = allocations.at(rinstr.get_dest_allocation_id());
+	const auto& reduction = *reducers.at(rinstr.get_reduction_id());
+	reduction.reduce(dest_allocation, gather_allocation, rinstr.get_num_source_values());
+}
+
+void executor_impl::issue(const fence_instruction& finstr) { // NOLINT(readability-convert-member-functions-to-static)
+	CELERITY_TRACE("[executor] I{}: fence", finstr.get_id());
+
+	finstr.get_promise()->fulfill();
+}
+
+void executor_impl::issue(const destroy_host_object_instruction& dhoinstr) {
+	assert(host_object_instances.count(dhoinstr.get_host_object_id()) != 0);
+	CELERITY_TRACE("[executor] I{}: destroy H{}", dhoinstr.get_id(), dhoinstr.get_host_object_id());
+
+	host_object_instances.erase(dhoinstr.get_host_object_id());
+}
+
+void executor_impl::issue(const horizon_instruction& hinstr) {
+	CELERITY_TRACE("[executor] I{}: horizon", hinstr.get_id());
+
+	if(delegate != nullptr) { delegate->horizon_reached(hinstr.get_horizon_task_id()); }
+	collect(hinstr.get_garbage());
+}
+
+void executor_impl::issue(const epoch_instruction& einstr) {
+	switch(einstr.get_epoch_action()) {
+	case epoch_action::none: //
+		CELERITY_TRACE("[executor] I{}: epoch", einstr.get_id());
+		break;
+	case epoch_action::barrier: //
+		CELERITY_TRACE("[executor] I{}: epoch (barrier)", einstr.get_id());
+		root_communicator->collective_barrier();
+		break;
+	case epoch_action::shutdown: //
+		CELERITY_TRACE("[executor] I{}: epoch (shutdown)", einstr.get_id());
+		expecting_more_submissions = false;
+		break;
+	}
+	if(delegate != nullptr && einstr.get_epoch_task_id() != 0 /* TODO task_manager doesn't expect us to actually execute the init epoch */) {
+		delegate->epoch_reached(einstr.get_epoch_task_id());
+	}
+	collect(einstr.get_garbage());
+}
+
+void executor_impl::issue_async(const alloc_instruction& ainstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async) {
+	assert(ainstr.get_allocation_id().get_memory_id() != user_memory_id);
+	assert(assignment.target == out_of_order_engine::target::alloc_queue);
+	assert(!assignment.lane.has_value());
+	assert(assignment.device.has_value() == (ainstr.get_allocation_id().get_memory_id() > host_memory_id));
+
+	CELERITY_TRACE(
+	    "[executor] I{}: alloc {}, {} % {} bytes", ainstr.get_id(), ainstr.get_allocation_id(), ainstr.get_size_bytes(), ainstr.get_alignment_bytes());
+
+	if(assignment.device.has_value()) {
+		async.event = backend->enqueue_device_alloc(*assignment.device, ainstr.get_size_bytes(), ainstr.get_alignment_bytes());
+	} else {
+		async.event = backend->enqueue_host_alloc(ainstr.get_size_bytes(), ainstr.get_alignment_bytes());
+	}
+}
+
+void executor_impl::issue_async(const free_instruction& finstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async) {
+	const auto it = allocations.find(finstr.get_allocation_id());
+	assert(it != allocations.end());
+	const auto ptr = it->second;
+	allocations.erase(it);
+
+	CELERITY_TRACE("[executor] I{}: free {}", finstr.get_id(), finstr.get_allocation_id());
+
+	if(assignment.device.has_value()) {
+		async.event = backend->enqueue_device_free(*assignment.device, ptr);
+	} else {
+		async.event = backend->enqueue_host_free(ptr);
+	}
+}
+
+void executor_impl::issue_async(const copy_instruction& cinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async) {
+	assert(assignment.target == out_of_order_engine::target::host_queue || assignment.target == out_of_order_engine::target::device_queue);
+	assert((assignment.target == out_of_order_engine::target::device_queue) == assignment.device.has_value());
+	assert(assignment.lane.has_value());
+
+	CELERITY_TRACE("[executor] I{}: copy {} ({}) -> {} ({}), {}x{} bytes", cinstr.get_id(), cinstr.get_source_allocation(), cinstr.get_source_box(),
+	    cinstr.get_dest_allocation(), cinstr.get_dest_box(), cinstr.get_copy_region(), cinstr.get_element_size());
+
+	const auto source_base = static_cast<const std::byte*>(allocations.at(cinstr.get_source_allocation().id)) + cinstr.get_source_allocation().offset_bytes;
+	const auto dest_base = static_cast<std::byte*>(allocations.at(cinstr.get_dest_allocation().id)) + cinstr.get_dest_allocation().offset_bytes;
+
+	if(assignment.device.has_value()) {
+		async.event = backend->enqueue_device_copy(*assignment.device, *assignment.lane, source_base, dest_base, cinstr.get_source_box(), cinstr.get_dest_box(),
+		    cinstr.get_copy_region(), cinstr.get_element_size());
+	} else {
+		async.event = backend->enqueue_host_copy(
+		    *assignment.lane, source_base, dest_base, cinstr.get_source_box(), cinstr.get_dest_box(), cinstr.get_copy_region(), cinstr.get_element_size());
+	}
+}
+
+std::string format_access_log(const buffer_access_allocation_map& map) {
+	std::string acc_log;
+	for(size_t i = 0; i < map.size(); ++i) {
+		auto& aa = map[i];
+		const auto accessed_box_in_allocation = box(aa.accessed_box_in_buffer.get_min() - aa.allocated_box_in_buffer.get_offset(),
+		    aa.accessed_box_in_buffer.get_max() - aa.allocated_box_in_buffer.get_offset());
+		fmt::format_to(std::back_inserter(acc_log), "{} {} {}", i == 0 ? ", accessing" : ",", aa.allocation_id, accessed_box_in_allocation);
+	}
+	return acc_log;
+}
+
+void executor_impl::issue_async(const device_kernel_instruction& dkinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async) {
+	assert(assignment.target == out_of_order_engine::target::device_queue);
+	assert(assignment.device == dkinstr.get_device_id());
+	assert(assignment.lane.has_value());
+
+	CELERITY_TRACE("[executor] I{}: launch device kernel on D{}, {}{}", dkinstr.get_id(), dkinstr.get_device_id(), dkinstr.get_execution_range(),
+	    format_access_log(dkinstr.get_access_allocations()));
+
+	auto accessor_infos = make_accessor_infos(dkinstr.get_access_allocations());
+#if CELERITY_ACCESSOR_BOUNDARY_CHECK
+	async.oob_info = attach_boundary_check_info(
+	    accessor_infos, dkinstr.get_access_allocations(), dkinstr.get_oob_task_type(), dkinstr.get_oob_task_id(), dkinstr.get_oob_task_name());
+#endif
+
+	const auto& reduction_allocs = dkinstr.get_reduction_allocations();
+	std::vector<void*> reduction_ptrs(reduction_allocs.size());
+	for(size_t i = 0; i < reduction_allocs.size(); ++i) {
+		reduction_ptrs[i] = allocations.at(reduction_allocs[i].allocation_id);
+	}
+
+	async.event = backend->enqueue_device_kernel(
+	    dkinstr.get_device_id(), *assignment.lane, dkinstr.get_launcher(), std::move(accessor_infos), dkinstr.get_execution_range(), reduction_ptrs);
+}
+
+void executor_impl::issue_async(const host_task_instruction& htinstr, const out_of_order_engine::assignment& assignment, async_instruction_state& async) {
+	assert(assignment.target == out_of_order_engine::target::host_queue);
+	assert(!assignment.device.has_value());
+	assert(assignment.lane.has_value());
+
+	CELERITY_TRACE(
+	    "[executor] I{}: launch host task, {}{}", htinstr.get_id(), htinstr.get_execution_range(), format_access_log(htinstr.get_access_allocations()));
+
+	auto accessor_infos = make_accessor_infos(htinstr.get_access_allocations());
+#if CELERITY_ACCESSOR_BOUNDARY_CHECK
+	async.oob_info = attach_boundary_check_info(
+	    accessor_infos, htinstr.get_access_allocations(), htinstr.get_oob_task_type(), htinstr.get_oob_task_id(), htinstr.get_oob_task_name());
+#endif
+
+	const auto& execution_range = htinstr.get_execution_range();
+	const auto collective_comm =
+	    htinstr.get_collective_group_id() != non_collective_group_id ? cloned_communicators.at(htinstr.get_collective_group_id()).get() : nullptr;
+
+	async.event = backend->enqueue_host_task(*assignment.lane, htinstr.get_launcher(), std::move(accessor_infos), execution_range, collective_comm);
+}
+
+void executor_impl::issue_async(
+    const send_instruction& sinstr, [[maybe_unused]] const out_of_order_engine::assignment& assignment, async_instruction_state& async) //
+{
+	assert(assignment.target == out_of_order_engine::target::immediate);
+
+	CELERITY_TRACE("[executor] I{}: send {}+{}, {}x{} bytes to N{} (MSG{})", sinstr.get_id(), sinstr.get_source_allocation_id(),
+	    sinstr.get_offset_in_source_allocation(), sinstr.get_send_range(), sinstr.get_element_size(), sinstr.get_dest_node_id(), sinstr.get_message_id());
+
+	const auto allocation_base = allocations.at(sinstr.get_source_allocation_id());
+	const communicator::stride stride{
+	    sinstr.get_source_allocation_range(),
+	    subrange<3>{sinstr.get_offset_in_source_allocation(), sinstr.get_send_range()},
+	    sinstr.get_element_size(),
+	};
+	async.event = root_communicator->send_payload(sinstr.get_dest_node_id(), sinstr.get_message_id(), allocation_base, stride);
+}
+
+void executor_impl::issue_async(
+    const receive_instruction& rinstr, [[maybe_unused]] const out_of_order_engine::assignment& assignment, async_instruction_state& async) //
+{
+	assert(assignment.target == out_of_order_engine::target::immediate);
+
+	CELERITY_TRACE("[executor] I{}: receive {} {}x{} bytes into {} ({})", rinstr.get_id(), rinstr.get_transfer_id(), rinstr.get_requested_region(),
+	    rinstr.get_element_size(), rinstr.get_dest_allocation_id(), rinstr.get_allocated_box());
+
+	const auto allocation = allocations.at(rinstr.get_dest_allocation_id());
+	async.event =
+	    recv_arbiter.receive(rinstr.get_transfer_id(), rinstr.get_requested_region(), allocation, rinstr.get_allocated_box(), rinstr.get_element_size());
+}
+
+void executor_impl::issue_async(
+    const await_receive_instruction& arinstr, [[maybe_unused]] const out_of_order_engine::assignment& assignment, async_instruction_state& async) //
+{
+	assert(assignment.target == out_of_order_engine::target::immediate);
+
+	CELERITY_TRACE("[executor] I{}: await receive {} {}", arinstr.get_id(), arinstr.get_transfer_id(), arinstr.get_received_region());
+
+	async.event = recv_arbiter.await_split_receive_subregion(arinstr.get_transfer_id(), arinstr.get_received_region());
+}
+
+void executor_impl::issue_async(
+    const gather_receive_instruction& grinstr, [[maybe_unused]] const out_of_order_engine::assignment& assignment, async_instruction_state& async) //
+{
+	assert(assignment.target == out_of_order_engine::target::immediate);
+
+	CELERITY_TRACE("[executor] I{}: gather receive {} into {}, {} bytes / node", grinstr.get_id(), grinstr.get_transfer_id(), grinstr.get_dest_allocation_id(),
+	    grinstr.get_node_chunk_size());
+
+	const auto allocation = allocations.at(grinstr.get_dest_allocation_id());
+	async.event = recv_arbiter.gather_receive(grinstr.get_transfer_id(), allocation, grinstr.get_node_chunk_size());
+}
+
+void executor_impl::collect(const instruction_garbage& garbage) {
+	for(const auto rid : garbage.reductions) {
+		assert(reducers.count(rid) != 0);
+		reducers.erase(rid);
+	}
+	for(const auto aid : garbage.user_allocations) {
+		assert(aid.get_memory_id() == user_memory_id);
+		assert(allocations.count(aid) != 0);
+		allocations.erase(aid);
+	}
+}
+
+std::vector<closure_hydrator::accessor_info> executor_impl::make_accessor_infos(const buffer_access_allocation_map& amap) const {
+	std::vector<closure_hydrator::accessor_info> accessor_infos(amap.size());
+	for(size_t i = 0; i < amap.size(); ++i) {
+		const auto ptr = allocations.at(amap[i].allocation_id);
+		accessor_infos[i] = closure_hydrator::accessor_info{ptr, amap[i].allocated_box_in_buffer, amap[i].accessed_box_in_buffer};
+	}
+	return accessor_infos;
+}
+
+#if CELERITY_ACCESSOR_BOUNDARY_CHECK
+std::unique_ptr<boundary_check_info> executor_impl::attach_boundary_check_info(std::vector<closure_hydrator::accessor_info>& accessor_infos,
+    const buffer_access_allocation_map& amap, task_type tt, task_id tid, const std::string& task_name) const //
+{
+	if(amap.empty()) return nullptr;
+
+	auto oob_info = std::make_unique<boundary_check_info>(tt, tid, task_name);
+
+	oob_info->illegal_access_bounding_boxes = static_cast<oob_bounding_box*>(backend->debug_alloc(amap.size() * sizeof(oob_bounding_box)));
+	std::uninitialized_default_construct_n(oob_info->illegal_access_bounding_boxes, amap.size());
+
+	oob_info->accessors.resize(amap.size());
+	for(size_t i = 0; i < amap.size(); ++i) {
+		oob_info->accessors[i] = boundary_check_info::accessor_info{amap[i].oob_buffer_id, amap[i].oob_buffer_name, amap[i].accessed_box_in_buffer};
+		accessor_infos[i].out_of_bounds_indices = oob_info->illegal_access_bounding_boxes + i;
+	}
+	return oob_info;
+}
+#endif // CELERITY_ACCESSOR_BOUNDARY_CHECK
+
+} // namespace celerity::detail::live_executor_detail
+
+namespace celerity::detail {
+
+live_executor::live_executor(std::unique_ptr<backend> backend, std::unique_ptr<communicator> root_comm, delegate* const dlg, const policy_set& policy)
+    : m_root_comm(std::move(root_comm)), m_thread(&live_executor::thread_main, this, std::move(backend), dlg, policy) //
+{
+	set_thread_name(m_thread.native_handle(), "cy-executor");
+}
+
+live_executor::~live_executor() {
+	m_thread.join(); // thread_main will exit only after executing shutdown epoch
+}
+
+void live_executor::track_user_allocation(const allocation_id aid, void* const ptr) {
+	m_submission_queue.push(live_executor_detail::user_allocation_transfer{aid, ptr});
+}
+
+void live_executor::track_host_object_instance(const host_object_id hoid, std::unique_ptr<host_object_instance> instance) {
+	assert(instance != nullptr);
+	m_submission_queue.push(live_executor_detail::host_object_transfer{hoid, std::move(instance)});
+}
+
+void live_executor::track_reducer(const reduction_id rid, std::unique_ptr<reducer> reducer) {
+	assert(reducer != nullptr);
+	m_submission_queue.push(live_executor_detail::reducer_transfer{rid, std::move(reducer)});
+}
+
+void live_executor::submit(std::vector<const instruction*> instructions, std::vector<outbound_pilot> pilots) {
+	m_submission_queue.push(live_executor_detail::instruction_pilot_batch{std::move(instructions), std::move(pilots)});
+}
+
+void live_executor::thread_main(std::unique_ptr<backend> backend, delegate* const dlg, const policy_set& policy) {
+	try {
+		live_executor_detail::executor_impl(std::move(backend), m_root_comm.get(), m_submission_queue, dlg, policy).run();
+	}
+	// LCOV_EXCL_START
+	catch(const std::exception& e) {
+		CELERITY_CRITICAL("[executor] {}", e.what());
+		std::abort();
+	}
+	// LCOV_EXCL_STOP
+}
+
+} // namespace celerity::detail

--- a/src/task.cc
+++ b/src/task.cc
@@ -76,23 +76,7 @@ namespace detail {
 	}
 
 	std::string print_task_debug_label(const task& tsk, bool title_case) {
-		const auto type_string = [&] {
-			switch(tsk.get_type()) {
-			case task_type::epoch: return "epoch";
-			case task_type::host_compute: return "host-compute task";
-			case task_type::device_compute: return "device kernel";
-			case task_type::collective: return "collective host task";
-			case task_type::master_node: return "master-node host task";
-			case task_type::horizon: return "horizon";
-			case task_type::fence: return "fence";
-			default: return "unknown task";
-			}
-		}();
-
-		auto label = fmt::format("{} T{}", type_string, tsk.get_id());
-		if(title_case) { label[0] = static_cast<char>(std::toupper(label[0])); }
-		if(!tsk.get_debug_name().empty()) { fmt::format_to(std::back_inserter(label), " \"{}\"", tsk.get_debug_name()); }
-		return label;
+		return utils::make_task_debug_label(tsk.get_type(), tsk.get_id(), tsk.get_debug_name(), title_case);
 	}
 
 	std::unordered_map<buffer_id, region<3>> detect_overlapping_writes(const task& tsk, const box_vector<3>& chunks) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -104,6 +104,26 @@ std::string make_buffer_debug_label(const buffer_id bid, const std::string& name
 	return !name.empty() ? fmt::format("B{} \"{}\"", bid, name) : fmt::format("B{}", bid);
 }
 
+std::string make_task_debug_label(const task_type tt, const task_id tid, const std::string& debug_name, bool title_case) {
+	const auto type_string = [tt] {
+		switch(tt) {
+		case task_type::epoch: return "epoch";
+		case task_type::host_compute: return "host-compute task";
+		case task_type::device_compute: return "device kernel";
+		case task_type::collective: return "collective host task";
+		case task_type::master_node: return "master-node host task";
+		case task_type::horizon: return "horizon";
+		case task_type::fence: return "fence";
+		default: return "unknown task";
+		}
+	}();
+
+	auto label = fmt::format("{} T{}", type_string, tid);
+	if(title_case) { label[0] = static_cast<char>(std::toupper(label[0])); }
+	if(!debug_name.empty()) { fmt::format_to(std::back_inserter(label), " \"{}\"", debug_name); }
+	return label;
+}
+
 } // namespace celerity::detail::utils
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,9 +25,11 @@ file(GLOB_RECURSE TEST_INCLUDES *.h)
 
 set(TEST_TARGETS
   accessor_tests
+  backend_tests
   buffer_manager_tests
   debug_naming_tests
   double_buffered_queue_tests
+  executor_tests
   graph_generation_tests
   graph_gen_granularity_tests
   graph_gen_reduction_tests

--- a/test/backend_tests.cc
+++ b/test/backend_tests.cc
@@ -1,0 +1,436 @@
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+#include "backend/sycl_backend.h"
+#include "nd_memory.h"
+
+#include "copy_test_utils.h"
+#include "test_utils.h"
+
+using namespace celerity;
+using namespace celerity::detail;
+
+// backend_*() functions here dispatch _host / _device member functions based on whether a device id is provided or not
+
+void* backend_alloc(backend& backend, const std::optional<device_id>& device, const size_t size, const size_t alignment) {
+	return test_utils::await(device.has_value() ? backend.enqueue_device_alloc(*device, size, alignment) : backend.enqueue_host_alloc(size, alignment));
+}
+
+void backend_free(backend& backend, const std::optional<device_id>& device, void* const ptr) {
+	test_utils::await(device.has_value() ? backend.enqueue_device_free(*device, ptr) : backend.enqueue_host_free(ptr));
+}
+
+void backend_copy(backend& backend, const std::optional<device_id>& source_device, const std::optional<device_id>& dest_device, const void* const source_base,
+    void* const dest_base, const box<3>& source_box, const box<3>& dest_box, const region<3>& copy_region, const size_t elem_size) {
+	if(source_device.has_value() || dest_device.has_value()) {
+		auto device = source_device.has_value() ? *source_device : *dest_device;
+		test_utils::await(backend.enqueue_device_copy(device, 0, source_base, dest_base, source_box, dest_box, copy_region, elem_size));
+	} else {
+		test_utils::await(backend.enqueue_host_copy(0, source_base, dest_base, source_box, dest_box, copy_region, elem_size));
+	}
+}
+
+/// For extracting hydration results
+template <target Target>
+struct mock_accessor {
+	hydration_id hid;
+	std::optional<closure_hydrator::accessor_info> info;
+
+	explicit mock_accessor(hydration_id hid) : hid(hid) {}
+	mock_accessor(const mock_accessor& other) : hid(other.hid) { copy_and_hydrate(other); }
+	mock_accessor(mock_accessor&&) = delete;
+	mock_accessor& operator=(const mock_accessor& other) { hid = other.hid, copy_and_hydrate(other); }
+	mock_accessor& operator=(mock_accessor&&) = delete;
+	~mock_accessor() = default;
+
+	void copy_and_hydrate(const mock_accessor& other) {
+		if(!info.has_value() && detail::closure_hydrator::is_available() && detail::closure_hydrator::get_instance().is_hydrating()) {
+			info = detail::closure_hydrator::get_instance().get_accessor_info<Target>(hid);
+		}
+	}
+};
+
+std::vector<sycl::device> select_devices_for_backend(sycl_backend_type type) {
+	// device discovery - we need at least one to run anything and two to run device-to-peer tests
+	const auto all_devices = sycl::device::get_devices(sycl::info::device_type::gpu);
+	std::vector<sycl::device> backend_devices;
+	std::copy_if(all_devices.begin(), all_devices.end(), std::back_inserter(backend_devices),
+	    [=](const sycl::device& device) { return utils::contains(sycl_backend_enumerator{}.compatible_backends(device), type); });
+	return backend_devices;
+}
+
+std::tuple<sycl_backend_type, std::unique_ptr<backend>, std::vector<sycl::device>> generate_backends_with_devices(bool enable_profiling = false) {
+	const auto backend_type = GENERATE(test_utils::from_vector(sycl_backend_enumerator{}.available_backends()));
+	auto sycl_devices = select_devices_for_backend(backend_type);
+	CAPTURE(backend_type, sycl_devices);
+
+	if(sycl_devices.empty()) { SKIP("No devices available for backend"); }
+	auto backend = make_sycl_backend(backend_type, sycl_devices, enable_profiling);
+	return {backend_type, std::move(backend), std::move(sycl_devices)};
+}
+
+bool accessor_info_equal(const closure_hydrator::accessor_info& lhs, const closure_hydrator::accessor_info& rhs) {
+	bool equal = lhs.ptr == rhs.ptr && lhs.allocated_box_in_buffer == rhs.allocated_box_in_buffer && lhs.accessed_box_in_buffer == rhs.accessed_box_in_buffer;
+	CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(equal &= lhs.out_of_bounds_indices == rhs.out_of_bounds_indices;)
+	return equal;
+}
+
+TEST_CASE("debug allocations are host- and device-accessible", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices();
+	CAPTURE(backend_type, sycl_devices);
+
+	const auto debug_ptr = static_cast<int*>(backend->debug_alloc(sizeof(int)));
+	*debug_ptr = 1;
+	sycl::queue(sycl_devices[0], sycl::property::queue::in_order{}).single_task([=]() { *debug_ptr += 1; }).wait();
+	CHECK(*debug_ptr == 2);
+	backend->debug_free(debug_ptr);
+}
+
+TEST_CASE("backend allocations are properly aligned", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices();
+	CAPTURE(backend_type, sycl_devices);
+
+	constexpr size_t size = 1024;
+	constexpr size_t sycl_max_alignment = 64; // See SYCL spec 4.14.2.6
+
+	const auto host_ptr = backend_alloc(*backend, std::nullopt, size, sycl_max_alignment);
+	CHECK(reinterpret_cast<uintptr_t>(host_ptr) % sycl_max_alignment == 0);
+	backend_free(*backend, std::nullopt, host_ptr);
+
+	for(device_id did = 0; did < sycl_devices.size(); ++did) {
+		CAPTURE(did);
+		const auto device_ptr = backend_alloc(*backend, did, size, sycl_max_alignment);
+		CHECK(reinterpret_cast<uintptr_t>(device_ptr) % sycl_max_alignment == 0);
+		backend_free(*backend, did, device_ptr);
+	}
+}
+
+TEST_CASE("backend allocations are pattern-filled in debug builds", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+#if defined(CELERITY_DETAIL_ENABLE_DEBUG)
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices();
+	CAPTURE(backend_type, sycl_devices);
+
+	sycl::queue sycl_queue(sycl_devices[0], sycl::property::queue::in_order{});
+
+	constexpr size_t size = 1024;
+	const std::vector<uint8_t> expected(size, sycl_backend_detail::uninitialized_memory_pattern);
+
+	for(const auto did : std::initializer_list<std::optional<device_id>>{std::nullopt, device_id(0)}) {
+		CAPTURE(did);
+		const auto ptr = backend_alloc(*backend, did, 1024, 1);
+		std::vector<uint8_t> contents(size);
+		sycl_queue.memcpy(contents.data(), ptr, size).wait();
+		CHECK(contents == expected);
+		backend_free(*backend, did, ptr);
+	}
+#else
+	SKIP("Not in a debug build");
+#endif
+}
+
+TEST_CASE("host task lambdas are hydrated and invoked with the correct parameters", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices();
+	CAPTURE(backend_type, sycl_devices);
+
+	const mock_accessor<target::host_task> acc1(hydration_id(1));
+	const mock_accessor<target::host_task> acc2(hydration_id(2));
+	const std::vector<closure_hydrator::accessor_info> accessor_infos{
+	    {reinterpret_cast<void*>(0x1337), box<3>{{1, 2, 3}, {4, 5, 6}},
+	        box<3>{{0, 1, 2}, {7, 8, 9}} CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, reinterpret_cast<oob_bounding_box*>(0x69420))},
+	    {reinterpret_cast<void*>(0x7331), box<3>{{3, 2, 1}, {6, 5, 4}},
+	        box<3>{{2, 1, 0}, {9, 8, 7}} CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, reinterpret_cast<oob_bounding_box*>(0x1230))}};
+
+	constexpr size_t lane = 0;
+	const box<3> execution_range({1, 2, 3}, {4, 5, 6});
+	const auto collective_comm = reinterpret_cast<const communicator*>(0x42000);
+
+	int value = 1;
+
+	// no accessors
+	test_utils::await(backend->enqueue_host_task(
+	    lane,
+	    [&](const box<3>& b, const communicator* c) {
+		    CHECK(b == execution_range);
+		    CHECK(c == collective_comm);
+		    value += 1;
+	    },
+	    {}, execution_range, collective_comm));
+
+	// yes accessors
+	test_utils::await(backend->enqueue_host_task(
+	    lane,
+	    [&, acc1, acc2](const box<3>& b, const communicator* c) {
+		    REQUIRE(acc1.info.has_value());
+		    REQUIRE(acc2.info.has_value());
+		    CHECK(accessor_info_equal(*acc1.info, accessor_infos[0]));
+		    CHECK(accessor_info_equal(*acc2.info, accessor_infos[1]));
+		    CHECK(b == execution_range);
+		    CHECK(c == collective_comm);
+		    value += 1;
+	    },
+	    accessor_infos, execution_range, collective_comm));
+
+	CHECK(value == 3);
+}
+
+TEST_CASE("host tasks in a single lane execute in-order", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices();
+	CAPTURE(backend_type, sycl_devices);
+
+	constexpr size_t lane = 0;
+
+	std::optional<std::thread::id> first_thread_id;
+	const auto first_fn = [&](const box<3>&, const communicator*) {
+		first_thread_id = std::this_thread::get_id();
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	};
+	const auto first = backend->enqueue_host_task(lane, first_fn, {}, box_cast<3>(box<0>()), nullptr);
+
+	std::optional<std::thread::id> second_thread_id;
+	const auto second_fn = [&](const box<3>&, const communicator* /* collective_comm */) {
+		CHECK(first.is_complete());
+		second_thread_id = std::this_thread::get_id();
+	};
+	const auto second = backend->enqueue_host_task(lane, second_fn, {}, box_cast<3>(box<0>()), nullptr);
+
+	for(;;) {
+		if(second.is_complete()) {
+			CHECK(first.is_complete());
+			break;
+		}
+	}
+
+	REQUIRE(first_thread_id.has_value());
+	REQUIRE(second_thread_id.has_value());
+	CHECK(*first_thread_id == *second_thread_id);
+}
+
+TEST_CASE("device kernel command groups are hydrated and invoked with the correct parameters", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices();
+	CAPTURE(backend_type, sycl_devices);
+
+	const mock_accessor<target::device> acc1(hydration_id(1));
+	const mock_accessor<target::device> acc2(hydration_id(2));
+	const std::vector<closure_hydrator::accessor_info> accessor_infos{
+	    {reinterpret_cast<void*>(0x1337), box<3>{{1, 2, 3}, {4, 5, 6}},
+	        box<3>{{0, 1, 2}, {7, 8, 9}} CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, reinterpret_cast<oob_bounding_box*>(0x69420))},
+	    {reinterpret_cast<void*>(0x7331), box<3>{{3, 2, 1}, {6, 5, 4}},
+	        box<3>{{2, 1, 0}, {9, 8, 7}} CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, reinterpret_cast<oob_bounding_box*>(0x1230))}};
+
+	constexpr size_t lane = 0;
+	const box<3> execution_range({1, 2, 3}, {4, 5, 6});
+	const std::vector<void*> reduction_ptrs{nullptr, reinterpret_cast<void*>(1337)};
+
+	const auto value_ptr = static_cast<int*>(backend->debug_alloc(sizeof(int)));
+
+	for(device_id did = 0; did < sycl_devices.size(); ++did) {
+		*value_ptr = 1;
+
+		// no accessors
+		test_utils::await(backend->enqueue_device_kernel(
+		    did, lane,
+		    [&](sycl::handler& cgh, const box<3>& b, const std::vector<void*>& r) {
+			    CHECK(b == execution_range);
+			    CHECK(r == reduction_ptrs);
+			    cgh.single_task([=] { *value_ptr += 1; });
+		    },
+		    {}, execution_range, reduction_ptrs));
+
+		// yes accessors
+		test_utils::await(backend->enqueue_device_kernel(
+		    did, lane,
+		    [&, acc1, acc2](sycl::handler& cgh, const box<3>& b, const std::vector<void*>& r) {
+			    REQUIRE(acc1.info.has_value());
+			    REQUIRE(acc2.info.has_value());
+			    CHECK(accessor_info_equal(*acc1.info, accessor_infos[0]));
+			    CHECK(accessor_info_equal(*acc2.info, accessor_infos[1]));
+			    CHECK(b == execution_range);
+			    CHECK(r == reduction_ptrs);
+			    cgh.single_task([=] { *value_ptr += 1; });
+		    },
+		    accessor_infos, execution_range, reduction_ptrs));
+
+		CHECK(*value_ptr == 3);
+	}
+
+	backend->debug_free(value_ptr);
+}
+
+TEST_CASE("device kernels in a single lane execute in-order", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices();
+	CAPTURE(backend_type, sycl_devices);
+
+	const auto dummy = static_cast<volatile int*>(backend->debug_alloc(sizeof(int)));
+	*dummy = 0;
+
+	constexpr size_t lane = 0;
+
+	const auto first = backend->enqueue_device_kernel(device_id(0), lane,
+	    [=](sycl::handler& cgh, const box<3>&, const std::vector<void*>&) {
+		    cgh.single_task([=] {
+			    while(++*dummy < 100'000) {} // busy "wait" - takes ~10ms on hipSYCL debug build with RTX 3090
+		    });
+	    },
+	    {}, box_cast<3>(box<0>()), {});
+
+	const auto second = backend->enqueue_device_kernel(
+	    device_id(0), lane, [=](sycl::handler& cgh, const box<3>&, const std::vector<void*>&) { cgh.single_task([=] {}); }, {}, box_cast<3>(box<0>()), {});
+
+	for(;;) {
+		if(second.is_complete()) {
+			CHECK(first.is_complete());
+			break;
+		}
+	}
+
+	backend->debug_free(const_cast<int*>(dummy));
+}
+
+TEST_CASE("backend copies work correctly on all source- and destination layouts", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices();
+	CAPTURE(backend_type, sycl_devices);
+
+	// "device to itself" is used for buffer resizes, and "device to peer" for coherence (if the backend supports it)
+	const auto direction = GENERATE(values<std::string>({"host to host", "host to device", "device to host", "device to peer", "device to itself"}));
+	CAPTURE(direction);
+
+	std::optional<device_id> source_did; // host memory if nullopt
+	std::optional<device_id> dest_did;   // host memory if nullopt
+	if(direction == "host to device") {
+		dest_did = device_id(0);
+	} else if(direction == "device to host") {
+		source_did = device_id(0);
+	} else if(direction == "device to itself") {
+		source_did = device_id(0);
+		dest_did = device_id(0);
+	} else if(direction == "device to peer") {
+		const auto& system = backend->get_system_info();
+		if(system.devices.size() < 2) { SKIP("Not enough devices available to test peer-to-peer copy"); }
+		if(system.devices[0].native_memory < first_device_memory_id || system.devices[1].native_memory < first_device_memory_id
+		    || system.devices[0].native_memory == system.devices[1].native_memory) {
+			SKIP("Available devices do not report disjoint, dedicated memories");
+		}
+		if(!system.memories[system.devices[0].native_memory].copy_peers.test(system.devices[1].native_memory)) {
+			SKIP("Available devices do not support peer-to-peer copy");
+		}
+		source_did = device_id(0);
+		dest_did = device_id(1);
+	} else if(direction != "host to host") {
+		FAIL("Unknown test type");
+	}
+	CAPTURE(source_did, dest_did);
+
+	// use a helper SYCL queue to init allocations and copy between user and source/dest memories
+	sycl::queue source_sycl_queue(sycl_devices[0], sycl::property::queue::in_order{});
+	sycl::queue dest_sycl_queue(sycl_devices[direction == "device to peer" ? 1 : 0], sycl::property::queue::in_order{});
+
+	const auto source_base = backend_alloc(*backend, source_did, test_utils::copy_test_max_range.size() * sizeof(int), alignof(int));
+	const auto dest_base = backend_alloc(*backend, dest_did, test_utils::copy_test_max_range.size() * sizeof(int), alignof(int));
+
+	// generate the source pattern in user memory
+	std::vector<int> source_template(test_utils::copy_test_max_range.size());
+	std::iota(source_template.begin(), source_template.end(), 1);
+
+	// use a loop instead of GENERATE() to avoid re-instantiating the backend and re-allocating device memory on each iteration (very expensive!)
+	for(const auto& [source_box, dest_box, copy_box] : test_utils::generate_copy_test_layouts()) {
+		CAPTURE(source_box, dest_box, copy_box);
+		REQUIRE(all_true(source_box.get_range() <= test_utils::copy_test_max_range));
+		REQUIRE(all_true(dest_box.get_range() <= test_utils::copy_test_max_range));
+
+		// reference is nd_copy_host (tested in nd_memory_tests)
+		std::vector<int> expected_dest(dest_box.get_area());
+		nd_copy_host(source_template.data(), expected_dest.data(), box_cast<3>(source_box), box_cast<3>(dest_box), box_cast<3>(copy_box), sizeof(int));
+
+		source_sycl_queue.memcpy(source_base, source_template.data(), source_box.get_area() * sizeof(int)).wait();
+		dest_sycl_queue.memset(dest_base, 0, dest_box.get_area() * sizeof(int)).wait();
+
+		backend_copy(
+		    *backend, source_did, dest_did, source_base, dest_base, box_cast<3>(source_box), box_cast<3>(dest_box), box_cast<3>(copy_box), sizeof(int));
+
+		std::vector<int> actual_dest(dest_box.get_area());
+		dest_sycl_queue.memcpy(actual_dest.data(), dest_base, actual_dest.size() * sizeof(int)).wait();
+
+		REQUIRE(actual_dest == expected_dest);
+	}
+
+	backend_free(*backend, source_did, source_base);
+	backend_free(*backend, dest_did, dest_base);
+}
+
+TEST_CASE("SYCL backend enumerator classifies backends correctly", "[backend]") {
+	CHECK_FALSE(sycl_backend_enumerator().is_specialized(sycl_backend_type::generic));
+	CHECK(sycl_backend_enumerator().is_specialized(sycl_backend_type::cuda));
+	CHECK(sycl_backend_enumerator().get_priority(sycl_backend_type::cuda) > sycl_backend_enumerator().get_priority(sycl_backend_type::generic));
+}
+
+TEST_CASE("backends report execution time iff profiling is enabled", "[backend]") {
+	test_utils::allow_backend_fallback_warnings();
+
+	const auto enable_profiling = static_cast<bool>(GENERATE(values({0, 1})));
+	const auto [backend_type, backend, sycl_devices] = generate_backends_with_devices(enable_profiling);
+	CAPTURE(backend_type, sycl_devices);
+
+	const auto dummy_ptr = static_cast<volatile int*>(backend->debug_alloc(sizeof(int)));
+	const size_t host_device_alloc_size = 4096;
+	const std::vector<uint8_t> user_alloc(4096);
+	const auto host_ptr = test_utils::await(backend->enqueue_host_alloc(host_device_alloc_size, 1));
+	const auto device_ptr = test_utils::await(backend->enqueue_device_alloc(device_id(0), host_device_alloc_size, 1));
+
+	async_event event;
+
+	SECTION("on device kernels") {
+		*dummy_ptr = 0;
+		event = backend->enqueue_device_kernel(device_id(0), /* lane */ 0,
+		    [=](sycl::handler& cgh, const box<3>&, const std::vector<void*>&) {
+			    cgh.single_task([=] {
+				    while(++*dummy_ptr < 100'000) {} // busy "wait" - takes ~1ms on hipSYCL debug build with RTX 3090
+			    });
+		    },
+		    {}, box_cast<3>(box<0>()), {});
+	}
+
+	SECTION("on host tasks") {
+		event = backend->enqueue_host_task(
+		    /* lane */ 0, [&](const box<3>&, const communicator*) { std::this_thread::sleep_for(std::chrono::milliseconds(1)); }, {}, box_cast<3>(box<0>()),
+		    nullptr);
+	}
+
+	const auto unit_box = box_cast<3>(box<0>());
+
+	SECTION("on host copies") {
+		event = backend->enqueue_host_copy(/* lane */ 0, user_alloc.data(), host_ptr, unit_box, unit_box, unit_box, host_device_alloc_size);
+	}
+
+	SECTION("on device copies") {
+		event = backend->enqueue_device_copy(device_id(0), /* lane */ 0, host_ptr, device_ptr, unit_box, unit_box, unit_box, host_device_alloc_size);
+	}
+
+	test_utils::await(event);
+
+	const auto time = event.get_native_execution_time();
+	REQUIRE(time.has_value() == enable_profiling);
+
+	if(enable_profiling) { CHECK(time.value() > std::chrono::nanoseconds(0)); }
+
+	test_utils::await(backend->enqueue_device_free(device_id(0), device_ptr));
+	test_utils::await(backend->enqueue_host_free(host_ptr));
+	backend->debug_free(const_cast<int*>(dummy_ptr));
+}

--- a/test/executor_tests.cc
+++ b/test/executor_tests.cc
@@ -1,0 +1,947 @@
+#include "backend/backend.h"
+#include "communicator.h"
+#include "dry_run_executor.h"
+#include "executor.h"
+#include "live_executor.h"
+#include "reduction.h"
+#include "thread_queue.h"
+
+#include "test_utils.h"
+
+#include <condition_variable>
+#include <mutex>
+
+using namespace celerity;
+using namespace celerity::detail;
+
+
+// The mock implementations in this test append all operations to a sequential operations_log, which is inspected after executor shutdown.
+namespace ops {
+
+struct common_alloc {
+	size_t size = 0;
+	size_t alignment = 0;
+	void* result = nullptr;
+};
+
+struct host_alloc : common_alloc {};
+
+struct device_alloc : common_alloc {
+	device_id device = 0;
+};
+
+struct common_free {
+	void* ptr = nullptr;
+};
+
+struct host_free : common_free {};
+
+struct device_free : common_free {
+	device_id device = 0;
+};
+
+struct host_task {
+	size_t host_lane;
+	std::vector<closure_hydrator::accessor_info> accessor_infos;
+	box<3> execution_range;
+	const communicator* collective_comm = nullptr;
+};
+
+struct device_kernel {
+	device_id device = 0;
+	size_t device_lane = 0;
+	std::vector<closure_hydrator::accessor_info> accessor_infos;
+	box<3> execution_range;
+	std::vector<void*> reduction_ptrs;
+};
+
+// base type for host_copy / device_copy only
+struct common_copy {
+	const void* source_base = nullptr;
+	void* dest_base = nullptr;
+	box<3> source_box;
+	box<3> dest_box;
+	region<3> copy_region;
+	size_t elem_size = 0;
+};
+
+struct host_copy : common_copy {
+	size_t host_lane = 0;
+};
+
+struct device_copy : common_copy {
+	device_id device = 0;
+	size_t device_lane = 0;
+};
+
+struct reduce {
+	void* dest = nullptr;
+	const void* src = nullptr;
+	size_t src_count = 0;
+};
+
+struct fill_identity {
+	void* dest = nullptr;
+	size_t count = 0;
+};
+
+struct send_outbound_pilot {
+	outbound_pilot pilot;
+};
+
+struct send_payload {
+	node_id to = 0;
+	message_id msgid = 0;
+	const void* base = nullptr;
+	communicator::stride stride;
+};
+
+struct collective_clone {
+	const communicator* parent = nullptr;
+	const communicator* child = nullptr;
+};
+
+struct collective_barrier {
+	const communicator* comm = nullptr;
+};
+
+} // namespace ops
+
+using operation = std::variant<ops::host_alloc, ops::device_alloc, ops::host_free, ops::device_free, ops::host_task, ops::device_kernel, ops::host_copy,
+    ops::device_copy, ops::reduce, ops::fill_identity, ops::send_outbound_pilot, ops::send_payload, ops::collective_clone, ops::collective_barrier>;
+using operations_log = std::vector<operation>;
+
+
+/// A mock host object instance type that notifies the owner about its destruction.
+struct mock_host_object final : host_object_instance {
+	std::atomic<bool>* destroyed = nullptr;
+
+	explicit mock_host_object(std::atomic<bool>* const destroyed) : destroyed(destroyed) {}
+
+	mock_host_object(const mock_host_object&) = delete;
+	mock_host_object(mock_host_object&&) = delete;
+	mock_host_object& operator=(const mock_host_object&) = delete;
+	mock_host_object& operator=(mock_host_object&&) = delete;
+
+	~mock_host_object() override {
+		if(destroyed != nullptr) { destroyed->store(true); }
+	}
+};
+
+/// Mock reducer implementation that collects an `operations_log` and notifies the owner about its destruction.
+class mock_reducer final : public reducer {
+  public:
+	explicit mock_reducer(std::atomic<bool>* const destroyed, operations_log* const log) : m_destroyed(destroyed), m_log(log) {}
+
+	mock_reducer(const mock_reducer&) = delete;
+	mock_reducer(mock_reducer&&) = delete;
+	mock_reducer& operator=(const mock_reducer&) = delete;
+	mock_reducer& operator=(mock_reducer&&) = delete;
+
+	~mock_reducer() override {
+		if(m_destroyed != nullptr) { m_destroyed->store(true); }
+	}
+
+	void reduce(void* dest, const void* src, size_t src_count) const override { m_log->push_back(ops::reduce{dest, src, src_count}); }
+	void fill_identity(void* dest, size_t count) const override { m_log->push_back(ops::fill_identity{dest, count}); }
+
+  private:
+	std::atomic<bool>* m_destroyed;
+	operations_log* m_log;
+};
+
+/// Mock (send-only) communicator implementation that collects an `operations_log`.
+class mock_exec_communicator final : public communicator {
+  public:
+	explicit mock_exec_communicator(operations_log* const log) : m_log(log) {}
+
+	size_t get_num_nodes() const override { return 2; }
+	node_id get_local_node_id() const override { return 0; }
+
+	std::vector<inbound_pilot> poll_inbound_pilots() override { return {}; }
+
+	void send_outbound_pilot(const outbound_pilot& pilot) override { m_log->push_back(ops::send_outbound_pilot{pilot}); }
+
+	async_event send_payload(node_id to, message_id msgid, const void* base, const stride& stride) override {
+		m_log->push_back(ops::send_payload({to, msgid, base, stride}));
+		return make_complete_event();
+	}
+
+	async_event receive_payload(node_id from, message_id msgid, void* base, const stride& stride) override {
+		// we don't test receiving because it would be annoying, and most of the pointer juggling is handled by receive_arbiter anyway
+		utils::panic("not implemented");
+	}
+
+	std::unique_ptr<communicator> collective_clone() override {
+		auto clone = std::make_unique<mock_exec_communicator>(m_log);
+		m_log->push_back(ops::collective_clone{this, clone.get()});
+		return clone;
+	}
+
+	void collective_barrier() override { m_log->push_back(ops::collective_barrier{this}); }
+
+  private:
+	operations_log* m_log;
+};
+
+/// Mock backend implementation that collects an `operations_log` and does some lightweight checking on operation arguments.
+class mock_backend final : public backend {
+  public:
+	mock_backend(const system_info& system, operations_log* const log) : m_system(system), m_log(log) {}
+
+	const system_info& get_system_info() const override { return m_system; }
+
+	void* debug_alloc(size_t size) override { return malloc(size); }
+	void debug_free(void* ptr) override { free(ptr); }
+
+	async_event enqueue_host_alloc(const size_t size, const size_t alignment) override {
+		const auto ptr = mock_alloc(size, alignment);
+		m_log->push_back(ops::host_alloc{{size, alignment, ptr}});
+		return make_complete_event(ptr);
+	}
+
+	async_event enqueue_device_alloc(const device_id device, const size_t size, const size_t alignment) override {
+		const auto ptr = mock_alloc(size, alignment);
+		m_log->push_back(ops::device_alloc{{size, alignment, ptr}, device});
+		return make_complete_event(ptr);
+	}
+
+	async_event enqueue_host_free(void* const ptr) override {
+		m_log->push_back(ops::host_free{{ptr}});
+		return make_complete_event();
+	}
+
+	async_event enqueue_device_free(const device_id device, void* const ptr) override {
+		m_log->push_back(ops::device_free{{ptr}, device});
+		return make_complete_event();
+	}
+
+	async_event enqueue_host_task(const size_t host_lane, const host_task_launcher& launcher, std::vector<closure_hydrator::accessor_info> accessor_infos,
+	    const box<3>& execution_range, const communicator* const collective_comm) override //
+	{
+		m_log->push_back(ops::host_task{host_lane, std::move(accessor_infos), execution_range, collective_comm});
+		if(launcher) {
+			// probably a delay task: submit to thread queue so we can return before it completes
+			return m_host_queue.submit([=] { launcher(execution_range, collective_comm); });
+		} else {
+			return make_complete_event();
+		}
+	}
+
+	async_event enqueue_device_kernel(const device_id device, const size_t device_lane, const device_kernel_launcher& launcher,
+	    std::vector<closure_hydrator::accessor_info> accessor_infos, const box<3>& execution_range, const std::vector<void*>& reduction_ptrs) override //
+	{
+		m_log->push_back(ops::device_kernel{device, device_lane, std::move(accessor_infos), execution_range, reduction_ptrs});
+		return make_complete_event();
+	}
+
+	async_event enqueue_host_copy(const size_t host_lane, const void* const source_base, void* const dest_base, const box<3>& source_box,
+	    const box<3>& dest_box, const region<3>& copy_region, const size_t elem_size) override //
+	{
+		m_log->push_back(ops::host_copy{{source_base, dest_base, source_box, dest_box, copy_region, elem_size}, host_lane});
+		return make_complete_event();
+	}
+
+	async_event enqueue_device_copy(const device_id device, const size_t device_lane, const void* const source_base, void* const dest_base,
+	    const box<3>& source_box, const box<3>& dest_box, const region<3>& copy_region, const size_t elem_size) override //
+	{
+		m_log->push_back(ops::device_copy{{source_base, dest_base, source_box, dest_box, copy_region, elem_size}, device, device_lane});
+		return make_complete_event();
+	}
+
+  private:
+	system_info m_system;
+	uintptr_t m_last_mock_alloc_address = 0;
+	operations_log* m_log;
+	thread_queue m_host_queue{"cy-mock-host"}; // for host tasks with in-tact launcher (= delay tasks)
+
+	/// alloc operations must return a non-null pointer, which we simply conjure from an integer to allow tests to identify allocations in the log.
+	void* mock_alloc(const size_t size, const size_t alignment) {
+		REQUIRE(size > 0);
+		REQUIRE(alignment > 0);
+		CHECK(size >= alignment);
+		CHECK(size % alignment == 0);
+		const auto address = (m_last_mock_alloc_address + alignment) / alignment * alignment;
+		m_last_mock_alloc_address = address + size;
+		return reinterpret_cast<void*>(address);
+	}
+};
+
+/// Minimal mock implementation of fence_promise that allows a test await completion of a fence instruction.
+class mock_fence_promise final : public fence_promise {
+  public:
+	void fulfill() override {
+		std::lock_guard lock(m_mutex);
+		m_fulfilled = true;
+		m_cv.notify_all();
+	}
+
+	allocation_id get_user_allocation_id() override { utils::panic("not implemented"); }
+
+	void wait() {
+		std::unique_lock lock(m_mutex);
+		m_cv.wait(lock, [this] { return m_fulfilled; });
+	}
+
+  private:
+	std::mutex m_mutex;
+	bool m_fulfilled = false;
+	std::condition_variable m_cv;
+};
+
+// GENERATE() infrastructure
+enum class executor_type { dry_run, live };
+
+template <>
+struct Catch::StringMaker<executor_type> {
+	static std::string convert(executor_type value) {
+		switch(value) {
+		case executor_type::dry_run: return "dry_run";
+		case executor_type::live: return "live";
+		}
+	}
+};
+
+/// Constructs a dry_run_ or live_executor with mock backend / communicator for collecting and inspecting operation logs and provides a test interface that
+/// submits individual instructions without an actual source task_graph / command_graph.
+class executor_test_context final : private executor::delegate {
+  public:
+	explicit executor_test_context(const executor_type type, const live_executor::policy_set& live_policy = {}) {
+		if(type == executor_type::dry_run) {
+			m_executor = std::make_unique<dry_run_executor>(static_cast<executor::delegate*>(this));
+		} else {
+			const auto system = test_utils::make_system_info(4 /* num devices */, false /* d2d copies*/);
+			auto backend = std::make_unique<mock_backend>(system, &m_log);
+			auto root_comm = std::make_unique<mock_exec_communicator>(&m_log);
+			m_root_comm = root_comm.get();
+			m_executor = std::make_unique<live_executor>(std::move(backend), std::move(root_comm), static_cast<executor::delegate*>(this), live_policy);
+		}
+	}
+
+	executor_test_context(const executor_test_context&) = delete;
+	executor_test_context(executor_test_context&&) = delete;
+	executor_test_context& operator=(const executor_test_context&) = delete;
+	executor_test_context& operator=(executor_test_context&&) = delete;
+
+	~executor_test_context() { REQUIRE(m_executor == nullptr); }
+
+	void track_reducer(const reduction_id rid, std::atomic<bool>* destroyed) {
+		m_executor->track_reducer(rid, std::make_unique<mock_reducer>(destroyed, &m_log));
+	}
+
+	void track_host_object(const host_object_id hoid, std::atomic<bool>* destroyed) {
+		m_executor->track_host_object_instance(hoid, std::make_unique<mock_host_object>(destroyed));
+	}
+
+	void track_user_allocation(const allocation_id aid, void* const ptr) { //
+		m_executor->track_user_allocation(aid, ptr);
+	}
+
+	/// Submit the init epoch instruction. Call before any other submission.
+	task_id init() {
+		submit<epoch_instruction>(task_manager::initial_epoch_task, epoch_action::none, instruction_garbage{});
+		return task_manager::initial_epoch_task;
+	}
+
+	task_id horizon(instruction_garbage garbage = {}) {
+		const auto tid = m_next_task_id++;
+		submit<horizon_instruction>(tid, std::move(garbage));
+		return tid;
+	}
+
+	task_id epoch(const epoch_action action, instruction_garbage garbage = {}) {
+		const auto tid = m_next_task_id++;
+		submit<epoch_instruction>(tid, action, std::move(garbage));
+		return tid;
+	}
+
+	void clone_collective_group(const collective_group_id original_cgid, const collective_group_id new_cgid) {
+		submit<clone_collective_group_instruction>(original_cgid, new_cgid);
+	}
+
+	void alloc(const allocation_id aid, const size_t size, const size_t alignment) { submit<alloc_instruction>(aid, size, alignment); }
+
+	void free(const allocation_id aid) { submit<free_instruction>(aid); }
+
+	void host_task(const box<3>& execution_range, const range<3>& global_range, buffer_access_allocation_map amap, const collective_group_id cgid) {
+		submit<host_task_instruction>(host_task_launcher{}, execution_range, global_range, std::move(amap),
+		    cgid CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, task_type::host_compute, task_id(1), "task_name"));
+	}
+
+	void device_kernel(const device_id did, const box<3>& execution_range, buffer_access_allocation_map amap, buffer_access_allocation_map rmap) {
+		submit<device_kernel_instruction>(did, device_kernel_launcher{}, execution_range, std::move(amap),
+		    std::move(rmap) CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, task_type::device_compute, task_id(1), "task_name"));
+	}
+
+	void copy(const allocation_with_offset& source_alloc, const allocation_with_offset& dest_alloc, const box<3>& source_box, const box<3>& dest_box,
+	    region<3> copy_region, const size_t elem_size) //
+	{
+		submit<copy_instruction>(source_alloc, dest_alloc, source_box, dest_box, std::move(copy_region), elem_size);
+	}
+
+	void destroy_host_object(const host_object_id hoid) { submit<destroy_host_object_instruction>(hoid); }
+
+	void fence_and_wait() {
+		mock_fence_promise fence_promise;
+		submit<fence_instruction>(&fence_promise);
+		fence_promise.wait();
+	}
+
+	void fill_identity(const reduction_id rid, const allocation_id aid, const size_t num_values) { submit<fill_identity_instruction>(rid, aid, num_values); }
+
+	void reduce(const reduction_id rid, const allocation_id source_allocation_id, const size_t num_source_values, const allocation_id dest_allocation_id) {
+		submit<reduce_instruction>(rid, source_allocation_id, num_source_values, dest_allocation_id);
+	}
+
+	void outbound_pilot(const outbound_pilot& pilot) { m_executor->submit({}, {pilot}); }
+
+	void send(const node_id to_nid, const message_id msgid, const allocation_id source_aid, const range<3>& source_alloc_range, const id<3>& offset_in_alloc,
+	    const range<3>& send_range, const size_t elem_size) //
+	{
+		submit<send_instruction>(to_nid, msgid, source_aid, source_alloc_range, offset_in_alloc, send_range, elem_size);
+	}
+
+	/// Submits a host task that sleeps for the given duration.
+	void delay(const std::chrono::milliseconds& duration) {
+		submit<host_task_instruction>(
+		    [=](const box<3>& /* execution_range */, const communicator* /* collective_comm */) { std::this_thread::sleep_for(duration); },
+		    subrange(id<3>(0, 0, 0), range<3>(1, 1, 1)), range<3>(1, 1, 1), buffer_access_allocation_map{},
+		    collective_group_id(0) CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, task_type::host_compute, task_id(1), "task_name"));
+	}
+
+	/// Submits and awaits the shutdown epoch, then returns the collected operations log. Call after the last submission.
+	operations_log finish() {
+		CHECK(m_executor != nullptr);
+		epoch(epoch_action::shutdown, instruction_garbage{});
+		m_executor.reset();
+		return std::move(m_log);
+	}
+
+	task_id get_last_epoch() { return m_epochs.get(); }
+	task_id get_last_horizon() { return m_horizons.get(); }
+
+	void await_horizon(const task_id tid) { m_horizons.await(tid); }
+	void await_epoch(const task_id tid) { m_epochs.await(tid); }
+
+	const communicator* get_root_communicator() const { return m_root_comm; }
+
+  private:
+	instruction_id m_next_iid = 1;
+	std::optional<instruction_id> m_last_iid; // serialize all instructions for simplicity - we do not test OoO capabilities here
+	task_id m_next_task_id = task_manager::initial_epoch_task + 1;
+	std::vector<std::unique_ptr<instruction>> m_instructions; // we need to guarantee liveness as long as the executor thread is around
+	std::unique_ptr<executor> m_executor;
+	epoch_monitor m_horizons{0};
+	epoch_monitor m_epochs{0};
+	operations_log m_log;                      // mutated by executor thread - do not access before shutdown!
+	const communicator* m_root_comm = nullptr; // always nullptr for dry_run_executor
+
+	template <typename Instruction, typename... CtorParams>
+	instruction_id submit(CtorParams&&... ctor_args) {
+		const auto iid = instruction_id(m_next_iid++);
+		auto instr = std::make_unique<Instruction>(iid, 0, std::forward<CtorParams>(ctor_args)...);
+		if(m_last_iid.has_value()) { instr->add_dependency(*m_last_iid); }
+		m_executor->submit({instr.get()}, {});
+		m_instructions.push_back(std::move(instr));
+		m_last_iid = iid;
+		return iid;
+	}
+
+	void horizon_reached(const task_id tid) override { m_horizons.set(tid); }
+	void epoch_reached(const task_id tid) override { m_epochs.set(tid); }
+};
+
+
+TEST_CASE("executors notify their delegate when encountering a horizon / epoch", "[executor]") {
+	test_utils::allow_dry_run_executor_warnings();
+
+	const auto executor_type = GENERATE(values({executor_type::dry_run, executor_type::live}));
+	CAPTURE(executor_type);
+
+	executor_test_context ectx(executor_type);
+	ectx.init();
+
+	CHECK(ectx.get_last_epoch() == task_id(0));
+	CHECK(ectx.get_last_horizon() == task_id(0));
+
+	SECTION("on epochs") {
+		const auto epoch_tid = ectx.epoch(epoch_action::none);
+		ectx.await_epoch(epoch_tid);
+		CHECK(ectx.get_last_epoch() == epoch_tid);
+	}
+
+	SECTION("on horizons") {
+		const auto horizon_tid = ectx.horizon();
+		ectx.await_horizon(horizon_tid);
+		CHECK(ectx.get_last_horizon() == horizon_tid);
+	}
+
+	ectx.finish();
+}
+
+TEST_CASE("dry_run_executor warns when encountering a fence instruction ", "[executor][dry_run]") {
+	test_utils::allow_dry_run_executor_warnings();
+
+	executor_test_context ectx(executor_type::dry_run);
+	ectx.init();
+	ectx.fence_and_wait();
+	CHECK(test_utils::log_contains_exact(log_level::warn, "Encountered a \"fence\" command while \"CELERITY_DRY_RUN_NODES\" is set. The result of this "
+	                                                      "operation will not match the expected output of an actual run."));
+	ectx.finish();
+}
+
+TEST_CASE("executors accept user allocations in garbage lists", "[executor]") {
+	test_utils::allow_dry_run_executor_warnings();
+
+	const auto executor_type = GENERATE(values({executor_type::dry_run, executor_type::live}));
+	CAPTURE(executor_type);
+
+	executor_test_context ectx(executor_type);
+	ectx.init();
+
+	const allocation_id aid(user_memory_id, raw_allocation_id(123));
+	const auto ptr = reinterpret_cast<void*>(0x1234);
+	ectx.track_user_allocation(aid, ptr);
+
+	SECTION("on epochs") {
+		const auto epoch_tid = ectx.epoch(epoch_action::none, instruction_garbage{{}, {aid}});
+		ectx.await_epoch(epoch_tid);
+	}
+
+	SECTION("on horizons") {
+		const auto horizon_tid = ectx.horizon(instruction_garbage{{}, {aid}});
+		ectx.await_horizon(horizon_tid);
+	}
+
+	ectx.finish();
+}
+
+TEST_CASE("executors free all reducers that appear in garbage lists  ", "[executor]") {
+	test_utils::allow_dry_run_executor_warnings();
+
+	const auto executor_type = GENERATE(values({executor_type::dry_run, executor_type::live}));
+	CAPTURE(executor_type);
+
+	executor_test_context ectx(executor_type);
+	ectx.init();
+
+	const reduction_id rid(123);
+	std::atomic<bool> destroyed{false};
+	ectx.track_reducer(rid, &destroyed);
+
+	SECTION("on epochs") {
+		const auto epoch_tid = ectx.epoch(epoch_action::none, instruction_garbage{{rid}, {}});
+		ectx.await_epoch(epoch_tid);
+	}
+
+	SECTION("on horizons") {
+		const auto horizon_tid = ectx.horizon(instruction_garbage{{rid}, {}});
+		ectx.await_horizon(horizon_tid);
+	}
+
+	ectx.finish();
+}
+
+TEST_CASE("host object lifetime is controlled by destroy_host_object_instruction", "[executor]") {
+	const auto executor_type = GENERATE(values({executor_type::dry_run, executor_type::live}));
+	CAPTURE(executor_type);
+
+	executor_test_context ectx(executor_type);
+	ectx.init();
+
+	const host_object_id hoid(42);
+	std::atomic<bool> destroyed{false};
+	ectx.track_host_object(hoid, &destroyed);
+	CHECK_FALSE(destroyed.load());
+
+	const auto after_track_tid = ectx.horizon();
+	CHECK_FALSE(destroyed.load());
+
+	ectx.await_horizon(after_track_tid);
+	CHECK_FALSE(destroyed.load());
+
+	ectx.destroy_host_object(hoid);
+	const auto after_destroy_tid = ectx.horizon();
+	ectx.await_horizon(after_destroy_tid);
+	CHECK(destroyed);
+
+	ectx.finish();
+}
+
+TEST_CASE("live_executor passes correct allocations to host tasks", "[executor]") {
+	executor_test_context ectx(executor_type::live);
+	ectx.init();
+
+	ectx.alloc(allocation_id(host_memory_id, 1), 1024, 8);
+	ectx.alloc(allocation_id(host_memory_id, 2), 2048, 16);
+
+	const auto amap = buffer_access_allocation_map{
+	    {
+	        allocation_id(host_memory_id, 1),
+	        box<3>({0, 0, 0}, {32, 32, 1}),
+	        box<3>({8, 8, 0}, {24, 24, 1}) //
+	        CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, 1, "buffer1"),
+	    },
+	    {
+	        allocation_id(host_memory_id, 2),
+	        box<3>({0, 0, 0}, {64, 16, 1}),
+	        box<3>({0, 0, 0}, {16, 16, 1}) //
+	        CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, 2, "buffer2"),
+	    },
+	};
+	ectx.host_task(box<3>{{0, 1, 2}, {3, 4, 5}}, range<3>{7, 8, 9}, amap, non_collective_group_id);
+
+	ectx.free(allocation_id(host_memory_id, 1));
+	ectx.free(allocation_id(host_memory_id, 2));
+
+	const auto log = ectx.finish();
+	REQUIRE(log.size() == 5);
+
+	const auto alloc1 = std::get<ops::host_alloc>(log[0]);
+	CHECK(alloc1.size == 1024);
+	CHECK(alloc1.alignment == 8);
+	CHECK(alloc1.result != nullptr);
+
+	const auto alloc2 = std::get<ops::host_alloc>(log[1]);
+	CHECK(alloc2.size == 2048);
+	CHECK(alloc2.alignment == 16);
+	CHECK(alloc2.result != nullptr);
+
+	const auto host_task = std::get<ops::host_task>(log[2]);
+	CHECK(host_task.collective_comm == nullptr);
+	CHECK(host_task.execution_range == box<3>{{0, 1, 2}, {3, 4, 5}});
+
+	REQUIRE(host_task.accessor_infos.size() == 2);
+	CHECK(host_task.accessor_infos[0].ptr == alloc1.result);
+	CHECK(host_task.accessor_infos[0].allocated_box_in_buffer == amap[0].allocated_box_in_buffer);
+	CHECK(host_task.accessor_infos[0].accessed_box_in_buffer == amap[0].accessed_box_in_buffer);
+	CHECK(host_task.accessor_infos[1].ptr == alloc2.result);
+	CHECK(host_task.accessor_infos[1].allocated_box_in_buffer == amap[1].allocated_box_in_buffer);
+	CHECK(host_task.accessor_infos[1].accessed_box_in_buffer == amap[1].accessed_box_in_buffer);
+
+	const auto free1 = std::get<ops::host_free>(log[3]);
+	CHECK(free1.ptr == alloc1.result);
+
+	const auto free2 = std::get<ops::host_free>(log[4]);
+	CHECK(free2.ptr == alloc2.result);
+}
+
+TEST_CASE("live_executor passes correct allocations to reducers", "[executor]") {
+	executor_test_context ectx(executor_type::live);
+	ectx.init();
+
+	const auto source_aid = allocation_id(host_memory_id, 1);
+	const auto dest_aid = allocation_id(host_memory_id, 2);
+	const size_t num_source_values = 4;
+	ectx.alloc(source_aid, 4 * sizeof(int), alignof(int));
+	ectx.alloc(dest_aid, sizeof(int), alignof(int));
+
+	const reduction_id rid(42);
+	ectx.track_reducer(rid, nullptr);
+	ectx.fill_identity(rid, source_aid, num_source_values);
+	ectx.reduce(rid, source_aid, num_source_values, dest_aid);
+
+	ectx.free(source_aid);
+	ectx.free(dest_aid);
+
+	const auto log = ectx.finish();
+	REQUIRE(log.size() == 6);
+
+	const auto source_alloc = std::get<ops::host_alloc>(log[0]);
+	const auto dest_alloc = std::get<ops::host_alloc>(log[1]);
+
+	const auto fill_identity = std::get<ops::fill_identity>(log[2]);
+	CHECK(fill_identity.dest == source_alloc.result);
+	CHECK(fill_identity.count == num_source_values);
+
+	const auto reduce = std::get<ops::reduce>(log[3]);
+	CHECK(reduce.dest == dest_alloc.result);
+	CHECK(reduce.src == source_alloc.result);
+	CHECK(reduce.src_count == num_source_values);
+
+	// correct arguments to alloc / free have already been tested above
+}
+
+TEST_CASE("live_executor passes correct allocations to device kernels", "[executor]") {
+	executor_test_context ectx(executor_type::live);
+	ectx.init();
+
+	const auto did = GENERATE(values<device_id>({0, 1}));
+	const auto mid = memory_id(first_device_memory_id + did);
+
+	ectx.alloc(allocation_id(mid, 1), 1024, 8);
+	ectx.alloc(allocation_id(mid, 2), 2048, 16);
+	ectx.alloc(allocation_id(mid, 3), 4, 4);
+	ectx.alloc(allocation_id(mid, 4), 4, 4);
+
+	const auto amap = buffer_access_allocation_map{
+	    {
+	        allocation_id(mid, 1),
+	        box<3>({0, 0, 0}, {32, 32, 1}),
+	        box<3>({8, 8, 0}, {24, 24, 1}) //
+	        CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, 1, "buffer1"),
+	    },
+	    {
+	        allocation_id(mid, 2),
+	        box<3>({0, 0, 0}, {64, 16, 1}),
+	        box<3>({0, 0, 0}, {16, 16, 1}) //
+	        CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, 2, "buffer2"),
+	    },
+	};
+	const auto rmap = buffer_access_allocation_map{
+	    {
+	        allocation_id(mid, 3),
+	        box<3>({0, 0, 0}, {1, 1, 1}),
+	        box<3>({0, 0, 0}, {1, 1, 1}) //
+	        CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, 3, "buffer3"),
+	    },
+	    {
+	        allocation_id(mid, 4),
+	        box<3>({0, 0, 0}, {1, 1, 1}),
+	        box<3>({0, 0, 0}, {1, 1, 1}) //
+	        CELERITY_DETAIL_IF_ACCESSOR_BOUNDARY_CHECK(, 4, "buffer4"),
+	    },
+	};
+	ectx.device_kernel(did, box<3>({1, 2, 3}, {4, 5, 6}), amap, rmap);
+
+	ectx.free(allocation_id(mid, 1));
+	ectx.free(allocation_id(mid, 2));
+	ectx.free(allocation_id(mid, 3));
+	ectx.free(allocation_id(mid, 4));
+
+	const auto log = ectx.finish();
+	REQUIRE(log.size() == 9);
+
+	const auto alloc1 = std::get<ops::device_alloc>(log[0]);
+	CHECK(alloc1.device == did);
+	CHECK(alloc1.size == 1024);
+	CHECK(alloc1.alignment == 8);
+	CHECK(alloc1.result != nullptr);
+
+	const auto alloc2 = std::get<ops::device_alloc>(log[1]);
+	CHECK(alloc2.device == did);
+	CHECK(alloc2.size == 2048);
+	CHECK(alloc2.alignment == 16);
+	CHECK(alloc2.result != nullptr);
+
+	const auto alloc3 = std::get<ops::device_alloc>(log[2]);
+	CHECK(alloc3.device == did);
+	CHECK(alloc3.size == 4);
+	CHECK(alloc3.alignment == 4);
+	CHECK(alloc3.result != nullptr);
+
+	const auto alloc4 = std::get<ops::device_alloc>(log[3]);
+	CHECK(alloc4.device == did);
+	CHECK(alloc4.size == 4);
+	CHECK(alloc4.alignment == 4);
+	CHECK(alloc4.result != nullptr);
+
+	const auto kernel = std::get<ops::device_kernel>(log[4]);
+	CHECK(kernel.device == did);
+	CHECK(kernel.execution_range == box<3>({1, 2, 3}, {4, 5, 6}));
+
+	REQUIRE(kernel.accessor_infos.size() == 2);
+	CHECK(kernel.accessor_infos[0].ptr == alloc1.result);
+	CHECK(kernel.accessor_infos[0].allocated_box_in_buffer == amap[0].allocated_box_in_buffer);
+	CHECK(kernel.accessor_infos[0].accessed_box_in_buffer == amap[0].accessed_box_in_buffer);
+	CHECK(kernel.accessor_infos[1].ptr == alloc2.result);
+	CHECK(kernel.accessor_infos[1].allocated_box_in_buffer == amap[1].allocated_box_in_buffer);
+	CHECK(kernel.accessor_infos[1].accessed_box_in_buffer == amap[1].accessed_box_in_buffer);
+
+	CHECK(kernel.reduction_ptrs == std::vector{alloc3.result, alloc4.result});
+
+	const auto free1 = std::get<ops::device_free>(log[5]);
+	CHECK(free1.device == did);
+	CHECK(free1.ptr == alloc1.result);
+
+	const auto free2 = std::get<ops::device_free>(log[6]);
+	CHECK(free2.device == did);
+	CHECK(free2.ptr == alloc2.result);
+
+	const auto free3 = std::get<ops::device_free>(log[7]);
+	CHECK(free3.device == did);
+	CHECK(free3.ptr == alloc3.result);
+
+	const auto free4 = std::get<ops::device_free>(log[8]);
+	CHECK(free4.device == did);
+	CHECK(free4.ptr == alloc4.result);
+}
+
+TEST_CASE("live_executor passes correct allocation pointers to copy instructions", "[executor]") {
+	executor_test_context ectx(executor_type::live);
+	ectx.init();
+
+	const auto did = device_id(1);
+	const auto source_mid = GENERATE(values({host_memory_id, memory_id(first_device_memory_id + 1)}));
+	const auto dest_mid = GENERATE(values({host_memory_id, memory_id(first_device_memory_id + 1)}));
+	const auto source_offset = GENERATE(values<size_t>({0, 16}));
+	const auto dest_offset = GENERATE(values<size_t>({0, 32}));
+
+	const auto source_aid = allocation_id(source_mid, 1);
+	ectx.alloc(source_aid, 4096, 8);
+	const auto dest_aid = allocation_id(dest_mid, 2);
+	ectx.alloc(dest_aid, 4096, 8);
+
+	const auto source_box = box<3>{{4, 0, 0}, {16, 16, 1}};
+	const auto dest_box = box<3>{{8, 0, 0}, {16, 16, 1}};
+	const auto copy_region = region<3>({box<3>({8, 0, 0}, {12, 8, 1}), box<3>({12, 0, 0}, {16, 4, 1})});
+	const auto elem_size = 4;
+
+	ectx.copy(allocation_with_offset(source_aid, source_offset), allocation_with_offset(dest_aid, dest_offset), source_box, dest_box, copy_region, elem_size);
+
+	ectx.free(source_aid);
+	ectx.free(dest_aid);
+
+	const auto log = ectx.finish();
+	REQUIRE(log.size() == 5);
+
+	const ops::common_alloc* source_alloc = nullptr;
+	if(source_mid == host_memory_id) {
+		source_alloc = &std::get<ops::host_alloc>(log[0]);
+	} else {
+		const auto& source_device_alloc = std::get<ops::device_alloc>(log[0]);
+		CHECK(source_device_alloc.device == did);
+		source_alloc = &source_device_alloc;
+	}
+	CHECK(source_alloc->size == 4096);
+	CHECK(source_alloc->alignment == 8);
+	CHECK(source_alloc->result != nullptr);
+
+	const ops::common_alloc* dest_alloc = nullptr;
+	if(dest_mid == host_memory_id) {
+		dest_alloc = &std::get<ops::host_alloc>(log[1]);
+	} else {
+		const auto& dest_device_alloc = std::get<ops::device_alloc>(log[1]);
+		CHECK(dest_device_alloc.device == did);
+		dest_alloc = &dest_device_alloc;
+	}
+	CHECK(dest_alloc->size == 4096);
+	CHECK(dest_alloc->alignment == 8);
+	CHECK(dest_alloc->result != nullptr);
+
+	const ops::common_copy* copy = nullptr;
+	if(source_mid == host_memory_id && dest_mid == host_memory_id) {
+		copy = &std::get<ops::host_copy>(log[2]);
+	} else {
+		const auto& device_copy = std::get<ops::device_copy>(log[2]);
+		CHECK(device_copy.device == did);
+		copy = &device_copy;
+	}
+	CHECK(copy->source_base == static_cast<std::byte*>(source_alloc->result) + source_offset);
+	CHECK(copy->dest_base == static_cast<std::byte*>(dest_alloc->result) + dest_offset);
+	CHECK(copy->source_box == source_box);
+	CHECK(copy->dest_box == dest_box);
+	CHECK(copy->copy_region == copy_region);
+	CHECK(copy->elem_size == elem_size);
+
+	if(source_mid == host_memory_id) {
+		const auto source_free = std::get<ops::host_free>(log[3]);
+		CHECK(source_free.ptr == source_alloc->result);
+	} else {
+		const auto source_free = std::get<ops::device_free>(log[3]);
+		CHECK(source_free.device == did);
+		CHECK(source_free.ptr == source_alloc->result);
+	}
+
+	if(dest_mid == host_memory_id) {
+		const auto dest_free = std::get<ops::host_free>(log[4]);
+		CHECK(dest_free.ptr == dest_alloc->result);
+	} else {
+		const auto dest_free = std::get<ops::device_free>(log[4]);
+		CHECK(dest_free.device == did);
+		CHECK(dest_free.ptr == dest_alloc->result);
+	}
+}
+
+TEST_CASE("live_executor clones communicators and issues barriers correctly", "[executor]") {
+	executor_test_context ectx(executor_type::live);
+	ectx.init();
+
+	// clone a tree: root -> clone1; root -> clone2; clone1 -> clone3
+	ectx.clone_collective_group(root_collective_group_id, root_collective_group_id + 1);
+	ectx.clone_collective_group(root_collective_group_id, root_collective_group_id + 2);
+	ectx.clone_collective_group(root_collective_group_id + 1, root_collective_group_id + 3);
+	ectx.epoch(epoch_action::barrier); // must happen on root communicator
+
+	const auto log = ectx.finish();
+	REQUIRE(log.size() == 4);
+
+	const auto clone1 = std::get<ops::collective_clone>(log[0]);
+	CHECK(clone1.parent == ectx.get_root_communicator());
+	CHECK(clone1.child != clone1.parent); // communicators are never deleted, so inequality-comparisons between communicator pointers are safe
+
+	const auto clone2 = std::get<ops::collective_clone>(log[1]);
+	CHECK(clone2.parent == ectx.get_root_communicator());
+	CHECK(clone2.child != clone2.parent);
+	CHECK(clone2.child != clone1.parent);
+
+	const auto clone3 = std::get<ops::collective_clone>(log[2]);
+	CHECK(clone3.parent == clone1.child);
+	CHECK(clone3.child != clone3.parent);
+	CHECK(clone3.child != ectx.get_root_communicator());
+
+	const auto barrier = std::get<ops::collective_barrier>(log[3]);
+	CHECK(barrier.comm == ectx.get_root_communicator());
+}
+
+TEST_CASE("live_executor passes the correct metadata and pointers for peer-to-peer send", "[executor]") {
+	executor_test_context ectx(executor_type::live);
+
+	// outbound pilots are sent immediately, so we post them first to get a deterministically ordered log
+	const node_id peer = 1;
+	const message_id msgid = 123;
+	const transfer_id trid{1, 2, 0};
+	const box<3> send_box{{0, 1, 2}, {4, 5, 6}};
+	ectx.outbound_pilot({peer, {msgid, trid, send_box}});
+
+	ectx.init();
+
+	const auto source_aid = allocation_id(host_memory_id, 1);
+	const auto source_box = box<3>{{0, 0, 0}, {7, 8, 9}};
+	ectx.alloc(source_aid, source_box.get_area() * sizeof(int), alignof(int));
+	ectx.send(peer, msgid, source_aid, source_box.get_range(), send_box.get_offset(), send_box.get_range(), sizeof(int));
+
+	ectx.free(source_aid);
+
+	const auto log = ectx.finish();
+	REQUIRE(log.size() == 4);
+
+	const auto send_pilot = std::get<ops::send_outbound_pilot>(log[0]);
+	CHECK(send_pilot.pilot.to == peer);
+	CHECK(send_pilot.pilot.message.id == msgid);
+	CHECK(send_pilot.pilot.message.transfer_id == trid);
+	CHECK(send_pilot.pilot.message.box == send_box);
+
+	const auto alloc = std::get<ops::host_alloc>(log[1]);
+	CHECK(alloc.size == source_box.get_area() * sizeof(int));
+	CHECK(alloc.alignment == alignof(int));
+
+	const auto send_payload = std::get<ops::send_payload>(log[2]);
+	CHECK(send_payload.to == peer);
+	CHECK(send_payload.base == alloc.result);
+	CHECK(send_payload.msgid == msgid);
+	CHECK(send_payload.stride.allocation_range == source_box.get_range());
+	CHECK(send_payload.stride.transfer == send_box.get_subrange());
+	CHECK(send_payload.stride.element_size == sizeof(int));
+
+	const auto free = std::get<ops::host_free>(log[3]);
+	CHECK(free.ptr == alloc.result);
+}
+
+// We don't test receives because it would be annoying, and most of the pointer juggling is handled by receive_arbiter anyway
+
+TEST_CASE("live_executor emits progress warning when a task appears stuck", "[executor]") {
+	test_utils::allow_max_log_level(log_level::warn);
+
+	live_executor::policy_set policy;
+	policy.progress_warning_timeout = std::chrono::milliseconds(100);
+	executor_test_context ectx(executor_type::live, policy);
+
+	ectx.init();
+	ectx.delay(std::chrono::milliseconds(200));
+	ectx.finish();
+
+	// no regex search in log, so we test two substrings of the warning message
+	CHECK(test_utils::log_contains_substring(log_level::warn, "[executor] no progress for "));
+	CHECK(test_utils::log_contains_substring(log_level::warn, ", might be stuck. Active instructions: I"));
+}

--- a/test/instruction_graph_misc_tests.cc
+++ b/test/instruction_graph_misc_tests.cc
@@ -301,7 +301,7 @@ TEST_CASE("epochs serialize execution and compact dependency tracking", "[instru
 	ictx.master_node_host_task().name("consumer").read(buf, acc::all()).affect(ho).submit();
 	ictx.finish();
 
-	// this test is very explicit about each instuction in the graph - things might easily break when touching IDAG generation.
+	// this test is very explicit about each instruction in the graph - things might easily break when touching IDAG generation.
 	const auto all_instrs = ictx.query_instructions();
 
 	// we expect an init epoch + optional barrier epoch + shutdown epoch
@@ -383,7 +383,7 @@ TEST_CASE("horizon application serializes execution and compacts dependency trac
 	ictx.master_node_host_task().name("consumer").read(buf, acc::all()).affect(test_ho).affect(age_ho).submit();
 	ictx.finish();
 
-	// this test is very explicit about each instuction in the graph - things might easily break when touching IDAG generation.
+	// this test is very explicit about each instruction in the graph - things might easily break when touching IDAG generation.
 	const auto all_instrs = ictx.query_instructions();
 
 	const auto all_horizons = all_instrs.select_all<horizon_instruction_record>();

--- a/test/integration/run-integration-tests.py
+++ b/test/integration/run-integration-tests.py
@@ -21,7 +21,7 @@ def run_backend_discovery_and_copy_test(build_dir: str, backend: Optional[Litera
 
     # Run once without arguments to get list of available devices
     output = subprocess.check_output(exe).decode()
-    print("\nAvailable devices:\n", output)
+    print("\nAvailable devices:\n" + output)
     devices = [line.strip() for line in output.split("\n") if line.strip()]
 
     # Try to find a device for the backend as well as an unrelated device

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -239,6 +239,13 @@ const char* const expected_device_enumeration_warnings_regex =
     "Selected devices are of different type and/or do not belong to the same platform.*|No suitable platform found that can provide.*|No backend "
     "specialization available for selected platform.*|Selected platform .* is compatible with specialized .* backend, but it has not been compiled.*";
 
+const char* const expected_backend_fallback_warnings_regex =
+    "No common backend specialization available for all selected devices, falling back to .*\\. Performance may be degraded\\.|"
+    "All selected devices are compatible with specialized .* backend, but it has not been compiled\\. Performance may be degraded\\.";
+
+const char* const expected_dry_run_executor_warnings_regex = "Encountered a \"fence\" command while \"CELERITY_DRY_RUN_NODES\" is set. The result of this "
+                                                             "operation will not match the expected output of an actual run.";
+
 } // namespace celerity::test_utils_detail
 
 namespace celerity::test_utils {
@@ -280,6 +287,10 @@ runtime_fixture::~runtime_fixture() {
 }
 
 device_queue_fixture::~device_queue_fixture() { get_device_queue().get_sycl_queue().wait_and_throw(); }
+
+void allow_backend_fallback_warnings() { allow_higher_level_log_messages(spdlog::level::warn, test_utils_detail::expected_backend_fallback_warnings_regex); }
+
+void allow_dry_run_executor_warnings() { allow_higher_level_log_messages(spdlog::level::warn, test_utils_detail::expected_dry_run_executor_warnings_regex); }
 
 detail::device_queue& device_queue_fixture::get_device_queue() {
 	if(!m_dq) {


### PR DESCRIPTION
This PR adds the last major components necessary for the switch to IDAG scheduling.

Executors spawn their own thread which receives instructions and outbound pilots from the scheduler thread as well as runtime state such as user-provided allocation pointers through a `double_buffered_queue`.

The `executor` interface has two implementations, `live_executor` (for normal execution) and `dry_run_executor` for dry runs. The `live_executor` maintains the state persistent between instructions, such as memory allocations, but delegates all state management complexity to `out_of_order_engine` and `receive_arbiter`.

`backend` is an abstract interface for executing any operation that might touch backend-allocated memory. The interface itself is independent of SYCL, and the tie-in happens with the `sycl_backend` derived class. Backend specialization for CUDA nd-copies is achieved by instantiating either a `sycl_generic_backend` or a `sycl_cuda_backend`.

Most of the backend and executor code is covered by explicit unit tests, with the exception of issuing receive instructions (would be annoying to test, and is mostly covered by `receive_arbiter_tests` and bounds-checking messages (will be automatically covered by `runtime_tests` after the big switch).