### PR TITLE
[CI] Bump pinned DPC++ version

### DIFF
--- a/.github/workflows/build_matrix.json
+++ b/.github/workflows/build_matrix.json
@@ -1,8 +1,8 @@
 {
     "NOTE": "Make sure to keep this in sync with docs/platform-support.md and benchmark.yml. Also ensure that the 'ubuntu-version' between 'HEAD' and 'latest' builds remains the same.",
     "default": [
-        { "sycl": "dpcpp", "sycl-version": "89327e0a", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
-        { "sycl": "dpcpp", "sycl-version": "89327e0a", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
+        { "sycl": "dpcpp", "sycl-version": "ad494e9d", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Debug" },
+        { "sycl": "dpcpp", "sycl-version": "ad494e9d", "ubuntu-version": "22.04", "platform": "intel", "build-type": "Release" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "24.04", "platform": "intel", "build-type": "Debug" },
         { "sycl": "dpcpp", "sycl-version": "latest", "ubuntu-version": "24.04", "platform": "intel", "build-type": "Release" },
         { "sycl": "acpp", "sycl-version": "v24.06.0", "ubuntu-version": "22.04", "platform": "nvidia", "build-type": "Debug" },

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -14,7 +14,7 @@ The most recent version of Celerity aims to support the following environments.
   * on NVIDIA hardware with compute capability ≥ 7.0 (`-DACPP_TARGETS=cuda:*`)
   * or on CPUs via OpenMP (`-DACPP_TARGETS=omp`, implicit)
   * the `generic` SSCP target cannot be supported yet and must be disabled when building Celerity applications.
-* DPC++ ≥ revision [`89327e0a`](https://github.com/intel/llvm/commit/89327e0a)
+* DPC++ ≥ revision [`ad494e9d`](https://github.com/intel/llvm/tree/ad494e9d)
   * [Intel Compute Runtime](https://github.com/intel/compute-runtime) ≥ 24.13.29138.7
   * [oneAPI Level Zero](https://github.com/oneapi-src/level-zero) ≥ 1.17.0
   * on integrated and dedicated Intel GPUs
@@ -40,7 +40,7 @@ Those are (CRT = Intel Compute Runtime, L0 = oneAPI Level Zero):
 
 | SYCL        | SYCL version                                                                                       | OS           | GPU             | Build type     |
 |-------------|----------------------------------------------------------------------------------------------------|--------------|-----------------|----------------|
-| DPC++       | [`89327e0a`](https://github.com/intel/llvm/tree/89327e0a) (CRT 24.13.29138.7, L0 1.17.0)           | Ubuntu 22.04 | Intel Arc A770  | Debug, Release |
+| DPC++       | [`ad494e9d`](https://github.com/intel/llvm/tree/ad494e9d) (CRT 24.13.29138.7, L0 1.17.0)           | Ubuntu 22.04 | Intel Arc A770  | Debug, Release |
 | DPC++       | [`HEAD`](https://github.com/intel/llvm/) (CRT 24.13.29138.7, L0 1.17.0)                            | Ubuntu 24.04 | Intel Arc A770  | Debug, Release |
 | AdaptiveCpp | [`v24.06.0`](https://github.com/AdaptiveCpp/AdaptiveCpp/tree/v24.06.0) (Clang 14.0, CUDA 11.8.0)   | Ubuntu 22.04 | NVIDIA RTX 2070 | Debug, Release |
 | AdaptiveCpp | [`HEAD`](https://github.com/AdaptiveCpp/AdaptiveCpp) (Clang 18.0, CUDA 12.5.0)\*                   | Ubuntu 24.04 | NVIDIA RTX 2070 | Debug, Release |


### PR DESCRIPTION
The previously pinned version of DPC++ depends on a _Unified Runtime_ version which in turn uses `FetchContent` to include OpenCL headers, but the version of those headers is not pinned. As a result, those headers changed since mid-july where we managed the last successful build, and now fail.

In the new pinned version (equals the current `latest`), the OpenCL header version is pinned as well, so this should not happen again.
