### PR TITLE
Fix: Update runtime last-epoch-reached before resuming from sync

### DIFF
--- a/src/dry_run_executor.cc
+++ b/src/dry_run_executor.cc
@@ -45,8 +45,10 @@ void dry_run_executor::thread_main(executor::delegate* const dlg) {
 			    host_object_instances.erase(dhoinstr.get_host_object_id());
 		    },
 		    [&](const epoch_instruction& einstr) {
-			    if(einstr.get_promise() != nullptr) { einstr.get_promise()->fulfill(); }
+			    // Update the runtime last-epoch *before* fulfilling the promise to ensure that the new state can be observed as soon as runtime::sync returns.
+			    // This in turn allows the TDAG to be pruned before any new work is submitted after the epoch.
 			    if(dlg != nullptr) { dlg->epoch_reached(einstr.get_epoch_task_id()); }
+			    if(einstr.get_promise() != nullptr) { einstr.get_promise()->fulfill(); }
 			    shutdown |= einstr.get_epoch_action() == epoch_action::shutdown;
 		    },
 		    [&](const fence_instruction& finstr) {

--- a/src/live_executor.cc
+++ b/src/live_executor.cc
@@ -696,8 +696,12 @@ void executor_impl::issue(const epoch_instruction& einstr) {
 		expecting_more_submissions = false;
 		break;
 	}
-	if(einstr.get_promise() != nullptr) { einstr.get_promise()->fulfill(); }
+
+	// Update the runtime last-epoch *before* fulfilling the promise to ensure that the new state can be observed as soon as runtime::sync returns.
+	// This in turn allows the TDAG to be pruned before any new work is submitted after the epoch.
 	if(delegate != nullptr) { delegate->epoch_reached(einstr.get_epoch_task_id()); }
+
+	if(einstr.get_promise() != nullptr) { einstr.get_promise()->fulfill(); }
 	collect(einstr.get_garbage());
 
 	CELERITY_DETAIL_IF_TRACY_ENABLED(FrameMarkNamed("Horizon"));


### PR DESCRIPTION
Fixes a race condition [spuriously observed](https://github.com/celerity/celerity-runtime/actions/runs/11854130628/job/33035670606) in unit tests after #299.

The unit test assumes that the runtime knows about the epoch being reached as soon as `sync` returns, but we signalled the epoch-promise before updating the reached epoch. This PR flips the signalling order so that the future establishes a proper happens-before-relationship around `sync` and `last_epoch_reached`.