### PR TITLE
Refactoring and unifying various thread-related code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,7 @@ set(SOURCES
   src/grid.cc
   src/instruction_graph_generator.cc
   src/live_executor.cc
+  src/named_threads.cc
   src/out_of_order_engine.cc
   src/print_graph.cc
   src/recorders.cc

--- a/include/named_threads.h
+++ b/include/named_threads.h
@@ -1,15 +1,34 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
-#include <thread>
 
 
-namespace celerity::detail {
+namespace celerity::detail::named_threads {
 
-std::thread::native_handle_type get_current_thread_handle();
+constexpr uint32_t thread_type_step = 10000;
 
-void set_thread_name(const std::thread::native_handle_type thread_handle, const std::string& name);
+// The threads Celerity interacts with ("application") and creates (everything else), identified for the purpose of naming and pinning.
+enum class thread_type : uint32_t {
+	application = 0 * thread_type_step,            // pinned
+	scheduler = 1 * thread_type_step,              // pinned
+	executor = 2 * thread_type_step,               // pinned
+	alloc = 3 * thread_type_step,                  //
+	first_device_submitter = 4 * thread_type_step, // pinned
+	first_host_queue = 5 * thread_type_step,       //
+	first_test = 6 * thread_type_step,             //
+	max = 7 * thread_type_step,                    //
+};
+// Builds the n-th thread types of various kinds
+thread_type task_type_device_submitter(const uint32_t n);
+thread_type task_type_host_queue(const uint32_t n);
+thread_type task_type_test(const uint32_t n);
 
-std::string get_thread_name(const std::thread::native_handle_type thread_handle);
+// Converts a thread type to a canoncial string representation
+std::string thread_type_to_string(const thread_type t_type);
 
-} // namespace celerity::detail
+// Performs naming, pinning and tracy ordering (if enabled for this thread) of the invoking thread
+// This should be the first thing called in any thread that is part of the Celerity runtime
+void name_and_pin_and_order_this_thread(const thread_type t_type);
+
+} // namespace celerity::detail::named_threads

--- a/src/affinity.cc
+++ b/src/affinity.cc
@@ -14,20 +14,6 @@
 
 namespace celerity::detail::thread_pinning {
 
-std::string thread_type_to_string(const thread_type t_type) {
-	switch(t_type) {
-	case thread_type::application: return "application";
-	case thread_type::scheduler: return "scheduler";
-	case thread_type::executor: return "executor";
-	default: break;
-	}
-	if(t_type >= thread_type::first_device_submitter && t_type < thread_type::first_host_queue) {
-		return fmt::format("device_submitter_{}", t_type - thread_type::first_device_submitter);
-	}
-	if(t_type >= thread_type::first_host_queue && t_type < thread_type::max) { return fmt::format("host_queue_{}", t_type - thread_type::first_host_queue); }
-	return fmt::format("unknown({})", static_cast<uint32_t>(t_type));
-}
-
 namespace {
 	// When we no longer need to support compilers without a working std::views::split, get rid of this function
 	std::vector<std::string> split(const std::string_view str, const char delim) {

--- a/src/dry_run_executor.cc
+++ b/src/dry_run_executor.cc
@@ -8,9 +8,7 @@
 
 namespace celerity::detail {
 
-dry_run_executor::dry_run_executor(executor::delegate* const dlg) : m_thread(&dry_run_executor::thread_main, this, dlg) {
-	set_thread_name(m_thread.native_handle(), "cy-executor");
-}
+dry_run_executor::dry_run_executor(executor::delegate* const dlg) : m_thread(&dry_run_executor::thread_main, this, dlg) {}
 
 dry_run_executor::~dry_run_executor() { m_thread.join(); }
 
@@ -34,6 +32,7 @@ void dry_run_executor::submit(std::vector<const instruction*> instructions, std:
 }
 
 void dry_run_executor::thread_main(executor::delegate* const dlg) {
+	name_and_pin_and_order_this_thread(named_threads::thread_type::executor);
 	// For simplicity we keep all executor state within this function.
 	std::unordered_map<host_object_id, std::unique_ptr<host_object_instance>> host_object_instances;
 	bool shutdown = false;

--- a/src/named_threads.cc
+++ b/src/named_threads.cc
@@ -1,0 +1,55 @@
+#include "named_threads.h"
+
+#include <cassert>
+
+#include <fmt/format.h>
+
+#include "affinity.h"
+#include "tracy.h"
+
+namespace celerity::detail::named_threads {
+
+thread_type task_type_device_submitter(const uint32_t n) {
+	assert(n < thread_type_step);
+	return thread_type(static_cast<uint32_t>(thread_type::first_device_submitter) + n); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+}
+thread_type task_type_host_queue(const uint32_t n) {
+	assert(n < thread_type_step);
+	return thread_type(static_cast<uint32_t>(thread_type::first_host_queue) + n); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+}
+thread_type task_type_test(const uint32_t n) {
+	assert(n < thread_type_step);
+	return thread_type(static_cast<uint32_t>(thread_type::first_test) + n); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+}
+
+std::string thread_type_to_string(const thread_type t_type) {
+	switch(t_type) {
+	case thread_type::application: return "cy-application";
+	case thread_type::scheduler: return "cy-scheduler";
+	case thread_type::executor: return "cy-executor";
+	case thread_type::alloc: return "cy-alloc";
+	default: break;
+	}
+	if(t_type >= thread_type::first_device_submitter && t_type < thread_type::first_host_queue) { //
+		return fmt::format("cy-dev-sub-{}", static_cast<uint32_t>(t_type) - static_cast<uint32_t>(thread_type::first_device_submitter));
+	}
+	if(t_type >= thread_type::first_host_queue && t_type < thread_type::first_test) { //
+		return fmt::format("cy-host-{}", static_cast<uint32_t>(t_type) - static_cast<uint32_t>(thread_type::first_host_queue));
+	}
+	if(t_type >= thread_type::first_test && t_type <= thread_type::max) { //
+		return fmt::format("cy-test-{}", static_cast<uint32_t>(t_type) - static_cast<uint32_t>(thread_type::first_test));
+	}
+	return fmt::format("unknown({})", static_cast<uint32_t>(t_type));
+}
+
+// Sets the name for the invoking thread to its canonical string representation using OS-specific functions, if available
+// Has a per-platform implementation in the platform-specific files
+void set_current_thread_name(const thread_type t_type);
+
+void name_and_pin_and_order_this_thread(const thread_type t_type) {
+	set_current_thread_name(t_type);
+	thread_pinning::pin_this_thread(t_type);
+	CELERITY_DETAIL_TRACY_SET_THREAD_NAME_AND_ORDER(t_type);
+}
+
+} // namespace celerity::detail::named_threads

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -2,12 +2,13 @@
 
 #include <cassert>
 #include <cwchar>
+#include <thread>
 #include <type_traits>
 
 #include <windows.h>
 
 
-namespace celerity::detail {
+namespace celerity::detail::named_threads {
 
 static_assert(std::is_same_v<std::thread::native_handle_type, HANDLE>, "Unexpected native thread handle type");
 
@@ -29,11 +30,9 @@ static inline std::wstring convert_string(const std::string& str) {
 	return dst;
 }
 
-std::thread::native_handle_type get_current_thread_handle() { return GetCurrentThread(); }
-
-void set_thread_name(const std::thread::native_handle_type thread_handle, const std::string& name) {
-	const auto wname = convert_string(name);
-	[[maybe_unused]] const auto res = SetThreadDescription(thread_handle, wname.c_str());
+void set_current_thread_name([[maybe_unused]] const thread_type t_type) {
+	const auto wname = convert_string(thread_type_to_string(t_type));
+	[[maybe_unused]] const auto res = SetThreadDescription(GetCurrentThread(), wname.c_str());
 	assert(SUCCEEDED(res) && "Failed to set thread name");
 }
 
@@ -49,4 +48,6 @@ std::string get_thread_name(const std::thread::native_handle_type thread_handle)
 	return name;
 }
 
-} // namespace celerity::detail
+std::string get_current_thread_name() { return get_thread_name(GetCurrentThread()); }
+
+} // namespace celerity::detail::named_threads

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -4,16 +4,14 @@
 #include "backend/sycl_backend.h"
 #include "cgf_diagnostics.h"
 #include "command_graph_generator.h"
-#include "config.h"
 #include "device_selection.h"
 #include "dry_run_executor.h"
-#include "executor.h"
 #include "host_object.h"
 #include "instruction_graph_generator.h"
 #include "live_executor.h"
 #include "log.h"
+#include "named_threads.h"
 #include "print_graph.h"
-#include "ranges.h"
 #include "reduction.h"
 #include "scheduler.h"
 #include "system_info.h"
@@ -46,6 +44,7 @@
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 #include <sycl/sycl.hpp>
+
 
 #ifdef _MSC_VER
 #include <process.h>
@@ -276,7 +275,7 @@ namespace detail {
 			    .hardcoded_core_ids = pin_cfg.hardcoded_core_ids,
 			};
 			m_thread_pinner = std::make_unique<thread_pinning::thread_pinner>(thread_pinning_cfg);
-			thread_pinning::pin_this_thread(thread_pinning::thread_type::application);
+			name_and_pin_and_order_this_thread(named_threads::thread_type::application);
 		}
 
 		const sycl_backend::configuration backend_config = {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TEST_TARGETS
   instruction_graph_misc_tests
   instruction_graph_p2p_tests
   instruction_graph_reduction_tests
+  named_threads_tests
   nd_memory_tests
   out_of_order_engine_tests
   print_graph_tests

--- a/test/dag_benchmarks.cc
+++ b/test/dag_benchmarks.cc
@@ -244,7 +244,7 @@ class restartable_scheduler_thread {
 
 	void main() {
 		// This thread is used for scheduling, so pin it to the scheduler core
-		detail::thread_pinning::pin_this_thread(detail::thread_pinning::thread_type::scheduler);
+		name_and_pin_and_order_this_thread(named_threads::thread_type::scheduler);
 		std::unique_lock lk{m_mutex};
 		for(;;) {
 			m_update.wait(lk, [this] { return !std::holds_alternative<empty>(m_next); });

--- a/test/executor_tests.cc
+++ b/test/executor_tests.cc
@@ -256,7 +256,7 @@ class mock_backend final : public backend {
 	system_info m_system;
 	uintptr_t m_last_mock_alloc_address = 0;
 	operations_log* m_log;
-	thread_queue m_host_queue{"cy-mock-host"}; // for host tasks with in-tact launcher (= delay tasks)
+	thread_queue m_host_queue{named_threads::task_type_test(0)}; // for host tasks with in-tact launcher (= delay tasks)
 
 	/// alloc operations must return a non-null pointer, which we simply conjure from an integer to allow tests to identify allocations in the log.
 	void* mock_alloc(const size_t size, const size_t alignment) {

--- a/test/named_threads_tests.cc
+++ b/test/named_threads_tests.cc
@@ -1,0 +1,74 @@
+#include <celerity.h>
+
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "live_executor.h"
+#include "named_threads.h"
+#include "test_utils.h"
+#include "thread_queue.h"
+
+using namespace celerity;
+using namespace celerity::detail::named_threads;
+
+namespace celerity::detail {
+struct executor_testspy {
+	static std::thread& get_thread(live_executor& exec) { return exec.m_thread; }
+};
+} // namespace celerity::detail
+
+TEST_CASE("semantic thread type enum entries can be constructed and turned into strings", "[named_threads]") {
+	using namespace detail::thread_pinning;
+	CHECK(thread_type_to_string(thread_type::application) == "cy-application");
+	CHECK(thread_type_to_string(thread_type::scheduler) == "cy-scheduler");
+	CHECK(thread_type_to_string(thread_type::executor) == "cy-executor");
+	CHECK(thread_type_to_string(thread_type::alloc) == "cy-alloc");
+	CHECK(thread_type_to_string(thread_type::first_device_submitter) == "cy-dev-sub-0");
+	CHECK(thread_type_to_string(task_type_device_submitter(13)) == "cy-dev-sub-13");
+	CHECK(thread_type_to_string(thread_type::first_host_queue) == "cy-host-0");
+	CHECK(thread_type_to_string(task_type_host_queue(42)) == "cy-host-42");
+	CHECK(thread_type_to_string(thread_type::first_test) == "cy-test-0");
+	CHECK(thread_type_to_string(task_type_test(3)) == "cy-test-3");
+	CHECK(thread_type_to_string(static_cast<thread_type>(3133337)) == "unknown(3133337)"); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+}
+
+#if CELERITY_DETAIL_HAS_NAMED_THREADS
+
+namespace celerity::detail::named_threads {
+// These functions have a per-platform implementation in the platform-specific files
+// They only work if CELERITY_DETAIL_HAS_NAMED_THREADS is defined
+std::string get_thread_name(const std::thread::native_handle_type thread_handle);
+std::string get_current_thread_name();
+} // namespace celerity::detail::named_threads
+
+TEST_CASE_METHOD(test_utils::runtime_fixture, "thread names are set", "[named_threads]") {
+	queue q;
+
+	auto& rt = detail::runtime::get_instance();
+	auto& schdlr = detail::runtime_testspy::get_schdlr(rt);
+	auto& exec = *detail::utils::as<detail::live_executor>(&detail::runtime_testspy::get_exec(rt));
+
+	q.submit([](handler& cgh) {
+		cgh.host_task(experimental::collective, [&](experimental::collective_partition) {
+			const auto base_name = std::string("cy-host-");
+			const auto worker_thread_name = get_current_thread_name();
+			CHECK_THAT(worker_thread_name, Catch::Matchers::StartsWith(base_name));
+		});
+	});
+	q.wait(); // make sure that the runtime threads are actually running for the subsequent checks
+
+	const auto application_thread_name = get_current_thread_name();
+	CHECK(application_thread_name == thread_type_to_string(thread_type::application));
+
+	const auto scheduler_thread_name = detail::scheduler_testspy::inspect_thread(schdlr, [](const auto&) { return get_current_thread_name(); });
+	CHECK(scheduler_thread_name == thread_type_to_string(thread_type::scheduler));
+
+	const auto executor_thread_name = get_thread_name(detail::executor_testspy::get_thread(exec).native_handle());
+	CHECK(executor_thread_name == thread_type_to_string(thread_type::executor));
+}
+
+TEST_CASE("thread_queue sets its thread name", "[named_threads][thread_queue]") {
+	detail::thread_queue tq(thread_type::first_test);
+	test_utils::await(tq.submit([] { CHECK(get_current_thread_name() == thread_type_to_string(thread_type::first_test)); }));
+}
+
+#endif

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -107,10 +107,6 @@ namespace detail {
 			return channel.get_future().get();
 		}
 
-		static std::thread::native_handle_type get_thread(scheduler& schdlr) {
-			return inspect_thread(schdlr, [](const test_state& /* state */) { return get_current_thread_handle(); });
-		}
-
 		static size_t get_live_command_count(scheduler& schdlr) {
 			return inspect_thread(schdlr, [](const test_state& state) { return graph_testspy::get_live_node_count(*state.cdag); });
 		}
@@ -186,7 +182,7 @@ namespace test_utils {
 			    .use_backend_device_submission_threads = false,
 			};
 			m_thread_pinner.emplace(cfg);
-			detail::thread_pinning::pin_this_thread(detail::thread_pinning::thread_type::application);
+			name_and_pin_and_order_this_thread(detail::named_threads::thread_type::application);
 		}
 
 		std::optional<detail::thread_pinning::thread_pinner> m_thread_pinner;

--- a/test/thread_queue_tests.cc
+++ b/test/thread_queue_tests.cc
@@ -7,27 +7,8 @@
 using namespace celerity;
 using namespace celerity::detail;
 
-namespace celerity::detail {
-
-struct thread_queue_testspy {
-	static std::thread& get_thread(thread_queue& tq) { return tq.m_impl->thread; }
-};
-
-} // namespace celerity::detail
-
-#if CELERITY_DETAIL_HAS_NAMED_THREADS
-
-TEST_CASE("thread_queue sets its thread name", "[thread_queue]") {
-	thread_queue tq("funny-name");
-	test_utils::await(tq.submit([] {})); // wait for thread to enter loop
-	auto& thread = thread_queue_testspy::get_thread(tq);
-	CHECK(get_thread_name(thread.native_handle()) == "funny-name");
-}
-
-#endif
-
 TEST_CASE("thread_queue forwards job results", "[thread_queue]") {
-	thread_queue tq("cy-test");
+	thread_queue tq(named_threads::thread_type::first_test);
 
 	auto evt1 = tq.submit([] {});
 	auto evt2 = tq.submit([] { return nullptr; });
@@ -48,7 +29,7 @@ TEST_CASE("thread_queue forwards job results", "[thread_queue]") {
 }
 
 TEST_CASE("thread_queue reports execution times when profiling is enabled", "[thread_queue]") {
-	thread_queue tq("cy-test", true /* enable profiling */);
+	thread_queue tq(named_threads::thread_type::first_test, true /* enable profiling */);
 
 	auto evt1 = tq.submit([] {});
 	auto evt2 = tq.submit([] { std::this_thread::sleep_for(std::chrono::milliseconds(99)); });


### PR DESCRIPTION
This refactoring PR performs 2 main tasks:

* Introduce a single source of truth for thread names, and a unified interface to both name and (if enabled and required) pin threads
* Also unify this with tracy thread ordering, so that there is only a single interface for all of it, and it takes a `named_threads` enum entry as its parameter

There are no functional changes, test coverage is slightly extended.

Note that the implementation of how the try/catch block in threads is designed and what happens in response to exceptions had already slightly diverged (presumably unintentionally).

Check-perf-impact result (no new file required):
:heavy_check_mark: No significant performance change in the microbenchmark set. You are good to go!