### PR TITLE
Improve coverage reporting of unreachable code

### DIFF
--- a/include/print_utils.h
+++ b/include/print_utils.h
@@ -5,6 +5,7 @@
 #include "intrusive_graph.h"
 #include "ranges.h"
 #include "types.h"
+#include "utils.h"
 
 #include <chrono>
 
@@ -177,7 +178,7 @@ struct fmt::formatter<celerity::detail::sycl_backend_type> : fmt::formatter<std:
 			switch(type) {
 			case celerity::detail::sycl_backend_type::generic: return "generic";
 			case celerity::detail::sycl_backend_type::cuda: return "CUDA";
-			default: abort();
+			default: celerity::detail::utils::unreachable(); // LCOV_EXCL_LINE
 			}
 		}();
 		return std::copy(repr.begin(), repr.end(), ctx.out());

--- a/include/range_mapper.h
+++ b/include/range_mapper.h
@@ -7,6 +7,7 @@
 #include <sycl/sycl.hpp>
 
 #include "ranges.h"
+#include "utils.h"
 
 namespace celerity {
 
@@ -70,7 +71,7 @@ namespace detail {
 		case 1: sr = invoke_range_mapper_for_kernel(fn, chunk_cast<1>(chunk), buffer_size); break;
 		case 2: sr = invoke_range_mapper_for_kernel(fn, chunk_cast<2>(chunk), buffer_size); break;
 		case 3: sr = invoke_range_mapper_for_kernel(fn, chunk_cast<3>(chunk), buffer_size); break;
-		default: assert(!"Unreachable"); return {};
+		default: utils::unreachable(); // LCOV_EXCL_LINE
 		}
 		return clamp_subrange_to_buffer_size(sr, buffer_size);
 	}

--- a/include/region_map.h
+++ b/include/region_map.h
@@ -13,6 +13,7 @@
 #include <matchbox.hh>
 
 #include "grid.h"
+#include "utils.h"
 
 // Some toggles that affect performance (but also change the behavior!)
 // TODO: Consider making these template arguments instead (inside some config object), and add these:
@@ -1262,7 +1263,7 @@ class region_map {
 		case 1: m_region_map.template emplace<region_map_impl<ValueType, 1>>(box_cast<1>(extent), default_value); break;
 		case 2: m_region_map.template emplace<region_map_impl<ValueType, 2>>(box_cast<2>(extent), default_value); break;
 		case 3: m_region_map.template emplace<region_map_impl<ValueType, 3>>(box_cast<3>(extent), default_value); break;
-		default: assert(false);
+		default: utils::unreachable(); // LCOV_EXCL_LINE
 		}
 	}
 
@@ -1286,7 +1287,7 @@ class region_map {
 		case 1: get_map<1>().update_box(box_cast<1>(box), value); break;
 		case 2: get_map<2>().update_box(box_cast<2>(box), value); break;
 		case 3: get_map<3>().update_box(box_cast<3>(box), value); break;
-		default: assert(false);
+		default: utils::unreachable(); // LCOV_EXCL_LINE
 		}
 	}
 
@@ -1336,7 +1337,7 @@ class region_map {
 		case 3: {
 			results = get_map<3>().get_region_values(box_cast<3>(request));
 		} break;
-		default: assert(false);
+		default: utils::unreachable(); // LCOV_EXCL_LINE
 		}
 		return results;
 	}
@@ -1353,7 +1354,7 @@ class region_map {
 		case 1: get_map<1>().apply_to_values(f); break;
 		case 2: get_map<2>().apply_to_values(f); break;
 		case 3: get_map<3>().apply_to_values(f); break;
-		default: assert(false);
+		default: utils::unreachable(); // LCOV_EXCL_LINE
 		}
 	}
 

--- a/include/task.h
+++ b/include/task.h
@@ -137,7 +137,7 @@ namespace detail {
 			case task_type::master_node: return execution_target::host;
 			case task_type::horizon:
 			case task_type::fence: return execution_target::none;
-			default: assert(!"Unhandled task type"); return execution_target::none;
+			default: utils::unreachable(); // LCOV_EXCL_LINE
 			}
 		}
 

--- a/src/grid.cc
+++ b/src/grid.cc
@@ -1,4 +1,5 @@
 #include "grid.h"
+#include "utils.h"
 
 namespace celerity::detail::grid_detail {
 
@@ -260,7 +261,7 @@ decltype(auto) dispatch_effective_dims(int effective_dims, F&& f) {
 	case 1: if constexpr(StorageDims >= 1) { return f(std::integral_constant<int, 1>()); } [[fallthrough]];
 	case 2: if constexpr(StorageDims >= 2) { return f(std::integral_constant<int, 2>()); } [[fallthrough]];
 	case 3: if constexpr(StorageDims >= 3) { return f(std::integral_constant<int, 3>()); } [[fallthrough]];
-	default: abort(); // unreachable with the explicit instantiations in this file
+	default: utils::unreachable(); // with the explicit instantiations in this file - LCOV_EXCL_LINE
 	}
 	// clang-format on
 }

--- a/src/out_of_order_engine.cc
+++ b/src/out_of_order_engine.cc
@@ -135,7 +135,7 @@ target_state& engine_impl::get_target_state(const target tgt, const std::optiona
 	switch(tgt) {
 	case target::host_queue: assert(!device.has_value()); return host_queue_target_state;
 	case target::device_queue: assert(device.has_value()); return device_queue_target_states[*device];
-	default: utils::unreachable();
+	default: utils::unreachable(); // LCOV_EXCL_LINE
 	}
 }
 

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -104,7 +104,7 @@ const char* print_epoch_label(epoch_action action) {
 	case epoch_action::none: return "<b>epoch</b>";
 	case epoch_action::barrier: return "<b>epoch</b> (barrier)";
 	case epoch_action::shutdown: return "<b>epoch</b> (shutdown)";
-	default: abort();
+	default: utils::unreachable(); // LCOV_EXCL_LINE
 	}
 }
 
@@ -147,7 +147,7 @@ std::string get_command_label(const node_id local_nid, const command_record& cmd
 	case command_type::fence: {
 		label += "<b>fence</b>";
 	} break;
-	default: assert(!"Unkown command"); label += "<b>unknown</b>";
+	default: utils::unreachable(); // LCOV_EXCL_LINE
 	}
 
 	if(cmd.task_id.has_value() && cmd.task_geometry.has_value()) {
@@ -250,7 +250,7 @@ std::string instruction_dependency_style(const instruction_dependency_origin ori
 	case instruction_dependency_origin::last_epoch: return "color=orchid";
 	case instruction_dependency_origin::execution_front: return "color=orange";
 	case instruction_dependency_origin::split_receive: return "color=gray";
-	default: abort();
+	default: utils::unreachable(); // LCOV_EXCL_LINE
 	}
 }
 

--- a/src/task.cc
+++ b/src/task.cc
@@ -30,7 +30,7 @@ namespace detail {
 		case 1: return subrange_cast<3>(rm->map_1(chnk));
 		case 2: return subrange_cast<3>(rm->map_2(chnk));
 		case 3: return rm->map_3(chnk);
-		default: assert(false); return subrange<3>{};
+		default: utils::unreachable(); // LCOV_EXCL_LINE
 		}
 	}
 
@@ -40,7 +40,7 @@ namespace detail {
 		case 1: return apply_range_mapper<1>(rm, chunk_cast<1>(chnk));
 		case 2: return apply_range_mapper<2>(rm, chunk_cast<2>(chnk));
 		case 3: return apply_range_mapper<3>(rm, chunk_cast<3>(chnk));
-		default: assert(!"Unreachable"); return subrange<3>{};
+		default: utils::unreachable(); // LCOV_EXCL_LINE
 		}
 	}
 

--- a/test/executor_tests.cc
+++ b/test/executor_tests.cc
@@ -300,6 +300,7 @@ struct Catch::StringMaker<executor_type> {
 		switch(value) {
 		case executor_type::dry_run: return "dry_run";
 		case executor_type::live: return "live";
+		default: utils::unreachable();
 		}
 	}
 };

--- a/test/receive_arbiter_tests.cc
+++ b/test/receive_arbiter_tests.cc
@@ -100,7 +100,7 @@ struct Catch::StringMaker<receive_event> {
 		case receive_event::call_to_receive: return fmt::format("call_to_receive[{}]", event.which);
 		case receive_event::incoming_pilot: return fmt::format("incoming_pilot[{}]", event.which);
 		case receive_event::incoming_data: return fmt::format("incoming_data[{}]", event.which);
-		default: abort();
+		default: utils::unreachable();
 		}
 	}
 };
@@ -132,7 +132,7 @@ std::vector<std::vector<receive_event>> enumerate_all_event_orders(
 		for(size_t i = 0; i < current_permutation.size(); ++i) {
 			if(current_permutation[i].transition == event.transition && current_permutation[i].which == event.which) return i;
 		}
-		abort();
+		utils::unreachable();
 	};
 
 	// collect all legal permutations (i.e. pilots are received before data, and calls to receive() also happen before receiving data)

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -182,7 +182,7 @@ namespace detail {
 		case mode::discard_write: mb.template get_access<mode::discard_write>(handler, rmfn); break;
 		case mode::discard_read_write: mb.template get_access<mode::discard_read_write>(handler, rmfn); break;
 		case mode::atomic: mb.template get_access<mode::atomic>(handler, rmfn); break;
-		default: assert(false);
+		default: utils::unreachable(); // LCOV_EXCL_LINE
 		}
 	}
 


### PR DESCRIPTION
There's currently no standard way to tell LCOV to ignore certain lines, such as those only containing a call to `abort`. This PR makes coverage reporting more faithful by manually excluding all such lines that are unreachable from tests since they unconditionally abort the process.

I've used the opportunity to replace some explicit calls to `abort` inside enum-switches with `utils::unreachable` to clarify the intent.