### PR TITLE
Fix graph printing in TDAG / CDAG generation tests

### DIFF
--- a/test/dag_benchmarks.cc
+++ b/test/dag_benchmarks.cc
@@ -152,7 +152,7 @@ static constexpr instruction_graph_generator::policy_set benchmark_instruction_g
 struct task_manager_benchmark_context {
 	const size_t num_nodes = 1;
 	task_recorder trec;
-	task_manager tm{1, nullptr, test_utils::print_graphs ? &trec : nullptr, benchmark_task_manager_policy};
+	task_manager tm{1, nullptr, test_utils::g_print_graphs ? &trec : nullptr, benchmark_task_manager_policy};
 	test_utils::mock_buffer_factory mbf{tm};
 
 	task_manager_benchmark_context() = default;
@@ -179,10 +179,10 @@ struct command_graph_generator_benchmark_context {
 	command_graph cdag;
 	graph_serializer gser{[](command_pkg&&) {}};
 	task_recorder trec;
-	task_manager tm{num_nodes, nullptr, test_utils::print_graphs ? &trec : nullptr, benchmark_task_manager_policy};
+	task_manager tm{num_nodes, nullptr, test_utils::g_print_graphs ? &trec : nullptr, benchmark_task_manager_policy};
 	command_recorder crec;
 	distributed_graph_generator dggen{
-	    num_nodes, 0 /* local_nid */, cdag, tm, test_utils::print_graphs ? &crec : nullptr, benchmark_command_graph_generator_policy};
+	    num_nodes, 0 /* local_nid */, cdag, tm, test_utils::g_print_graphs ? &crec : nullptr, benchmark_command_graph_generator_policy};
 	test_utils::mock_buffer_factory mbf{tm, dggen};
 
 	explicit command_graph_generator_benchmark_context(const size_t num_nodes) : num_nodes(num_nodes) {
@@ -215,14 +215,14 @@ struct instruction_graph_generator_benchmark_context {
 	const size_t num_devices;
 	command_graph cdag;
 	task_recorder trec;
-	task_manager tm{num_nodes, nullptr /* host_queue */, test_utils::print_graphs ? &trec : nullptr, benchmark_task_manager_policy};
+	task_manager tm{num_nodes, nullptr /* host_queue */, test_utils::g_print_graphs ? &trec : nullptr, benchmark_task_manager_policy};
 	command_recorder crec;
 	distributed_graph_generator dggen{
-	    num_nodes, 0 /* local_nid */, cdag, tm, test_utils::print_graphs ? &crec : nullptr, benchmark_command_graph_generator_policy};
+	    num_nodes, 0 /* local_nid */, cdag, tm, test_utils::g_print_graphs ? &crec : nullptr, benchmark_command_graph_generator_policy};
 	instruction_recorder irec;
 	instruction_graph idag;
 	instruction_graph_generator iggen{tm, num_nodes, 0 /* local nid */, test_utils::make_system_info(num_devices, true /* allow d2d copies */), idag,
-	    nullptr /* delegate */, test_utils::print_graphs ? &irec : nullptr, benchmark_instruction_graph_generator_policy};
+	    nullptr /* delegate */, test_utils::g_print_graphs ? &irec : nullptr, benchmark_instruction_graph_generator_policy};
 	test_utils::mock_buffer_factory mbf{tm, dggen, iggen};
 
 	explicit instruction_graph_generator_benchmark_context(const size_t num_nodes, const size_t num_devices) : num_nodes(num_nodes), num_devices(num_devices) {

--- a/test/instruction_graph_test_utils.h
+++ b/test/instruction_graph_test_utils.h
@@ -507,7 +507,7 @@ class idag_test_context {
 	~idag_test_context() {
 		// instruction-graph-generator has no exception guarantees, so we must not call further member functions if one of them threw an exception
 		if(m_uncaught_exceptions_before == std::uncaught_exceptions()) { finish(); }
-		maybe_log_graphs();
+		maybe_print_graphs();
 	}
 
 	idag_test_context(const idag_test_context&) = delete;
@@ -693,14 +693,11 @@ class idag_test_context {
 		m_most_recently_built_horizon = current_horizon;
 	}
 
-	void maybe_log_graphs() {
-		if(test_utils::print_graphs) {
-			fmt::print("{}\n", std::string(79, '-'));
-			if(const auto capture = Catch::getCurrentContext().getResultCapture()) { fmt::print("DAGs for [{}]\n", capture->getCurrentTestName()); }
+	void maybe_print_graphs() {
+		if(test_utils::g_print_graphs) {
 			fmt::print("\n{}\n", print_task_graph());
 			fmt::print("\n{}\n", print_command_graph());
 			fmt::print("\n{}\n", print_instruction_graph());
-			fmt::print("\n{}\n\n", std::string(79, '-'));
 		}
 	}
 

--- a/test/test_main.cc
+++ b/test/test_main.cc
@@ -10,7 +10,7 @@ int main(int argc, char* argv[]) {
 	Catch::Session session;
 
 	using namespace Catch::Clara;
-	const auto cli = session.cli() | Opt(celerity::test_utils::print_graphs)["--print-graphs"]("print graphs (GraphViz)");
+	const auto cli = session.cli() | Opt(celerity::test_utils::g_print_graphs)["--print-graphs"]("print graphs (GraphViz)");
 
 	session.cli(cli);
 

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -291,6 +291,31 @@ detail::device_queue& device_queue_fixture::get_device_queue() {
 	return *m_dq;
 }
 
+bool g_print_graphs = false;
+
+std::string make_test_graph_title(const std::string& type) {
+	const auto test_name = Catch::getResultCapture().getCurrentTestName();
+	auto title = fmt::format("<br/>{}", type);
+	if(!test_name.empty()) { fmt::format_to(std::back_inserter(title), "<br/><b>{}</b>", test_name); }
+	return title;
+}
+
+std::string make_test_graph_title(const std::string& type, const size_t num_nodes, const detail::node_id local_nid) {
+	auto title = make_test_graph_title(type);
+	fmt::format_to(std::back_inserter(title), "<br/>for N{} out of {} nodes", local_nid, num_nodes);
+	return title;
+}
+
+std::string make_test_graph_title(const std::string& type, const size_t num_nodes, const detail::node_id local_nid, const size_t num_devices_per_node) {
+	auto title = make_test_graph_title(type, num_nodes, local_nid);
+	fmt::format_to(std::back_inserter(title), ", with {} devices / node", num_devices_per_node);
+	return title;
+}
+
+task_test_context::~task_test_context() {
+	if(g_print_graphs) { fmt::print("\n{}\n", detail::print_task_graph(trec, make_test_graph_title("Task Graph"))); }
+}
+
 } // namespace celerity::test_utils
 
 CATCH_REGISTER_LISTENER(celerity::test_utils_detail::global_setup_and_teardown);

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -390,15 +390,11 @@ namespace test_utils {
 	};
 
 	// Printing of graphs can be enabled using the "--print-graphs" command line flag
-	inline bool print_graphs = false;
+	extern bool g_print_graphs;
 
-	inline void maybe_print_task_graph(const detail::task_recorder& trec) {
-		if(print_graphs) { CELERITY_INFO("Task graph:\n\n{}\n", detail::print_task_graph(trec)); }
-	}
-
-	inline void maybe_print_command_graph(const detail::node_id local_nid, const detail::command_recorder& crec) {
-		if(print_graphs) { CELERITY_INFO("Command graph:\n\n{}\n", detail::print_command_graph(local_nid, crec)); }
-	}
+	std::string make_test_graph_title(const std::string& type);
+	std::string make_test_graph_title(const std::string& type, size_t num_nodes, detail::node_id local_nid);
+	std::string make_test_graph_title(const std::string& type, size_t num_nodes, detail::node_id local_nid, size_t num_devices_per_node);
 
 	struct task_test_context {
 		detail::task_recorder trec;
@@ -408,7 +404,11 @@ namespace test_utils {
 		mock_reduction_factory mrf;
 
 		explicit task_test_context(const detail::task_manager::policy_set& policy = {}) : tm(1, nullptr, &trec, policy), mbf(tm), mhof(tm) {}
-		~task_test_context() { maybe_print_task_graph(trec); }
+		task_test_context(const task_test_context&) = delete;
+		task_test_context(task_test_context&&) = delete;
+		task_test_context& operator=(const task_test_context&) = delete;
+		task_test_context& operator=(task_test_context&&) = delete;
+		~task_test_context();
 	};
 
 	// explicitly invoke a copy constructor without repeating the type


### PR DESCRIPTION
Previously with `--print-graphs`, dot graphs were written to the log inside TDAG / CDAG tests, but test logs are captured and discarded on success since #234, breaking this command-line option.

This PR updates TDAG / CDAG tests to write dot graphs to stdout like already done for IDAG tests. Test names are included in the dot title, and no additional context information is printed alongside. The user / developer is expected to invoke test executables with [render-graphs.py](https://github.com/celerity/celerity-debug-tools/blob/master/render-graphs.py).

While at it, I've taken the opportunity to rename `test_utils::print_graphs` to `g_print_graphs` to highlight that it's an unprotected global.