### PR TITLE
Fix out-of-bounds access in double_buffered_queue_tests

### DIFF
--- a/test/double_buffered_queue_tests.cc
+++ b/test/double_buffered_queue_tests.cc
@@ -67,7 +67,7 @@ TEST_CASE("double_buffered_queue provides ordered communication between threads"
 		for(;;) {
 			const auto& got = dbq.pop_all();
 			CHECK(std::is_sorted(got.begin(), got.end()));
-			if(got.back() == 3) break;
+			if(!got.empty() && got.back() == 3) break;
 		}
 
 		post_state(1);


### PR DESCRIPTION
Found by chance in an [ASan run](https://github.com/celerity/celerity-runtime/actions/runs/10140967533/job/28037265641): Calling `vector::back()` requires `!empty()`.