### PR TITLE
Shutdown runtime `atexit()`, introduce `celerity::queue` , deprecate `distr_queue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Support builds for single-node multi-device setups without MPI by specifying `-DCELERITY_ENABLE_MPI=0` in CMake (#282)
 - Add `celerity::once` tag type for host tasks (equivalent to `range<0>{}`) as a replacement for `on_master_node` (#282)
+- Replaces `celerity::distr_queue` with `celerity::queue`, which permits multiple instances and aligns closer with SYCL (#283)
+- The runtime can be explicitly shut down using `celerity::shutdown()`, complementing `celerity::init()` (#283)
+
+### Changed
+
+- Automatic runtime shutdown, which was previously triggered by the last queue / buffer / host object going out of scope,
+  is now postponed until process termination (`atexit()`). This allows multiple non-overlapping sections of Celerity code
+  to execute in the same process (#283)
+- Celerity warns when on excessive calls to `queue::wait()` or `distr_queue::slow_full_sync()` in a long running program.
+  This operation has a much more pronounced performance penalty than its SYCL counterpart (#283)
+
+### Fixed
+
+- Host-initialized buffers will not read from user-provided memory after the last reference to the buffer has been dropped (#283)
+
+### Deprecated
+
+- `celerity::distr_queue` is deprecated in favor of `celerity::queue` (#283)
 
 ## [0.6.0] - 2024-08-12
 

--- a/docs/host-tasks.md
+++ b/docs/host-tasks.md
@@ -26,7 +26,7 @@ when constructing an accessor, a `fixed` or `all` range mapper is used to specif
 the `*_host_task` selector must be used for selecting the access mode.
 
 ```cpp
-celerity::distr_queue q;
+celerity::queue q;
 celerity::buffer<float, 1> result;
 q.submit([&](celerity::handler &cgh) {
 	celerity::accessor acc{buffer, cgh, celerity::access::all{},
@@ -62,7 +62,7 @@ computations, ther host kernel will receive _partitions_ of the iteration space.
 this node receives:
 
 ```cpp
-celerity::distr_queue q;
+celerity::queue q;
 q.submit([&](celerity::handler &cgh) {
     cgh.host_task(celerity::range<1>(100), [=](celerity::partition<1> part) {
         printf("This node received %zu items\n", part.get_subrange().range[0]);
@@ -101,7 +101,7 @@ participating nodes, and the single-element subrange on each node is the node in
 `collective_partition` provides access to the MPI communicator for this task:
 
 ```cpp
-celerity::distr_queue q;
+celerity::queue q;
 q.submit([](celerity::handler &cgh) {
     cgh.host_task(celerity::experimental::collective,
             [](celerity::experimental::collective_partition> part) {
@@ -122,7 +122,7 @@ must neither be run concurrently nor be reordered on one node. In case there are
 operations eligible to be run concurrently, Celerity can be notified of this by using _collective groups_:
 
 ```cpp
-celerity::distr_queue q;
+celerity::queue q;
 celerity::experimental::collective_group first_group;
 celerity::experimental::collective_group second_group;
 q.submit([&](celerity::handler &cgh) {
@@ -149,7 +149,7 @@ splitting them along the first (slowest) dimension into contiguous memory portio
 `celerity::accessor::get_allocation_window` can then be used to retrieve the host-local chunk of the buffer:
 
 ```cpp
-celerity::distr_queue q;
+celerity::queue q;
 celerity::buffer<float, 2> buf;
 q.submit([&](celerity::handler& cgh) {
 	celerity::accessor acc{buffer, cgh,

--- a/docs/issues-and-limitations.md
+++ b/docs/issues-and-limitations.md
@@ -26,7 +26,7 @@ example, the branching decision can be made using a [reduction](reductions.md)
 and then observed on the application thread on a `fence`:
 
 ```cpp
-celerity::distr_queue q;
+celerity::queue q;
 celerity::buffer<float, 0> error;
 for (;;) {
     q.submit([&](celerity::handler& cgh) {

--- a/docs/reductions.md
+++ b/docs/reductions.md
@@ -10,7 +10,7 @@ Celerity implements cluster-wide reductions in the spirit of
 The following distributed program computes the sum from 0 to 999 in `sum_buf` using a reduction:
 
 ```c++
-celerity::distr_queue q;
+celerity::queue q;
 celerity::buffer<size_t, 1> sum_buf{{1}};
 q.submit([&](celerity::handler& cgh) {
     auto rd = celerity::reduction(sum_buf, cgh, sycl::plus<size_t>{},

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -100,7 +100,7 @@ uint8_t* img_data = stbi_load(argv[1], &img_width, &img_height, nullptr, 1);
 celerity::buffer<uint8_t, 2> input_buf(img_data, celerity::range<2>(img_height, img_width));
 stbi_image_free(img_data);
 celerity::buffer<uint8_t, 2> edge_buf(celerity::range<2>(img_height, img_width));
-celerity::distr_queue queue;
+celerity::queue queue;
 ...
 ```
 

--- a/examples/convolution/convolution.cc
+++ b/examples/convolution/convolution.cc
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
-	celerity::distr_queue queue;
+	celerity::queue queue;
 
 	celerity::buffer<sycl::float3, 2> image_input_buf(image_input.data(), celerity::range<2>(image_height, image_width));
 	celerity::buffer<sycl::float3, 2> image_tmp_buf(celerity::range<2>(image_height, image_width));

--- a/examples/distr_io/distr_io.cc
+++ b/examples/distr_io/distr_io.cc
@@ -27,7 +27,7 @@ static std::pair<hid_t, hid_t> allocation_window_to_dataspace(const celerity::bu
 }
 
 
-static void read_hdf5_file(celerity::distr_queue& q, celerity::buffer<float, 2>& buffer, const char* file_name) {
+static void read_hdf5_file(celerity::queue& q, celerity::buffer<float, 2>& buffer, const char* file_name) {
 	q.submit([&](celerity::handler& cgh) {
 		celerity::accessor a{buffer, cgh, celerity::experimental::access::even_split<2>{}, celerity::write_only_host_task, celerity::no_init};
 		cgh.host_task(celerity::experimental::collective, [=](celerity::experimental::collective_partition part) {
@@ -54,7 +54,7 @@ static void read_hdf5_file(celerity::distr_queue& q, celerity::buffer<float, 2>&
 }
 
 
-static void write_hdf5_file(celerity::distr_queue& q, celerity::buffer<float, 2>& buffer, const char* file_name) {
+static void write_hdf5_file(celerity::queue& q, celerity::buffer<float, 2>& buffer, const char* file_name) {
 	q.submit([&](celerity::handler& cgh) {
 		celerity::accessor a{buffer, cgh, celerity::experimental::access::even_split<2>{}, celerity::read_only_host_task};
 		cgh.host_task(celerity::experimental::collective, [=](celerity::experimental::collective_partition part) {
@@ -103,7 +103,7 @@ int main(int argc, char* argv[]) {
 		std::generate(initial.begin(), initial.end(), [&] { return dist(gen); });
 		celerity::buffer<float, 2> out(initial.data(), celerity::range<2>{N, N});
 
-		celerity::distr_queue q;
+		celerity::queue q;
 		write_hdf5_file(q, out, argv[2]);
 		return EXIT_SUCCESS;
 	}
@@ -112,7 +112,7 @@ int main(int argc, char* argv[]) {
 		celerity::buffer<float, 2> in(celerity::range<2>{N, N});
 		celerity::buffer<float, 2> out(celerity::range<2>{N, N});
 
-		celerity::distr_queue q;
+		celerity::queue q;
 
 		read_hdf5_file(q, in, argv[2]);
 
@@ -130,7 +130,7 @@ int main(int argc, char* argv[]) {
 	}
 
 	if(argc == 4 && strcmp(argv[1], "--compare") == 0) {
-		celerity::distr_queue q;
+		celerity::queue q;
 
 		celerity::buffer<float, 2> left(celerity::range<2>{N, N});
 		celerity::buffer<float, 2> right(celerity::range<2>{N, N});

--- a/examples/hello_world/hello_world.cc
+++ b/examples/hello_world/hello_world.cc
@@ -6,7 +6,7 @@
 int main() {
 	const std::string input_str = "Ifmmp!Xpsme\"\x01";
 
-	celerity::distr_queue queue;
+	celerity::queue queue;
 	celerity::buffer<char> str_buffer(input_str.data(), input_str.size());
 
 	queue.submit([&](celerity::handler& cgh) {

--- a/examples/matmul/matmul.cc
+++ b/examples/matmul/matmul.cc
@@ -9,7 +9,7 @@ const size_t MAT_SIZE = 1024;
 #endif
 
 template <typename T>
-void set_identity(celerity::distr_queue queue, celerity::buffer<T, 2> mat, bool reverse) {
+void set_identity(celerity::queue queue, celerity::buffer<T, 2> mat, bool reverse) {
 	queue.submit([&](celerity::handler& cgh) {
 		celerity::accessor dw{mat, cgh, celerity::access::one_to_one{}, celerity::write_only, celerity::no_init};
 		const auto range = mat.get_range();
@@ -26,7 +26,7 @@ void set_identity(celerity::distr_queue queue, celerity::buffer<T, 2> mat, bool 
 }
 
 template <typename T>
-void multiply(celerity::distr_queue queue, celerity::buffer<T, 2> mat_a, celerity::buffer<T, 2> mat_b, celerity::buffer<T, 2> mat_c) {
+void multiply(celerity::queue queue, celerity::buffer<T, 2> mat_a, celerity::buffer<T, 2> mat_b, celerity::buffer<T, 2> mat_c) {
 	queue.submit([&](celerity::handler& cgh) {
 		celerity::accessor a{mat_a, cgh, celerity::access::slice<2>(1), celerity::read_only};
 		celerity::accessor b{mat_b, cgh, celerity::access::slice<2>(0), celerity::read_only};
@@ -61,7 +61,7 @@ void multiply(celerity::distr_queue queue, celerity::buffer<T, 2> mat_a, celerit
 
 // TODO this should really reduce into a buffer<bool> on the device, but not all backends currently support reductions
 template <typename T>
-void verify(celerity::distr_queue& queue, celerity::buffer<T, 2> mat_c, celerity::experimental::host_object<bool> passed_obj) {
+void verify(celerity::queue& queue, celerity::buffer<T, 2> mat_c, celerity::experimental::host_object<bool> passed_obj) {
 	queue.submit([&](celerity::handler& cgh) {
 		celerity::accessor c{mat_c, cgh, celerity::access::one_to_one{}, celerity::read_only_host_task};
 		celerity::experimental::side_effect passed{passed_obj, cgh};
@@ -86,7 +86,7 @@ void verify(celerity::distr_queue& queue, celerity::buffer<T, 2> mat_c, celerity
 }
 
 int main() {
-	celerity::distr_queue queue;
+	celerity::queue queue;
 
 	const auto range = celerity::range<2>(MAT_SIZE, MAT_SIZE);
 	celerity::buffer<float, 2> mat_a_buf(range);

--- a/examples/reduction/reduction.cc
+++ b/examples/reduction/reduction.cc
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
 	std::unique_ptr<uint8_t, decltype((stbi_image_free))> srgb_255_data{stbi_load(argv[1], &image_width, &image_height, &image_channels, 4), stbi_image_free};
 	assert(srgb_255_data != nullptr);
 
-	celerity::distr_queue q;
+	celerity::queue q;
 
 	celerity::range<2> image_size{static_cast<size_t>(image_height), static_cast<size_t>(image_width)};
 	celerity::buffer<sycl::uchar4, 2> srgb_255_buf{reinterpret_cast<const sycl::uchar4*>(srgb_255_data.get()), image_size};

--- a/examples/syncing/syncing.cc
+++ b/examples/syncing/syncing.cc
@@ -5,7 +5,7 @@
 int main(int argc, char* argv[]) {
 	constexpr size_t buf_size = 512;
 
-	celerity::distr_queue queue;
+	celerity::queue queue;
 	celerity::buffer<size_t, 1> buf(buf_size);
 
 	// Initialize buffer in a distributed device kernel
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
 	});
 
 	// Wait until both tasks have completed
-	queue.slow_full_sync();
+	queue.wait();
 
 	// At this point we can safely interact with host_buf from within the main thread
 	bool valid = true;

--- a/include/celerity.h
+++ b/include/celerity.h
@@ -6,8 +6,8 @@
 #include "buffer.h"
 #include "debug.h"
 #include "distr_queue.h"
-#include "fence.h"
 #include "host_utils.h"
+#include "queue.h"
 #include "side_effect.h"
 #include "version.h"
 

--- a/include/celerity.h
+++ b/include/celerity.h
@@ -13,6 +13,7 @@
 
 namespace celerity {
 namespace runtime {
+
 	/**
 	 * @brief Initializes the Celerity runtime.
 	 */
@@ -33,5 +34,15 @@ namespace runtime {
 	 *                        If there are multiple nodes running on the same host, the selector must be the same across nodes on the same host.
 	 */
 	inline void init(int* argc, char** argv[], const detail::device_selector& device_selector) { detail::runtime::init(argc, argv, device_selector); }
+
+	/**
+	 * @brief Manually shuts down the Celerity runtime if it has previously been initialized.
+	 *
+	 * No Celerity object (buffer, queue or host_object) must be live when calling this function, and the runtime cannot be re-initialized afterwards.
+	 *
+	 * Shutdown is also performed automatically on application exit.
+	 */
+	inline void shutdown() { detail::runtime::shutdown(); }
+
 } // namespace runtime
 } // namespace celerity

--- a/include/queue.h
+++ b/include/queue.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <future>
+#include <memory>
+
+#include "fence.h"
+#include "runtime.h"
+#include "tracy.h"
+
+namespace celerity {
+
+class queue {
+  public:
+	/// Constructs a queue which distributes work across all devices associated with the runtime.
+	///
+	/// To manually select a subset of devices in the system, call `runtime::init` with an appropriate selector before constructing the first Celerity object.
+	queue() : m_tracker(std::make_shared<tracker>()) {}
+
+	/// Submits a command group to the queue.
+	template <typename CGF>
+	void submit(CGF cgf) { // NOLINT(readability-convert-member-functions-to-static)
+		// (Note while this function could be made static, it must not be! Otherwise we can't be sure the runtime has been initialized.)
+		CELERITY_DETAIL_TRACY_ZONE_SCOPED("queue::submit", Orange3);
+		[[maybe_unused]] const auto tid = detail::runtime::get_instance().get_task_manager().submit_command_group(std::move(cgf));
+		CELERITY_DETAIL_TRACY_ZONE_NAME("T{} submit", tid);
+	}
+
+	/// Waits for all tasks submitted to the queue to complete.
+	///
+	/// Since waiting will stall the scheduling of more work, this should be used sparingly - more so than on a single-node SYCL program.
+	void wait() { // NOLINT(readability-convert-member-functions-to-static)
+		CELERITY_DETAIL_TRACY_ZONE_SCOPED("queue::wait", Red2);
+		[[maybe_unused]] const auto tid = detail::runtime::get_instance().sync(detail::epoch_action::none);
+		CELERITY_DETAIL_TRACY_ZONE_NAME("T{} wait", tid);
+	}
+
+	/**
+	 * Asynchronously captures the value of a host object by copy, introducing the same dependencies as a side-effect would.
+	 *
+	 * Waiting on the returned future in the application thread can stall scheduling of more work. To hide latency, either submit more command groups between
+	 * fence and wait operations or ensure that other independent command groups are eligible to run while the fence is executed.
+	 */
+	template <typename T>
+	[[nodiscard]] std::future<T> fence(const experimental::host_object<T>& obj) {
+		return detail::fence(obj);
+	}
+
+	/**
+	 * Asynchronously captures the contents of a buffer subrange, introducing the same dependencies as a read-accessor would.
+	 *
+	 * Waiting on the returned future in the application thread can stall scheduling of more work. To hide latency, either submit more command groups between
+	 * fence and wait operations or ensure that other independent command groups are eligible to run while the fence is executed.
+	 */
+	template <typename DataT, int Dims>
+	[[nodiscard]] std::future<buffer_snapshot<DataT, Dims>> fence(const buffer<DataT, Dims>& buf, const subrange<Dims>& sr) {
+		return detail::fence(buf, sr);
+	}
+
+	/**
+	 * Asynchronously captures the contents of an entire buffer, introducing the same dependencies as a read-accessor would.
+	 *
+	 * Waiting on the returned future in the application thread can stall scheduling of more work. To hide latency, either submit more command groups between
+	 * fence and wait operations or ensure that other independent command groups are eligible to run while the fence is executed.
+	 */
+	template <typename DataT, int Dims>
+	[[nodiscard]] std::future<buffer_snapshot<DataT, Dims>> fence(const buffer<DataT, Dims>& buf) {
+		return detail::fence(buf, {{}, buf.get_range()});
+	}
+
+  private:
+	/// A `tacker` instance is shared by all copies of this `queue` via a `std::shared_ptr` to implement (SYCL) reference semantics.
+	/// It notifies the runtime of queue creation and destruction, which might trigger runtime initialization if it is the first such object.
+	struct tracker {
+		tracker() {
+			CELERITY_DETAIL_TRACY_ZONE_SCOPED("queue::queue", DarkSlateBlue);
+			if(!detail::runtime::has_instance()) { detail::runtime::init(nullptr, nullptr, detail::auto_select_devices{}); }
+			detail::runtime::get_instance().create_queue();
+		}
+
+		tracker(const tracker&) = delete;
+		tracker(tracker&&) = delete;
+		tracker& operator=(const tracker&) = delete;
+		tracker& operator=(tracker&&) = delete;
+
+		~tracker() {
+			CELERITY_DETAIL_TRACY_ZONE_SCOPED("queue::~queue", DarkCyan);
+
+			detail::runtime::get_instance().destroy_queue();
+
+			// ~queue() guarantees that all operations on that particular queue have finished executing, which we simply guarantee by waiting on all operations
+			// on all live queues.
+			if(detail::runtime::has_instance()) { detail::runtime::get_instance().sync(detail::epoch_action::none); }
+		}
+	};
+
+	std::shared_ptr<tracker> m_tracker;
+};
+
+} // namespace celerity

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -87,7 +87,7 @@ namespace detail {
 		size_t m_num_local_devices = 0;
 
 		// track all instances of celerity::distr_queue, celerity::buffer and celerity::host_object to know when to destroy s_instance
-		bool m_has_live_queue = false;
+		size_t m_num_live_queues = 0;
 		std::unordered_set<buffer_id> m_live_buffers;
 		std::unordered_set<host_object_id> m_live_host_objects;
 

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -30,6 +30,8 @@ namespace detail {
 
 		static bool has_instance() { return s_instance != nullptr; }
 
+		static void shutdown();
+
 		static runtime& get_instance();
 
 		runtime(const runtime&) = delete;
@@ -120,11 +122,6 @@ namespace detail {
 
 		/// True when no buffers, host objects or queues are live that keep the runtime alive.
 		bool is_unreferenced() const;
-
-		/**
-		 * @brief Destroys the runtime if it is no longer active and all buffers and host objects have been unregistered.
-		 */
-		static void destroy_instance_if_unreferenced();
 
 		// ------------------------------------------ TESTING UTILS ------------------------------------------
 		// We have to jump through some hoops to be able to re-initialize the runtime for unit testing.

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -86,7 +86,7 @@ namespace detail {
 		node_id m_local_nid = 0;
 		size_t m_num_local_devices = 0;
 
-		// track all instances of celerity::distr_queue, celerity::buffer and celerity::host_object to know when to destroy s_instance
+		// track all instances of celerity::queue, celerity::buffer and celerity::host_object to sanity-check runtime destruction
 		size_t m_num_live_queues = 0;
 		std::unordered_set<buffer_id> m_live_buffers;
 		std::unordered_set<host_object_id> m_live_host_objects;

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -88,6 +88,7 @@ namespace detail {
 
 			if(need_new_horizon()) { generate_horizon_task(); }
 
+			++m_num_user_command_groups_submitted;
 			return tid;
 		}
 
@@ -238,6 +239,10 @@ namespace detail {
 
 		// The last epoch task that has been processed by the executor. Behind a monitor to allow awaiting this change from the main thread.
 		epoch_monitor m_latest_epoch_reached{initial_epoch_task};
+
+		// Track the number of user-generated task and epochs to heuristically detect programs that lose performance by frequently calling `queue::wait()`.
+		size_t m_num_user_command_groups_submitted = 0;
+		size_t m_num_user_epochs_generated = 0;
 
 		// Set of tasks with no dependents
 		std::unordered_set<task*> m_execution_front;

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -282,7 +282,7 @@ namespace detail {
 
 	void runtime::require_call_from_application_thread() const {
 		if(std::this_thread::get_id() != m_application_thread) {
-			utils::panic("Celerity runtime, distr_queue, handler, buffer and host_object types must only be constructed, used, and destroyed from the "
+			utils::panic("Celerity runtime, queue, handler, buffer and host_object types must only be constructed, used, and destroyed from the "
 			             "application thread. Make sure that you did not accidentally capture one of these types in a host_task.");
 		}
 	}
@@ -291,7 +291,7 @@ namespace detail {
 		// LCOV_EXCL_START
 		if(!is_unreferenced()) {
 			// this call might originate from static destruction - we cannot assume spdlog to still be around
-			utils::panic("Detected an attempt to destroy runtime while at least one distr_queue, buffer or host_object was still alive. This likely means "
+			utils::panic("Detected an attempt to destroy runtime while at least one queue, buffer or host_object was still alive. This likely means "
 			             "that one of these objects was leaked, or at least its lifetime extended beyond the scope of main(). This is undefined.");
 		}
 		// LCOV_EXCL_STOP

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -427,16 +427,14 @@ namespace detail {
 
 	void runtime::create_queue() {
 		require_call_from_application_thread();
-
-		if(m_has_live_queue) { throw std::runtime_error("Only one celerity::distr_queue can be created per process (but it can be copied!)"); }
-		m_has_live_queue = true;
+		++m_num_live_queues;
 	}
 
 	void runtime::destroy_queue() {
 		require_call_from_application_thread();
 
-		assert(m_has_live_queue);
-		m_has_live_queue = false;
+		assert(m_num_live_queues > 0);
+		--m_num_live_queues;
 	}
 
 	allocation_id runtime::create_user_allocation(void* const ptr) {
@@ -503,7 +501,7 @@ namespace detail {
 		return rid;
 	}
 
-	bool runtime::is_unreferenced() const { return !m_has_live_queue && m_live_buffers.empty() && m_live_host_objects.empty(); }
+	bool runtime::is_unreferenced() const { return m_num_live_queues == 0 && m_live_buffers.empty() && m_live_host_objects.empty(); }
 
 } // namespace detail
 } // namespace celerity

--- a/test/instruction_graph_misc_tests.cc
+++ b/test/instruction_graph_misc_tests.cc
@@ -323,7 +323,7 @@ TEST_CASE("epochs serialize execution and compact dependency tracking", "[instru
 
 	const auto all_producers = all_instrs.select_all("producer");
 
-	// the barrier epoch (aka slow_full_sync) will transitively depend on all previous instructions
+	// the barrier epoch, aka queue::wait(experimental::barrier) or distr_queue::slow_full_sync(), will transitively depend on all previous instructions
 	const auto barrier_epoch = all_instrs.select_unique<epoch_instruction_record>(barrier_epoch_tid.value());
 	CHECK(barrier_epoch->epoch_action == epoch_action::barrier);
 	CHECK(barrier_epoch.transitive_predecessors() == union_of(init_epoch, all_device_allocs, all_producers));

--- a/test/integration/backend.cc
+++ b/test/integration/backend.cc
@@ -39,7 +39,7 @@ template <typename T, int Dims>
 struct kernel_name {};
 
 template <int Dims>
-void test_copy(celerity::distr_queue& q) {
+void test_copy(celerity::queue& q) {
 	celerity::buffer<size_t, Dims> buf(truncate_range<Dims>({5, 7, 9}));
 
 	// Initialize on device
@@ -111,8 +111,9 @@ int main(int argc, char* argv[]) {
 	}
 
 	const auto device_idx = std::atoi(argv[1]);
-	celerity::distr_queue q{{all_devices[device_idx]}};
+	celerity::runtime::init(&argc, &argv, {all_devices[device_idx]});
 
+	celerity::queue q;
 	test_copy<1>(q);
 	test_copy<2>(q);
 	test_copy<3>(q);

--- a/test/print_graph_tests.cc
+++ b/test/print_graph_tests.cc
@@ -250,7 +250,7 @@ TEST_CASE("instruction-graph printing is unchanged", "[print_graph][instruction-
 TEST_CASE_METHOD(test_utils::runtime_fixture, "buffer debug names show up in the generated graph", "[print_graph]") {
 	env::scoped_test_environment tenv(print_graphs_env_setting);
 
-	distr_queue q;
+	queue q;
 	celerity::range<1> range(16);
 	celerity::buffer<int, 1> buff_a(range);
 	std::string buff_name{"my_buffer"};
@@ -263,7 +263,7 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "buffer debug names show up in the
 	});
 
 	// wait for commands to be generated in the scheduler thread
-	q.slow_full_sync();
+	q.wait();
 
 	using Catch::Matchers::ContainsSubstring;
 	const std::string expected_substring = "B0 \"my_buffer\"";
@@ -280,7 +280,7 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "buffer debug names show up in the
 TEST_CASE_METHOD(test_utils::runtime_fixture, "full graph is printed if CELERITY_PRINT_GRAPHS is set", "[print_graph]") {
 	env::scoped_test_environment tenv(print_graphs_env_setting);
 
-	distr_queue q;
+	queue q;
 	celerity::range<1> range(16);
 	std::vector<int> init(range.size());
 	celerity::buffer<int, 1> buff_a(init.data(), range);
@@ -297,7 +297,7 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "full graph is printed if CELERITY
 		});
 	}
 
-	q.slow_full_sync();
+	q.wait();
 
 	// Smoke test: It is valid for the dot output to change with updates to graph generation. If this test fails, verify that the printed graphs are sane and
 	// complete, and if so, replace the `expected` values with the new dot graph.
@@ -332,7 +332,7 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "full graph is printed if CELERITY
 		    "color=\"#606060\">T5 (host-compute)</font>>;color=darkgray;id_0_5[label=<C5 on N0<br/><b>execution</b> [0,0,0] + [16,1,1]<br/><i>read_write</i> "
 		    "B0 {[0,0,0] - [16,1,1]}> fontcolor=black shape=box];}subgraph cluster_id_0_6{label=<<font color=\"#606060\">T6 "
 		    "(horizon)</font>>;color=darkgray;id_0_6[label=<C6 on N0<br/><b>horizon</b>> fontcolor=black shape=box];}subgraph cluster_id_0_7{label=<<font "
-		    "color=\"#606060\">T7 (epoch)</font>>;color=darkgray;id_0_7[label=<C7 on N0<br/><b>epoch</b> (barrier)> fontcolor=black "
+		    "color=\"#606060\">T7 (epoch)</font>>;color=darkgray;id_0_7[label=<C7 on N0<br/><b>epoch</b>> fontcolor=black "
 		    "shape=box];}id_0_0->id_0_1[];id_0_1->id_0_2[color=orange];id_0_1->id_0_3[];id_0_3->id_0_4[color=orange];id_0_2->id_0_4[color=orange];id_0_3->id_0_"
 		    "5[];id_0_5->id_0_6[color=orange];id_0_4->id_0_6[color=orange];id_0_6->id_0_7[color=orange];}";
 

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -38,10 +38,17 @@ namespace detail {
 		static std::thread& get_thread(live_executor& exec) { return exec.m_thread; }
 	};
 
-	TEST_CASE_METHOD(test_utils::runtime_fixture, "only a single distr_queue can be created", "[distr_queue][lifetime][dx]") {
+	TEST_CASE_METHOD(test_utils::runtime_fixture, "any number of distr_queues can be created", "[distr_queue][lifetime]") {
 		distr_queue q1;
-		auto q2{q1}; // Copying is allowed
-		REQUIRE_THROWS_WITH(distr_queue{}, "Only one celerity::distr_queue can be created per process (but it can be copied!)");
+		auto q2{q1};    // Copying is allowed
+		distr_queue q3; // so is creating new ones as of Celerity 0.7.0
+		distr_queue q4; // so is creating new ones as of Celerity 0.7.0
+	}
+
+	TEST_CASE_METHOD(test_utils::runtime_fixture, "new distr_queues can be created after the last one has been destroyed", "[distr_queue][lifetime]") {
+		distr_queue{};
+		CHECK(runtime::has_instance()); // ~distr_queue does not shut down the runtime as of Celerity 0.7.0
+		distr_queue{};
 	}
 
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "distr_queue implicitly initializes the runtime", "[distr_queue][lifetime]") {

--- a/test/system/distr_tests.cc
+++ b/test/system/distr_tests.cc
@@ -141,7 +141,10 @@ namespace detail {
 				accessor acc{sum, cgh, celerity::access::all{}, celerity::read_only_host_task};
 				cgh.host_task(on_master_node, [=] { (void)acc; });
 			});
-		} // shutdown runtime and print graph
+		}
+
+		// shutdown runtime manually to print the graph
+		runtime::shutdown();
 
 		if(is_node_0) { // We log graphs only on node 0
 			CHECK(test_utils::log_contains_substring(log_level::info, "digraph G{label=<Command Graph>"));

--- a/test/system/distr_tests.cc
+++ b/test/system/distr_tests.cc
@@ -122,8 +122,8 @@ namespace detail {
 	    "[reductions][print_graph][smoke-test]") //
 	{
 		env::scoped_test_environment test_env(print_graphs_env_setting);
-		// init runtime early so the queue ctor doesn't override the log level set by log_capture
-		runtime::init(nullptr, nullptr);
+
+		runtime::init(nullptr, nullptr); // init runtime explicitly so we can use runtime_testspy
 
 		const auto num_nodes = runtime_testspy::get_num_nodes(runtime::get_instance());
 		if(num_nodes < 2) { SKIP("Test needs at least 2 participating nodes"); }

--- a/test/system_benchmarks.cc
+++ b/test/system_benchmarks.cc
@@ -22,7 +22,7 @@ TEMPLATE_TEST_CASE_METHOD_SIG(
 	if(N > 100) { SKIP("Skipping larger-scale benchmark in debug build to save CI time"); }
 #endif
 
-	celerity::distr_queue queue;
+	celerity::queue queue;
 
 	const auto size = celerity::range<2>(items_per_task, num_tasks);
 	celerity::buffer<size_t, 2> buffer(size);
@@ -32,7 +32,7 @@ TEMPLATE_TEST_CASE_METHOD_SIG(
 		celerity::accessor w{buffer, cgh, celerity::access::one_to_one{}, celerity::write_only, celerity::no_init};
 		cgh.parallel_for(size, [=](celerity::item<2> item) { w[item] = item.get_linear_id(); });
 	});
-	queue.slow_full_sync();
+	queue.wait();
 
 	size_t bench_repeats = 0;
 	BENCHMARK("task generation") {
@@ -48,7 +48,7 @@ TEMPLATE_TEST_CASE_METHOD_SIG(
 				});
 			}
 		}
-		queue.slow_full_sync();
+		queue.wait();
 		bench_repeats++;
 	};
 
@@ -79,7 +79,7 @@ TEMPLATE_TEST_CASE_METHOD_SIG(
 	if(N > 50) { SKIP("Skipping larger-scale benchmark in debug build to save CI time"); }
 #endif
 
-	celerity::distr_queue queue;
+	celerity::queue queue;
 
 	const auto size = celerity::range<2>(side_length, side_length);
 	celerity::buffer<float, 2> buffer_a(size);
@@ -93,7 +93,7 @@ TEMPLATE_TEST_CASE_METHOD_SIG(
 			w[item] = ((item.get_id(0) % 2) ^ (item.get_id(1) % 2)) == 0 ? 1.f : 0.f;
 		});
 	});
-	queue.slow_full_sync();
+	queue.wait();
 
 	BENCHMARK("iterations") {
 		for(size_t r = 0; r < num_iterations; ++r) {
@@ -118,7 +118,7 @@ TEMPLATE_TEST_CASE_METHOD_SIG(
 			});
 			std::swap(buffer_a, buffer_b);
 		}
-		queue.slow_full_sync();
+		queue.wait();
 	};
 
 	// check result

--- a/test/task_ring_buffer_tests.cc
+++ b/test/task_ring_buffer_tests.cc
@@ -11,7 +11,7 @@ namespace celerity::detail {
 
 TEST_CASE_METHOD(test_utils::runtime_fixture, "freeing task ring buffer capacity via horizons continues execution in runtime", "[task_ring_buffer]") {
 	using namespace std::chrono_literals;
-	celerity::distr_queue q;
+	celerity::queue q;
 
 	std::atomic<bool> reached_ringbuffer_capacity = false;
 
@@ -38,11 +38,11 @@ TEST_CASE_METHOD(test_utils::runtime_fixture, "freeing task ring buffer capacity
 
 	observer.join();
 
-	q.slow_full_sync(); // `reach_ringbuffer_capacity` must not go out of scope before the host task has finished
+	q.wait(); // `reach_ringbuffer_capacity` must not go out of scope before the host task has finished
 }
 
 TEST_CASE_METHOD(test_utils::runtime_fixture, "deadlock in task ring buffer due to slot exhaustion is reported", "[task_ring_buffer]") {
-	celerity::distr_queue q;
+	celerity::queue q;
 
 	// set a high maximum so that we can actually run out of slots
 	runtime::get_instance().get_task_manager().set_horizon_max_parallelism(task_ringbuffer_size * 16);

--- a/test/utils_tests.cc
+++ b/test/utils_tests.cc
@@ -28,14 +28,14 @@ struct space {
 };
 
 template <typename T>
-auto set_identity(distr_queue queue, buffer<T, 2> mat, bool reverse) {
+auto set_identity(queue queue, buffer<T, 2> mat, bool reverse) {
 	return [](handler& cgh) {
 		class set_identity_kernel {};
 		return set_identity_kernel{};
 	};
 }
 
-using set_identity_name = decltype(set_identity(std::declval<distr_queue>(), std::declval<buffer<int, 2>>(), false)(std::declval<handler&>()));
+using set_identity_name = decltype(set_identity(std::declval<queue>(), std::declval<buffer<int, 2>>(), false)(std::declval<handler&>()));
 
 TEST_CASE("name strings are correctly extracted from types", "[utils][get_simplified_type_name]") {
 	CHECK(utils::get_simplified_type_name<class name>() == "name");


### PR DESCRIPTION
As it turns out, moving the runtime shutdown trigger from the current refcount approach to using `atexit` is relatively straight-forward. This change will allow a user to create multiple queues, and to create new Celerity objects after the last active one has gone out of scope.

To add back some manual control, `celerity::runtime::shutdown` is added.

We had an existing bug where `~buffer()` would not necessarily wait for all tasks that could read from the host-init-pointer, leading to potential use-after-free behavior. I fixed this by submitting an epoch when destroying a buffer that references user memory, and applied the same fix for `host_object<T&>` and `host_object<void>`, both of which semantically reference user memory.

The PR further adds `celerity::queue` as a replacement for `distr_queue` and deprecates the latter. `queue` is more closely aligned to SYCL queue, and has two significant differences to `distr_queue`:
- There are no device-selecting constructors, because their existence would communicate that there can be multiple queues addressing disjoint subsets of devices, which the runtime does not support yet.
- `wait()`, the replacement for `slow_full_sync()`, does not trigger an `MPI_Barrier`. This is always enough to guarantee local synchronization, and we should find a better mechanism for user-side benchmarking anyway.

### Open questions
- [ ] Can we downgrade the epoch emitted for the `~buffer` fix to a fence instruction (without the preceding "snapshot" instruction)? This could avoid a full sync.
