### PR TITLE
Experimental support for AdaptiveCpp SSCP flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Replace `celerity::distr_queue` with `celerity::queue`, which permits multiple instances and aligns closer with SYCL (#283)
 - The runtime can be explicitly shut down using `celerity::shutdown()`, complementing `celerity::init()` (#283)
 - `handler::parallel_for(size_t, [size_t,] ...)` now acts as a shorthand for `parallel_for(range<1>, [id<1>,] ...)` (#288)
+- Experimental support for the AdaptiveCpp generic single-pass compiler (#294)
 
 ### Changed
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -13,7 +13,7 @@ The most recent version of Celerity aims to support the following environments.
   * Clang ≥ 14.0 for CUDA &lt; 12.0, Clang ≥ 16.0 for CUDA ≥ 12.0
   * on NVIDIA hardware with compute capability ≥ 7.0 (`-DACPP_TARGETS=cuda:*`)
   * or on CPUs via OpenMP (`-DACPP_TARGETS=omp`, implicit)
-  * the `generic` SSCP target cannot be supported yet and must be disabled when building Celerity applications.
+  * any target with the `generic` SSCP compiler (experimental, `-DACPP_TARGETS=generic`, which is the default)
 * DPC++ ≥ revision [`ad494e9d`](https://github.com/intel/llvm/tree/ad494e9d)
   * [Intel Compute Runtime](https://github.com/intel/compute-runtime) ≥ 24.13.29138.7
   * [oneAPI Level Zero](https://github.com/oneapi-src/level-zero) ≥ 1.17.0

--- a/include/closure_hydrator.h
+++ b/include/closure_hydrator.h
@@ -166,4 +166,4 @@ class closure_hydrator {
 	}
 };
 
-}; // namespace celerity::detail
+} // namespace celerity::detail


### PR DESCRIPTION
Single-pass compilation cannot provide `__SYCL_DEVICE_ONLY__` detection macro, so we need to guard accessor hydration with `__acpp_if_target_host()`. This works because AdaptiveCpp does not verify that kernels are actually device copyable.

For DPC++ (and anything else) we still need to conditionally remove definitions for accessor copy and move ctors.

This now works on my machine :tm:, but there is no CI integration yet.