### PR TITLE
CI: Bump report action to v8

### DIFF
--- a/.github/workflows/celerity_ci.yml
+++ b/.github/workflows/celerity_ci.yml
@@ -284,7 +284,7 @@ jobs:
             echo "$unformatted"
             echo EOF
           } >> "$GITHUB_OUTPUT"
-      - uses: "celerity/ci-report-action@v7"
+      - uses: "celerity/ci-report-action@v8"
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           unformatted-files: ${{ steps.formatting.outputs.unformatted-files }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,14 @@ if(CELERITY_TRACY_SUPPORT)
   set(TRACY_STATIC ON CACHE BOOL "" FORCE)
   set(TRACY_NO_SAMPLING ON CACHE BOOL "" FORCE)
   set(TRACY_NO_SYSTEM_TRACING ON CACHE BOOL "" FORCE)
+
+  set(PREVIOUS_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Disable warning until we have https://github.com/wolfpld/tracy/pull/924
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result")
+  endif()
   fetch_content_from_submodule(Tracy vendor/tracy)
+  set(CMAKE_CXX_FLAGS "${PREVIOUS_CMAKE_CXX_FLAGS}")
 endif()
 
 # Deprecated feature flags
@@ -360,7 +367,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
   target_compile_options(celerity_runtime PRIVATE -Wall -Wextra -Wno-unused-parameter -Werror=return-type -Werror=init-self -Werror=undef)
 endif()
 
-if(CMAKE_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(celerity_runtime PRIVATE -Wno-array-bounds -Wno-stringop-overflow)  # false positives with GCC 13.2
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,10 @@ function(set_test_target_parameters TARGET SOURCE)
     target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wextra -Wno-unused-parameter -Wno-unused-variable)
   endif()
 
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(${TARGET} PRIVATE -Wno-array-bounds -Wno-stringop-overflow)  # false positives with GCC 13.2
+  endif()
+
   add_celerity_to_target(TARGET ${TARGET} SOURCES ${SOURCE})
 endfunction()
 

--- a/test/command_graph_reduction_tests.cc
+++ b/test/command_graph_reduction_tests.cc
@@ -239,10 +239,10 @@ TEST_CASE("nodes that do not participate in reduction only push data to those th
 	cdag_test_context cctx(num_nodes);
 	auto buf = cctx.create_buffer(range<1>(1));
 
-	const auto tid_producer = cctx.device_compute(range<1>(num_nodes)).reduce(buf, false /* include_current_buffer_value */).submit();
+	cctx.device_compute(range<1>(num_nodes)).reduce(buf, false /* include_current_buffer_value */).submit();
 
 	SECTION("when reducing on a single node") {
-		const auto tid_reducer = cctx.device_compute(range<1>(1)).read(buf, acc::all()).submit();
+		cctx.device_compute(range<1>(1)).read(buf, acc::all()).submit();
 		// Theres a push on nodes 1-3
 		CHECK(cctx.query<push_command_record>().total_count() == 3);
 		CHECK(cctx.query<push_command_record>().on(0).count() == 0);
@@ -266,7 +266,7 @@ TEST_CASE("nodes that do not participate in reduction generate await-pushes when
 	cdag_test_context cctx(num_nodes);
 	auto buf = cctx.create_buffer(range<1>(1));
 
-	const auto tid_producer = cctx.device_compute(range<1>(num_nodes)).reduce(buf, false /* include_current_buffer_value */).submit();
+	cctx.device_compute(range<1>(num_nodes)).reduce(buf, false /* include_current_buffer_value */).submit();
 
 	SECTION("when reducing on a single node") {
 		const auto tid_reducer = cctx.device_compute(range<1>(1)).read(buf, acc::all()).submit();

--- a/test/command_graph_transfer_tests.cc
+++ b/test/command_graph_transfer_tests.cc
@@ -349,7 +349,7 @@ TEST_CASE("5-point stencil program with 2D split does not exchange boundaries wi
 	    .submit();
 
 	const std::vector<std::pair<node_id, node_id>> diagonals{{0, 3}, {1, 2}, {2, 1}, {3, 0}};
-	for(const auto [nid, diag] : diagonals) {
+	for(const auto& [nid, diag] : diagonals) {
 		CHECK(std::ranges::none_of(cctx.query<push_command_record>().on(nid)->target_regions, [diag = diag](auto& tr) { return tr.first == diag; }));
 	}
 }


### PR DESCRIPTION
This fixes our build warning check that was broken since 0bbe6e564, due to a version mismatch between the artifact upload action and the module we use to download them inside the report action. If this breaks again in the future, the action should now report this as a failure.

Additionally, a long standing issue where the report result would not show up in CI runs triggered by a `pull_request` event is also fixed. This is more relevant now because we no longer run the `push` trigger on PRs.