### PR TITLE
Fix executor-scheduler race between instruction retirement and pruning

### DIFF
--- a/include/out_of_order_engine.h
+++ b/include/out_of_order_engine.h
@@ -77,7 +77,7 @@ class out_of_order_engine {
 
 	/// Call once an instruction that was previously returned from `assign_one` has completed synchronously or asynchronously. For simplicity it is permitted
 	/// to mark assigned instructions as completed in any order, even if that would violate internal dependency order.
-	void complete_assigned(const instruction* instr);
+	void complete_assigned(const instruction_id iid);
 
   private:
 	std::unique_ptr<out_of_order_engine_detail::engine_impl> m_impl;

--- a/test/out_of_order_engine_tests.cc
+++ b/test/out_of_order_engine_tests.cc
@@ -138,7 +138,7 @@ class out_of_order_test_context {
 		return create<epoch_instruction>(dependencies, priority, task_id(0), epoch_action::none, instruction_garbage{});
 	}
 
-	void complete(const instruction* instr) { m_engine.complete_assigned(instr); }
+	void complete(const instruction* instr) { m_engine.complete_assigned(instr->get_id()); }
 
 	std::optional<out_of_order_engine::assignment> assign_one() {
 		const auto assignment = m_engine.assign_one();


### PR DESCRIPTION
`live_executor` previously dereferenced instruction pointers on retirement, which raced with their deletion on IDAG pruning when the executing instruction was an horizon or epoch. To avoid future similar issues, we now strictly regard the pointer to any instruction that has been issued as dangling and work with instruction ids instead in those cases.

`out_of_order_engine` also had potentially hazardous uses of instruction pointers that might - under the right circumstances - incorrectly regard two instruction as identical when their pointers happen to alias as the old one being freed before the new one was allocated in the same memory location.