### PR TITLE
[clang-tidy] Disable lints that frequently cause false positives

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,20 +11,29 @@
 #    `git diff -U0 --no-color | clang-tidy-diff.py -p1 -path path/to/compile_commands.json`
 #
 InheritParentConfig: false
+
 # See https://clang.llvm.org/extra/clang-tidy/checks/list.html for a full list of available checks.
-# Note: We would like to enable `misc-const-correctness` (introduced with Clang 15), but it currently
-#       seems to be somewhat buggy still (producing false positives) => revisit at some point.
+# We disable a number of checks that cause frequent false positives, including:
+#   -bugprone-unchecked-optional-access treats std::optional::value as "unchecked"
+#   -misc-include-cleaner can't deal with "interface headers" such as sycl.hpp
+#   -misc-unused-using-decls complains about "using sub_group = sycl::sub_group" (API export)
+#   -readability-convert-member-functions-to-static lints against implementations of fmt::formatter
 Checks: -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-lambda-function-name,
   -bugprone-macro-parentheses,
+  -bugprone-unchecked-optional-access,
   misc-*,
-  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-misplaced-const,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
+  -misc-unused-using-decls,
+  -misc-use-anonymous-namespace,
   clang-analyzer-*,
+  -clang-analyzer-optin.mpi.MPI-Checker,
   clang-diagnostic-*,
   cppcoreguidelines-*,
   -cppcoreguidelines-avoid-c-arrays,
@@ -32,19 +41,28 @@ Checks: -*,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   mpi-*,
   performance-*,
   -performance-enum-size,
   readability-*,
   -readability-avoid-const-params-in-decls,
+  -readability-convert-member-functions-to-static,
+  -readability-else-after-return,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-qualified-auto,
+  -readability-redundant-inline-specifier,
   -readability-uppercase-literal-suffix,
 
 CheckOptions:
+  - key: misc-const-correctness.WarnPointersAsValues
+    value: true
   # Naming conventions
   - key: readability-identifier-naming.ClassCase
     value: lower_case

--- a/examples/.clang-tidy
+++ b/examples/.clang-tidy
@@ -1,0 +1,6 @@
+---
+InheritParentConfig: true
+
+# We disable some checks that cause false-positives in examples.
+#   -misc-const-correctness: Would suggest `const accessor` in CGFs
+Checks: -misc-const-correctness

--- a/include/access_modes.h
+++ b/include/access_modes.h
@@ -4,6 +4,7 @@
 
 #include <sycl/sycl.hpp>
 
+
 namespace celerity::detail::access {
 
 constexpr std::array<sycl::access::mode, 6> all_modes = {sycl::access::mode::atomic, sycl::access::mode::discard_read_write, sycl::access::mode::discard_write,

--- a/include/accessor.h
+++ b/include/accessor.h
@@ -1,16 +1,25 @@
 #pragma once
 
-#include <type_traits>
-
-#include <sycl/sycl.hpp>
-
 #include "access_modes.h"
 #include "buffer.h"
 #include "cgf_diagnostics.h"
 #include "closure_hydrator.h"
 #include "handler.h"
+#include "range_mapper.h"
+#include "ranges.h"
 #include "sycl_wrappers.h"
+#include "types.h"
 #include "version.h"
+#include "workaround.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <mutex>
+#include <stdexcept>
+#include <type_traits>
+
+#include <sycl/sycl.hpp>
+
 
 namespace celerity {
 

--- a/include/affinity.h
+++ b/include/affinity.h
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <vector>
 
+
 // The goal of this thread pinning mechanism, when enabled, is to ensure that threads which benefit from fast communication
 // are pinned to cores that are close to each other in terms of cache hierarchy.
 // It currently accomplishes this by pinning threads to cores in a round-robin fashion according to their order in the `thread_type` enum.

--- a/include/async_event.h
+++ b/include/async_event.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <optional>
 #include <type_traits>
+#include <utility>
+
 
 namespace celerity::detail {
 

--- a/include/backend/backend.h
+++ b/include/backend/backend.h
@@ -2,13 +2,14 @@
 
 #include "async_event.h"
 #include "closure_hydrator.h"
+#include "grid.h"
 #include "launcher.h"
 #include "nd_memory.h"
 #include "types.h"
 
+#include <cstddef>
 #include <vector>
 
-#include <sycl/sycl.hpp>
 
 namespace celerity::detail {
 

--- a/include/backend/sycl_backend.h
+++ b/include/backend/sycl_backend.h
@@ -1,15 +1,25 @@
 #pragma once
 
 #include "async_event.h"
-
 #include "backend/backend.h"
+#include "closure_hydrator.h"
+#include "grid.h"
+#include "launcher.h"
+#include "nd_memory.h"
+#include "types.h"
 
 #include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
+#include <utility>
 #include <vector>
 
-#include <fmt/format.h>
+#include <sycl/sycl.hpp>
+
 
 namespace celerity::detail::sycl_backend_detail {
 

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <memory>
-
-#include <sycl/sycl.hpp>
-
 #include "ranges.h"
 #include "runtime.h"
 #include "sycl_wrappers.h"
 #include "tracy.h"
+
+#include <memory>
+
+#include <sycl/sycl.hpp>
 
 
 namespace celerity {

--- a/include/celerity.h
+++ b/include/celerity.h
@@ -11,6 +11,7 @@
 #include "side_effect.h"
 #include "version.h"
 
+
 namespace celerity {
 namespace runtime {
 

--- a/include/cgf_diagnostics.h
+++ b/include/cgf_diagnostics.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "task.h"
+
 #include <optional>
 
-#include "task.h"
 
 namespace celerity::detail {
 

--- a/include/closure_hydrator.h
+++ b/include/closure_hydrator.h
@@ -1,13 +1,23 @@
 #pragma once
 
-#include <optional>
-#include <vector>
-
 #include "grid.h"
 #include "ranges.h"
 #include "sycl_wrappers.h"
 #include "types.h"
 #include "version.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <sycl/sycl.hpp>
+
 
 namespace celerity::detail {
 

--- a/include/command_graph_generator.h
+++ b/include/command_graph_generator.h
@@ -1,16 +1,7 @@
 #pragma once
 
-#include <bitset>
-#include <concepts>
-#include <cstddef>
-#include <cstdint>
-#include <functional>
-#include <tuple>
-#include <unordered_map>
-#include <utility>
-#include <vector>
-
 #include "command_graph.h"
+#include "grid.h"
 #include "intrusive_graph.h"
 #include "ranges.h"
 #include "recorders.h"
@@ -18,6 +9,19 @@
 #include "region_map.h"
 #include "types.h"
 #include "utils.h"
+
+#include <bitset>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 
 namespace celerity::detail {

--- a/include/communicator.h
+++ b/include/communicator.h
@@ -2,7 +2,15 @@
 
 #include "async_event.h"
 #include "pilot.h"
+#include "ranges.h"
+#include "types.h"
 #include "utils.h"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <vector>
+
 
 namespace celerity::detail {
 

--- a/include/config.h
+++ b/include/config.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "affinity.h"
+#include "log.h"
+#include "types.h"
+
 #include <cstddef>
 #include <optional>
 
-#include "affinity.h"
-#include "log.h"
 
 namespace celerity {
 namespace detail {

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,10 +1,12 @@
-#include <string>
-
 #include "buffer.h"
 #include "handler.h"
 
+#include <string>
+
+
 namespace celerity {
 namespace debug {
+
 	template <typename DataT, int Dims>
 	void set_buffer_name(const celerity::buffer<DataT, Dims>& buff, const std::string& debug_name) {
 		detail::set_buffer_name(buff, debug_name);
@@ -16,5 +18,6 @@ namespace debug {
 	}
 
 	inline void set_task_name(celerity::handler& cgh, const std::string& debug_name) { detail::set_task_name(cgh, debug_name); }
+
 } // namespace debug
 } // namespace celerity

--- a/include/dense_map.h
+++ b/include/dense_map.h
@@ -5,6 +5,7 @@
 #include <iterator>
 #include <vector>
 
+
 namespace celerity::detail {
 
 /// Like a simple std::unordered_map, but implemented by indexing into a vector with the integral key type.

--- a/include/device_selection.h
+++ b/include/device_selection.h
@@ -1,16 +1,25 @@
 #pragma once
 
+#include "config.h"
+#include "log.h"
+#include "types.h"
+#include "utils.h"
+
+#include <cassert>
+#include <concepts>
+#include <cstddef>
 #include <functional>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
-#include "config.h"
-#include "log.h"
-#include "utils.h"
-
+#include <fmt/format.h>
 #include <sycl/sycl.hpp>
+
 
 namespace celerity::detail {
 

--- a/include/distr_queue.h
+++ b/include/distr_queue.h
@@ -1,11 +1,23 @@
 #pragma once
 
-#include <future>
-#include <memory>
-
+#include "buffer.h"
+#include "device_selection.h"
 #include "fence.h"
+#include "host_object.h"
+#include "ranges.h"
 #include "runtime.h"
 #include "tracy.h"
+#include "types.h"
+
+#include <future>
+#include <memory>
+#include <stdexcept>
+#include <variant>
+#include <vector>
+
+#include <fmt/format.h>
+#include <sycl/sycl.hpp>
+
 
 namespace celerity {
 

--- a/include/double_buffered_queue.h
+++ b/include/double_buffered_queue.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "system_info.h"
+
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <vector>
 
-#include "system_info.h"
 
 namespace celerity::detail {
 

--- a/include/dry_run_executor.h
+++ b/include/dry_run_executor.h
@@ -2,9 +2,14 @@
 
 #include "double_buffered_queue.h"
 #include "executor.h"
+#include "types.h"
 
+#include <memory>
 #include <thread>
+#include <utility>
 #include <variant>
+#include <vector>
+
 
 namespace celerity::detail {
 

--- a/include/executor.h
+++ b/include/executor.h
@@ -3,6 +3,8 @@
 #include "types.h"
 
 #include <memory>
+#include <vector>
+
 
 namespace celerity::detail {
 

--- a/include/fence.h
+++ b/include/fence.h
@@ -1,10 +1,5 @@
 #pragma once
 
-#include <future>
-#include <memory>
-#include <type_traits>
-#include <vector>
-
 #include "buffer.h"
 #include "host_object.h"
 #include "range_mapper.h"
@@ -13,6 +8,12 @@
 #include "task.h"
 #include "task_manager.h"
 #include "tracy.h"
+
+#include <future>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
 
 namespace celerity::detail {
 

--- a/include/grid.h
+++ b/include/grid.h
@@ -1,14 +1,18 @@
 #pragma once
 
+#include "ranges.h"
+#include "workaround.h"
+
 #include <algorithm>
+#include <cassert>
+#include <cstddef>
 #include <iterator>
 #include <limits>
 #include <numeric>
+#include <vector>
 
 #include <gch/small_vector.hpp>
 
-#include "ranges.h"
-#include "workaround.h"
 
 namespace celerity::detail {
 

--- a/include/handler.h
+++ b/include/handler.h
@@ -1,6 +1,29 @@
 #pragma once
 
+#include "buffer.h"
+#include "cgf_diagnostics.h"
+#include "communicator.h"
+#include "grid.h"
+#include "hint.h"
+#include "item.h"
+#include "launcher.h"
+#include "partition.h"
+#include "range_mapper.h"
+#include "ranges.h"
+#include "reduction.h"
+#include "sycl_wrappers.h"
+#include "task.h"
+#include "types.h"
+#include "version.h"
+#include "workaround.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
 #include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
@@ -9,17 +32,6 @@
 #include <fmt/format.h>
 #include <sycl/sycl.hpp>
 
-#include "buffer.h"
-#include "cgf_diagnostics.h"
-#include "item.h"
-#include "partition.h"
-#include "range_mapper.h"
-#include "ranges.h"
-#include "sycl_wrappers.h"
-#include "task.h"
-#include "types.h"
-#include "version.h"
-#include "workaround.h"
 
 namespace celerity {
 class handler;

--- a/include/hint.h
+++ b/include/hint.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <stdexcept>
+
 
 namespace celerity {
 class handler;

--- a/include/host_object.h
+++ b/include/host_object.h
@@ -1,11 +1,15 @@
 #pragma once
 
+#include "runtime.h"
+#include "tracy.h"
+#include "types.h"
+
+#include <cassert>
+#include <functional>
 #include <memory>
 #include <type_traits>
 #include <utility>
 
-#include "runtime.h"
-#include "tracy.h"
 
 namespace celerity::experimental {
 

--- a/include/host_utils.h
+++ b/include/host_utils.h
@@ -2,6 +2,10 @@
 
 #include "item.h"
 #include "partition.h"
+#include "ranges.h"
+
+#include <cstddef>
+
 
 namespace celerity::experimental {
 

--- a/include/instruction_graph.h
+++ b/include/instruction_graph.h
@@ -7,10 +7,15 @@
 #include "ranges.h"
 #include "types.h"
 #include "version.h"
+#include "workaround.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdlib>
 #include <memory>
+#include <string>
+#include <utility>
+#include <variant>
 #include <vector>
 
 #include <gch/small_vector.hpp>

--- a/include/instruction_graph_generator.h
+++ b/include/instruction_graph_generator.h
@@ -4,7 +4,11 @@
 #include "ranges.h"
 #include "types.h"
 
+#include <cstddef>
 #include <limits>
+#include <memory>
+#include <string>
+#include <vector>
 
 
 namespace celerity::detail {

--- a/include/intrusive_graph.h
+++ b/include/intrusive_graph.h
@@ -2,10 +2,12 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <optional>
 #include <type_traits>
 
 #include <gch/small_vector.hpp>
+
 
 namespace celerity {
 namespace detail {

--- a/include/item.h
+++ b/include/item.h
@@ -1,6 +1,14 @@
 #pragma once
 
 #include "ranges.h"
+#include "sycl_wrappers.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+
+#include <sycl/sycl.hpp>
+
 
 namespace celerity {
 

--- a/include/launcher.h
+++ b/include/launcher.h
@@ -8,6 +8,7 @@
 
 #include <sycl/sycl.hpp>
 
+
 namespace celerity::detail {
 
 class communicator;

--- a/include/live_executor.h
+++ b/include/live_executor.h
@@ -2,11 +2,15 @@
 
 #include "double_buffered_queue.h"
 #include "executor.h"
+#include "types.h"
 
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <thread>
 #include <variant>
+#include <vector>
+
 
 namespace celerity::detail::live_executor_detail {
 

--- a/include/local_communicator.h
+++ b/include/local_communicator.h
@@ -1,7 +1,14 @@
 #pragma once
 
+#include "async_event.h"
 #include "communicator.h"
+#include "pilot.h"
+#include "types.h"
 #include "utils.h"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
 
 
 namespace celerity::detail {

--- a/include/log.h
+++ b/include/log.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <spdlog/spdlog.h>
-
 #include "print_utils.h" // any translation unit that needs logging probably also wants pretty-printing
+
+#include <spdlog/spdlog.h>
 
 
 #define CELERITY_LOG(level, ...) (::spdlog::should_log(level) ? SPDLOG_LOGGER_CALL(::spdlog::default_logger_raw(), level, __VA_ARGS__) : (void)0)

--- a/include/mpi_communicator.h
+++ b/include/mpi_communicator.h
@@ -1,12 +1,18 @@
 #pragma once
 
+#include "async_event.h"
 #include "communicator.h"
+#include "pilot.h"
+#include "types.h"
 
+#include <cstddef>
 #include <memory>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
 #include <mpi.h>
+
 
 namespace celerity::detail {
 

--- a/include/named_threads.h
+++ b/include/named_threads.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <thread>
 
+
 namespace celerity::detail {
 
 std::thread::native_handle_type get_current_thread_handle();

--- a/include/nd_memory.h
+++ b/include/nd_memory.h
@@ -4,6 +4,8 @@
 #include "ranges.h"
 #include "utils.h"
 
+#include <cassert>
+#include <cstddef>
 #include <cstring>
 #include <variant>
 

--- a/include/out_of_order_engine.h
+++ b/include/out_of_order_engine.h
@@ -1,8 +1,10 @@
 #include "types.h"
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <unordered_set>
+
 
 namespace celerity::detail::out_of_order_engine_detail {
 struct engine_impl;

--- a/include/partition.h
+++ b/include/partition.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "communicator.h"
 #include "ranges.h"
 #include "utils.h"
 #include "version.h"
+
+#include <cstddef>
 
 #if CELERITY_ENABLE_MPI
 #include "mpi_communicator.h" // TODO only used for type cast - move that function to .cc file

--- a/include/print_graph.h
+++ b/include/print_graph.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include <memory>
-#include <string>
-
 #include "recorders.h"
+#include "types.h"
+
+#include <string>
+#include <vector>
+
 
 namespace celerity::detail {
 

--- a/include/print_utils.h
+++ b/include/print_utils.h
@@ -9,7 +9,11 @@
 #include "types.h"
 #include "utils.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <string_view>
 #include <type_traits>
 
 #include <fmt/format.h>

--- a/include/queue.h
+++ b/include/queue.h
@@ -1,12 +1,17 @@
 #pragma once
 
-#include <future>
-#include <memory>
-
+#include "buffer.h"
+#include "device_selection.h"
 #include "fence.h"
+#include "host_object.h"
+#include "ranges.h"
 #include "runtime.h"
 #include "tracy.h"
 #include "types.h"
+
+#include <future>
+#include <memory>
+
 
 namespace celerity::detail {
 struct barrier_tag {};

--- a/include/range_mapper.h
+++ b/include/range_mapper.h
@@ -1,14 +1,16 @@
 #pragma once
 
+#include "grid.h"
+#include "ranges.h"
+
+#include <cassert>
+#include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <type_traits>
 
 #include <fmt/format.h>
 #include <sycl/sycl.hpp>
-
-#include "grid.h"
-#include "ranges.h"
-#include "utils.h"
 
 
 namespace celerity {

--- a/include/ranges.h
+++ b/include/ranges.h
@@ -1,7 +1,13 @@
 #pragma once
 
-#include "sycl_wrappers.h"
 #include "workaround.h"
+
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
+
+#include <sycl/sycl.hpp>
+
 
 namespace celerity {
 

--- a/include/receive_arbiter.h
+++ b/include/receive_arbiter.h
@@ -1,10 +1,18 @@
 #pragma once
 
+#include "async_event.h"
 #include "communicator.h"
+#include "grid.h"
 #include "pilot.h"
+#include "types.h"
 
+#include <cstddef>
+#include <memory>
 #include <unordered_map>
+#include <utility>
 #include <variant>
+#include <vector>
+
 
 namespace celerity::detail::receive_arbiter_detail {
 

--- a/include/recorders.h
+++ b/include/recorders.h
@@ -4,7 +4,6 @@
 #include "grid.h"
 #include "instruction_graph.h"
 #include "intrusive_graph.h"
-#include "matchbox.hh"
 #include "nd_memory.h"
 #include "pilot.h"
 #include "ranges.h"
@@ -23,6 +22,8 @@
 #include <utility>
 #include <variant>
 #include <vector>
+
+#include <matchbox.hh>
 
 
 namespace celerity::detail {

--- a/include/recorders.h
+++ b/include/recorders.h
@@ -1,11 +1,26 @@
 #pragma once
 
 #include "command_graph.h"
+#include "grid.h"
 #include "instruction_graph.h"
+#include "intrusive_graph.h"
+#include "matchbox.hh"
+#include "nd_memory.h"
 #include "pilot.h"
+#include "ranges.h"
+#include "sycl_wrappers.h"
 #include "task.h"
+#include "types.h"
 
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
 #include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 

--- a/include/reduction.h
+++ b/include/reduction.h
@@ -2,8 +2,10 @@
 
 #include "types.h"
 
+#include <cstddef>
 #include <memory>
 #include <numeric>
+
 
 namespace celerity::detail {
 

--- a/include/region_map.h
+++ b/include/region_map.h
@@ -1,19 +1,23 @@
 #pragma once
 
+#include "grid.h"
+#include "ranges.h"
+#include "utils.h"
+
+#include <cassert>
+#include <cstddef>
 #include <limits>
 #include <memory>
-#include <numeric>
 #include <optional>
 #include <queue>
 #include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
 #include <fmt/format.h>
 #include <matchbox.hh>
 
-#include "grid.h"
-#include "utils.h"
 
 // Some toggles that affect performance (but also change the behavior!)
 // TODO: Consider making these template arguments instead (inside some config object), and add these:

--- a/include/runtime.h
+++ b/include/runtime.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <memory>
-#include <unordered_set>
-
 #include "config.h"
 #include "device_selection.h"
 #include "executor.h"
@@ -11,6 +8,10 @@
 #include "task.h"
 #include "task_manager.h"
 #include "types.h"
+
+#include <memory>
+#include <unordered_set>
+
 
 namespace celerity {
 namespace detail {

--- a/include/split.h
+++ b/include/split.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "ranges.h"
+
+#include <cstddef>
 #include <vector>
 
-#include "ranges.h"
 
 namespace celerity::detail {
 

--- a/include/sycl_wrappers.h
+++ b/include/sycl_wrappers.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "workaround.h"
+#include <type_traits>
 
 #include <sycl/sycl.hpp>
+
 
 namespace celerity {
 

--- a/include/system_info.h
+++ b/include/system_info.h
@@ -4,6 +4,8 @@
 #include "types.h"
 
 #include <bitset>
+#include <cstddef>
+
 
 namespace celerity::detail {
 

--- a/include/task.h
+++ b/include/task.h
@@ -1,12 +1,5 @@
 #pragma once
 
-#include <cassert>
-#include <memory>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
-#include <vector>
-
 #include "graph.h"
 #include "grid.h"
 #include "hint.h"
@@ -17,6 +10,17 @@
 #include "reduction.h"
 #include "sycl_wrappers.h"
 #include "types.h"
+#include "utils.h"
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
 
 namespace celerity {
 

--- a/include/task_manager.h
+++ b/include/task_manager.h
@@ -1,13 +1,18 @@
 #pragma once
 
+#include "intrusive_graph.h"
+#include "ranges.h"
+#include "region_map.h"
+#include "task.h"
+#include "types.h"
+
+#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
-#include "region_map.h"
-#include "task.h"
-#include "types.h"
 
 namespace celerity {
 namespace detail {

--- a/include/thread_queue.h
+++ b/include/thread_queue.h
@@ -6,11 +6,19 @@
 #include "tracy.h"
 #include "utils.h"
 
+#include <cassert>
 #include <chrono>
+#include <exception>
+#include <functional>
 #include <future>
+#include <memory>
+#include <optional>
+#include <string>
 #include <thread>
 #include <type_traits>
+#include <utility>
 #include <variant>
+
 
 namespace celerity::detail {
 

--- a/include/tracy.h
+++ b/include/tracy.h
@@ -13,6 +13,7 @@
 #include <tracy/Tracy.hpp>
 #include <tracy/TracyC.h>
 
+
 namespace celerity::detail::tracy_detail {
 
 // This is intentionally not an atomic, as parts of Celerity (= live_executor) expect it not to change after runtime startup.

--- a/include/types.h
+++ b/include/types.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <type_traits>
 
+
 namespace celerity::detail {
 
 /// Like `false`, but dependent on one or more template parameters. Use as the condition of always-failing static assertions in overloads, template

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "types.h"
+
 #include <algorithm>
 #include <cassert>
+#include <concepts>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <string>
@@ -9,10 +13,9 @@
 #include <tuple>
 #include <type_traits>
 #include <typeinfo>
+#include <utility>
 
 #include <fmt/format.h>
-
-#include "types.h"
 
 
 #define CELERITY_DETAIL_UTILS_CAT_2(a, b) a##b

--- a/include/workaround.h
+++ b/include/workaround.h
@@ -6,6 +6,7 @@
 
 #include <sycl/sycl.hpp>
 
+
 #if CELERITY_SYCL_IS_DPCPP
 #define CELERITY_WORKAROUND_DPCPP 1
 #else

--- a/src/affinity.cc
+++ b/src/affinity.cc
@@ -8,7 +8,9 @@
 #include <string_view>
 #include <vector>
 
+#include <fmt/format.h>
 #include <libenvpp/env.hpp>
+
 
 namespace celerity::detail::thread_pinning {
 

--- a/src/backend/sycl_backend.cc
+++ b/src/backend/sycl_backend.cc
@@ -25,7 +25,7 @@ std::optional<std::chrono::nanoseconds> sycl_event::get_native_execution_time() 
 
 void delayed_async_event::state::set_value(async_event event) {
 	m_event = std::move(event);
-	[[maybe_unused]] bool previously_ready = m_is_ready.exchange(true, std::memory_order_release);
+	[[maybe_unused]] const bool previously_ready = m_is_ready.exchange(true, std::memory_order_release);
 	assert(!previously_ready && "delayed_async_event::state::set_value() called more than once");
 }
 
@@ -309,7 +309,7 @@ async_event celerity::detail::sycl_backend::enqueue_device_work(
 
 	// Note: this mechanism is quite similar in principle to a std::future/promise,
 	//       but implementing it with that caused a 50% (!) slowdown in system-level benchmarks
-	sycl_backend_detail::delayed_async_event::shared_state async_event_state = std::make_shared<sycl_backend_detail::delayed_async_event::state>();
+	const auto async_event_state = std::make_shared<sycl_backend_detail::delayed_async_event::state>();
 	auto async_event = make_async_event<sycl_backend_detail::delayed_async_event>(async_event_state);
 
 	(void)submission_thread->submit([this, device, lane, work, async_event_state] {

--- a/src/backend/sycl_backend.cc
+++ b/src/backend/sycl_backend.cc
@@ -1,17 +1,39 @@
 #include "backend/sycl_backend.h"
 
 #include "affinity.h"
+#include "async_event.h"
+#include "backend/backend.h"
 #include "closure_hydrator.h"
 #include "dense_map.h"
+#include "fmt/format.h"
+#include "grid.h"
+#include "launcher.h"
 #include "nd_memory.h"
+#include "sycl_wrappers.h"
 #include "system_info.h"
 #include "thread_queue.h"
+#include "tracy.h"
 #include "types.h"
+#include "utils.h"
+#include "workaround.h"
 
+#include <algorithm>
 #include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+#include <cstring>
+#include <exception>
+#include <functional>
 #include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <fmt/ranges.h>
+#include <sycl/sycl.hpp>
+
 
 namespace celerity::detail::sycl_backend_detail {
 

--- a/src/backend/sycl_backend.cc
+++ b/src/backend/sycl_backend.cc
@@ -5,7 +5,6 @@
 #include "backend/backend.h"
 #include "closure_hydrator.h"
 #include "dense_map.h"
-#include "fmt/format.h"
 #include "grid.h"
 #include "launcher.h"
 #include "nd_memory.h"
@@ -31,6 +30,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <sycl/sycl.hpp>
 

--- a/src/backend/sycl_cuda_backend.cc
+++ b/src/backend/sycl_cuda_backend.cc
@@ -1,14 +1,28 @@
 #include "backend/sycl_backend.h"
 
-#include <cuda_runtime.h>
-
+#include "async_event.h"
+#include "grid.h"
 #include "log.h"
 #include "nd_memory.h"
 #include "ranges.h"
 #include "system_info.h"
 #include "tracy.h"
+#include "types.h"
 #include "utils.h"
 #include "version.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cuda_runtime_api.h>
+#include <driver_functions.h>
+#include <driver_types.h>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <sycl/sycl.hpp>
+
 
 #define CELERITY_STRINGIFY2(f) #f
 #define CELERITY_STRINGIFY(f) CELERITY_STRINGIFY2(f)

--- a/src/backend/sycl_cuda_backend.cc
+++ b/src/backend/sycl_cuda_backend.cc
@@ -13,14 +13,12 @@
 
 #include <cassert>
 #include <cstddef>
-#include <cuda_runtime_api.h>
-#include <driver_functions.h>
-#include <driver_types.h>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
+#include <cuda_runtime.h>
 #include <sycl/sycl.hpp>
 
 

--- a/src/backend/sycl_generic_backend.cc
+++ b/src/backend/sycl_generic_backend.cc
@@ -1,10 +1,21 @@
 #include "backend/sycl_backend.h"
 
+#include "async_event.h"
+#include "grid.h"
 #include "log.h"
 #include "nd_memory.h"
 #include "ranges.h"
 #include "tracy.h"
 #include "types.h"
+
+#include <cassert>
+#include <cstddef>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <sycl/sycl.hpp>
+
 
 namespace celerity::detail::sycl_backend_detail {
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -1,14 +1,20 @@
 #include "config.h"
 
-#include <cstdlib>
-#include <string_view>
-
 #include "affinity.h"
 #include "log.h"
+#include "types.h"
+#include "workaround.h"
 
-#include <spdlog/sinks/sink.h>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
+#include <fmt/format.h>
 #include <libenvpp/env.hpp>
+
 
 namespace env {
 

--- a/src/dry_run_executor.cc
+++ b/src/dry_run_executor.cc
@@ -1,4 +1,5 @@
 #include "dry_run_executor.h"
+
 #include "host_object.h"
 #include "instruction_graph.h"
 #include "log.h"

--- a/src/grid.cc
+++ b/src/grid.cc
@@ -1,5 +1,15 @@
 #include "grid.h"
+
+#include "ranges.h"
 #include "utils.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <vector>
+
 
 namespace celerity::detail::grid_detail {
 

--- a/src/instruction_graph_generator.cc
+++ b/src/instruction_graph_generator.cc
@@ -3,14 +3,11 @@
 #include "access_modes.h"
 #include "command_graph.h"
 #include "dense_map.h"
-#include "fmt/base.h"
-#include "fmt/format.h"
 #include "grid.h"
 #include "hint.h"
 #include "instruction_graph.h"
 #include "launcher.h"
 #include "log.h"
-#include "matchbox.hh"
 #include "nd_memory.h"
 #include "pilot.h"
 #include "ranges.h"
@@ -40,7 +37,9 @@
 #include <variant>
 #include <vector>
 
+#include <fmt/format.h>
 #include <gch/small_vector.hpp>
+#include <matchbox.hh>
 
 
 namespace celerity::detail::instruction_graph_generator_detail {

--- a/src/instruction_graph_generator.cc
+++ b/src/instruction_graph_generator.cc
@@ -2,11 +2,20 @@
 
 #include "access_modes.h"
 #include "command_graph.h"
+#include "dense_map.h"
+#include "fmt/base.h"
+#include "fmt/format.h"
 #include "grid.h"
+#include "hint.h"
 #include "instruction_graph.h"
+#include "launcher.h"
 #include "log.h"
-#include "print_utils.h"
+#include "matchbox.hh"
+#include "nd_memory.h"
+#include "pilot.h"
+#include "ranges.h"
 #include "recorders.h"
+#include "reduction.h"
 #include "region_map.h"
 #include "split.h"
 #include "system_info.h"
@@ -14,10 +23,24 @@
 #include "tracy.h"
 #include "types.h"
 #include "utils.h"
+#include "workaround.h"
 
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <limits>
+#include <numeric>
+#include <optional>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <variant>
 #include <vector>
+
+#include <gch/small_vector.hpp>
 
 
 namespace celerity::detail::instruction_graph_generator_detail {

--- a/src/live_executor.cc
+++ b/src/live_executor.cc
@@ -1,4 +1,5 @@
 #include "live_executor.h"
+
 #include "affinity.h"
 #include "backend/backend.h"
 #include "closure_hydrator.h"

--- a/src/mpi_communicator.cc
+++ b/src/mpi_communicator.cc
@@ -1,11 +1,24 @@
 #include "mpi_communicator.h"
-#include "log.h"
-#include "ranges.h"
 
+#include "async_event.h"
+#include "communicator.h"
+#include "log.h"
+#include "pilot.h"
+#include "ranges.h"
+#include "types.h"
+
+#include <algorithm>
+#include <cassert>
 #include <climits>
 #include <cstddef>
+#include <memory>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include <mpi.h>
+
 
 namespace celerity::detail::mpi_detail {
 

--- a/src/out_of_order_engine.cc
+++ b/src/out_of_order_engine.cc
@@ -1,4 +1,5 @@
 #include "out_of_order_engine.h"
+
 #include "dense_map.h"
 #include "instruction_graph.h"
 #include "system_info.h"
@@ -11,6 +12,7 @@
 #include <vector>
 
 #include <matchbox.hh>
+
 
 namespace celerity::detail::out_of_order_engine_detail {
 

--- a/src/platform_specific/affinity.unix.cc
+++ b/src/platform_specific/affinity.unix.cc
@@ -1,6 +1,11 @@
+#include "affinity.h"
+
+#include "log.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <iterator>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -12,8 +17,6 @@
 #include <pthread.h>
 #include <sched.h>
 
-#include "affinity.h"
-#include "log.h"
 
 namespace {
 

--- a/src/platform_specific/affinity.win.cc
+++ b/src/platform_specific/affinity.win.cc
@@ -1,11 +1,15 @@
-#include <cassert>
-
 #include "affinity.h"
+
 #include "log.h"
 
+#include <cassert>
+
+
 namespace celerity::detail::thread_pinning {
+
 thread_pinner::thread_pinner(const runtime_configuration& cfg) {
 	if(cfg.enabled) { CELERITY_WARN("Thread pinning is currently not supported on Windows."); }
 }
 thread_pinner::~thread_pinner() {}
+
 } // namespace celerity::detail::thread_pinning

--- a/src/platform_specific/named_threads.unix.cc
+++ b/src/platform_specific/named_threads.unix.cc
@@ -1,10 +1,14 @@
 #include "named_threads.h"
+
 #include "version.h"
 
 #include <cassert>
+#include <string>
+#include <thread>
 #include <type_traits>
 
 #include <pthread.h>
+
 
 namespace celerity::detail {
 

--- a/src/platform_specific/named_threads.win.cc
+++ b/src/platform_specific/named_threads.win.cc
@@ -6,6 +6,7 @@
 
 #include <windows.h>
 
+
 namespace celerity::detail {
 
 static_assert(std::is_same_v<std::thread::native_handle_type, HANDLE>, "Unexpected native thread handle type");

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -1,18 +1,32 @@
 #include "print_graph.h"
 
-#include <fmt/format.h>
-
 #include "access_modes.h"
 #include "grid.h"
 #include "instruction_graph.h"
+#include "intrusive_graph.h"
 #include "log.h"
-#include "print_utils.h"
+#include "matchbox.hh"
+#include "ranges.h"
 #include "recorders.h"
+#include "sycl_wrappers.h"
 #include "task.h"
+#include "types.h"
+#include "utils.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
 #include <map>
 #include <set>
+#include <string>
+#include <string_view>
 #include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
 
 namespace celerity::detail {
 

--- a/src/print_graph.cc
+++ b/src/print_graph.cc
@@ -5,7 +5,6 @@
 #include "instruction_graph.h"
 #include "intrusive_graph.h"
 #include "log.h"
-#include "matchbox.hh"
 #include "ranges.h"
 #include "recorders.h"
 #include "sycl_wrappers.h"
@@ -26,6 +25,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <matchbox.hh>
 
 
 namespace celerity::detail {

--- a/src/receive_arbiter.cc
+++ b/src/receive_arbiter.cc
@@ -1,10 +1,23 @@
 #include "receive_arbiter.h"
+
+#include "async_event.h"
+#include "communicator.h"
 #include "grid.h"
+#include "pilot.h"
+#include "ranges.h"
+#include "types.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <utility>
+#include <variant>
 
 #include <matchbox.hh>
 
-#include <exception>
-#include <memory>
 
 namespace celerity::detail::receive_arbiter_detail {
 

--- a/src/recorders.cc
+++ b/src/recorders.cc
@@ -1,8 +1,19 @@
 #include "recorders.h"
 
-#include <cstddef>
-
 #include "command_graph.h"
+#include "grid.h"
+#include "instruction_graph.h"
+#include "ranges.h"
+#include "task.h"
+#include "types.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <optional>
+#include <utility>
+#include <vector>
+
 
 namespace celerity::detail {
 

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -245,7 +245,7 @@ namespace detail {
 
 		{
 			const auto& pin_cfg = m_cfg->get_thread_pinning_config();
-			thread_pinning::runtime_configuration thread_pinning_cfg{
+			const thread_pinning::runtime_configuration thread_pinning_cfg{
 			    .enabled = pin_cfg.enabled,
 			    .num_devices = static_cast<uint32_t>(devices.size()),
 			    .use_backend_device_submission_threads = m_cfg->should_use_backend_device_submission_threads(),

--- a/src/runtime.cc
+++ b/src/runtime.cc
@@ -1,9 +1,51 @@
 #include "runtime.h"
 
+#include "affinity.h"
+#include "backend/sycl_backend.h"
+#include "cgf_diagnostics.h"
+#include "command_graph_generator.h"
+#include "config.h"
+#include "device_selection.h"
+#include "dry_run_executor.h"
+#include "executor.h"
+#include "host_object.h"
+#include "instruction_graph_generator.h"
+#include "live_executor.h"
+#include "log.h"
+#include "print_graph.h"
+#include "ranges.h"
+#include "reduction.h"
+#include "scheduler.h"
+#include "system_info.h"
+#include "task.h"
+#include "task_manager.h"
+#include "tracy.h"
+#include "types.h"
+#include "utils.h"
+#include "version.h"
+
 #include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <future>
 #include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
 #include <string>
+#include <thread>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <fmt/format.h>
+#include <spdlog/spdlog.h>
+#include <sycl/sycl.hpp>
 
 #ifdef _MSC_VER
 #include <process.h>
@@ -15,27 +57,6 @@
 // override default new/delete operators to use the mimalloc memory allocator
 #include <mimalloc-new-delete.h>
 #endif
-
-#include "affinity.h"
-#include "backend/sycl_backend.h"
-#include "cgf_diagnostics.h"
-#include "command_graph_generator.h"
-#include "device_selection.h"
-#include "dry_run_executor.h"
-#include "host_object.h"
-#include "instruction_graph_generator.h"
-#include "live_executor.h"
-#include "log.h"
-#include "print_graph.h"
-#include "reduction.h"
-#include "scheduler.h"
-#include "system_info.h"
-#include "task.h"
-#include "task_manager.h"
-#include "tracy.h"
-#include "types.h"
-#include "utils.h"
-#include "version.h"
 
 #if CELERITY_ENABLE_MPI
 #include "mpi_communicator.h"

--- a/src/split.cc
+++ b/src/split.cc
@@ -1,10 +1,16 @@
 #include "split.h"
 
-#include <array>
-#include <cmath>
-#include <tuple>
-
 #include "grid.h"
+#include "ranges.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <tuple>
+#include <vector>
+
 
 namespace {
 

--- a/src/task.cc
+++ b/src/task.cc
@@ -1,16 +1,18 @@
 #include "task.h"
 
-#include <cstddef>
-#include <unordered_map>
-#include <utility>
-#include <vector>
-
 #include "access_modes.h"
 #include "grid.h"
 #include "range_mapper.h"
 #include "ranges.h"
 #include "types.h"
 #include "utils.h"
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 
 namespace celerity::detail {
 

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -1,17 +1,25 @@
 #include "task_manager.h"
 
-#include "access_modes.h"
 #include "grid.h"
 #include "intrusive_graph.h"
 #include "log.h"
+#include "ranges.h"
 #include "recorders.h"
 #include "task.h"
 #include "types.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 #include <fmt/format.h>
 
-#include <algorithm>
-#include <stdexcept>
 
 namespace celerity {
 namespace detail {

--- a/src/task_manager.cc
+++ b/src/task_manager.cc
@@ -228,7 +228,7 @@ namespace detail {
 		const auto previous_horizon = m_current_horizon;
 		m_current_horizon = unique_horizon.get();
 
-		task& new_horizon = reduce_execution_front(std::move(unique_horizon));
+		const task& new_horizon = reduce_execution_front(std::move(unique_horizon));
 		if(previous_horizon != nullptr) { set_epoch_for_new_tasks(previous_horizon); }
 
 		invoke_callbacks(&new_horizon);

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,9 +1,24 @@
 #include "utils.h"
+
 #include "log.h"
+#include "types.h"
 
 #include <atomic>
+#include <cassert>
+#include <cctype>
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <iterator>
+#include <memory>
 #include <regex>
 #include <stdexcept>
+#include <stdlib.h>
+#include <string>
+#include <string_view>
+#include <typeinfo>
+
+#include <fmt/format.h>
 
 #if !defined(_MSC_VER)
 // Required for kernel name demangling in Clang

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,11 +1,13 @@
 ---
 InheritParentConfig: true
+
 # Disable some checks that cause frequent false-positives in tests
-# misc-include-cleaner: Does not understand that celerity.h is the entry point for all public Celerity headers
-# misc-use-anonymous-namespace: Catch2 emits static functions for TEST_CASE()
-# bugprone-chained-comparison: Catch2 uses a comparison operator overloading hack to decompose expressions
-Checks: -readability-function-cognitive-complexity,
+#   -misc-const-correctness: Would suggest `const accessor` in CGFs
+#   -misc-include-cleaner: Does not understand that celerity.h is the entry point for all public Celerity headers
+#   -misc-use-anonymous-namespace: Catch2 emits static functions for TEST_CASE()
+#   -bugprone-chained-comparison: Catch2 uses a comparison operator overloading hack to decompose expressions
+Checks: -misc-const-correctness,
+  -readability-function-cognitive-complexity,
+  -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-avoid-non-const-global-variables,
-  -misc-include-cleaner,
-  -misc-use-anonymous-namespace,
-  -bugprone-chained-comparison,
+  -bugprone-chained-comparison

--- a/test/accessor_tests.cc
+++ b/test/accessor_tests.cc
@@ -192,12 +192,12 @@ namespace detail {
 				accessor acc_read(buf_in, cgh, one_to_one(), read_only);
 				accessor acc_write(buf_out, cgh, one_to_one(), write_only, no_init);
 				cgh.parallel_for(range, [=](celerity::item<Dims> item) {
-					size_t i = item[0];
-					size_t j = item[1];
+					const size_t i = item[0];
+					const size_t j = item[1];
 					if constexpr(Dims == 2) {
 						acc_write[i][j] = acc_read[i][j];
 					} else {
-						size_t k = item[2];
+						const size_t k = item[2];
 						acc_write[i][j][k] = acc_read[i][j][k];
 					}
 				});
@@ -210,12 +210,12 @@ namespace detail {
 				accessor acc_write(buf_out, cgh, one_to_one(), write_only_host_task, no_init);
 				cgh.host_task(range, [=](celerity::partition<Dims> part) {
 					experimental::for_each_item(range, [&](celerity::item<Dims> item) {
-						size_t i = item[0];
-						size_t j = item[1];
+						const size_t i = item[0];
+						const size_t j = item[1];
 						if constexpr(Dims == 2) {
 							acc_write[i][j] = acc_read[i][j];
 						} else {
-							size_t k = item[2];
+							const size_t k = item[2];
 							acc_write[i][j][k] = acc_read[i][j][k];
 						}
 					});
@@ -299,7 +299,7 @@ namespace detail {
 		queue q;
 		std::optional<buffer<int>> buf;
 
-		int init = 0;
+		const int init = 0;
 		SECTION("when the buffer is uninitialized") { buf = buffer<int>{1}; };
 		SECTION("when the buffer is host-initialized") { buf = buffer<int>{&init, 1}; };
 

--- a/test/affinity_tests.cc
+++ b/test/affinity_tests.cc
@@ -52,7 +52,7 @@ class raii_test_runtime {
   public:
 	raii_test_runtime(int n) {
 		// devices are default constructible, and we don't care if we use the same more than once
-		std::vector<sycl::device> devices(n);
+		const std::vector<sycl::device> devices(n);
 		celerity::runtime::init(nullptr, nullptr, devices);
 	}
 	~raii_test_runtime() { celerity::runtime::shutdown(); }

--- a/test/dag_benchmarks.cc
+++ b/test/dag_benchmarks.cc
@@ -24,7 +24,7 @@ TEMPLATE_TEST_CASE_SIG("benchmark intrusive graph dependency handling with N nod
 	// existing nodes -- this is intentional; both cases are relevant in practise
 
 	BENCHMARK("creating nodes") {
-		bench_graph_node nodes[N];
+		const bench_graph_node nodes[N];
 		return nodes[N - 1].get_pseudo_critical_path_length(); // trick the compiler
 	};
 

--- a/test/debug/pretty_printables.cc
+++ b/test/debug/pretty_printables.cc
@@ -9,31 +9,31 @@ static const auto epoch_cmd = std::make_unique<celerity::detail::epoch_command>(
     celerity::detail::command_id{123}, epoch_task.get(), celerity::detail::epoch_action::none, std::vector<celerity::detail::reduction_id>());
 
 int main() {
-	[[maybe_unused]] celerity::detail::task_id tid = 10;
-	[[maybe_unused]] celerity::detail::buffer_id bid = 11;
-	[[maybe_unused]] celerity::detail::node_id nid = 12;
-	[[maybe_unused]] celerity::detail::command_id cid = 13;
-	[[maybe_unused]] celerity::detail::collective_group_id cgid = 14;
-	[[maybe_unused]] celerity::detail::reduction_id rid = 15;
-	[[maybe_unused]] celerity::detail::host_object_id hoid = 16;
-	[[maybe_unused]] celerity::detail::hydration_id hyid = 17;
-	[[maybe_unused]] celerity::detail::transfer_id trid{18, 19};
-	[[maybe_unused]] celerity::detail::transfer_id reduction_trid{20, 21, 22};
-	[[maybe_unused]] celerity::detail::memory_id mid = 23;
-	[[maybe_unused]] celerity::detail::raw_allocation_id raid = 24;
-	[[maybe_unused]] celerity::detail::device_id did = 25;
-	[[maybe_unused]] celerity::detail::instruction_id iid = 26;
-	[[maybe_unused]] celerity::detail::allocation_id aid(27, 28);
-	[[maybe_unused]] celerity::detail::message_id msgid(34);
+	[[maybe_unused]] const celerity::detail::task_id tid = 10;
+	[[maybe_unused]] const celerity::detail::buffer_id bid = 11;
+	[[maybe_unused]] const celerity::detail::node_id nid = 12;
+	[[maybe_unused]] const celerity::detail::command_id cid = 13;
+	[[maybe_unused]] const celerity::detail::collective_group_id cgid = 14;
+	[[maybe_unused]] const celerity::detail::reduction_id rid = 15;
+	[[maybe_unused]] const celerity::detail::host_object_id hoid = 16;
+	[[maybe_unused]] const celerity::detail::hydration_id hyid = 17;
+	[[maybe_unused]] const celerity::detail::transfer_id trid{18, 19};
+	[[maybe_unused]] const celerity::detail::transfer_id reduction_trid{20, 21, 22};
+	[[maybe_unused]] const celerity::detail::memory_id mid = 23;
+	[[maybe_unused]] const celerity::detail::raw_allocation_id raid = 24;
+	[[maybe_unused]] const celerity::detail::device_id did = 25;
+	[[maybe_unused]] const celerity::detail::instruction_id iid = 26;
+	[[maybe_unused]] const celerity::detail::allocation_id aid(27, 28);
+	[[maybe_unused]] const celerity::detail::message_id msgid(34);
 
-	[[maybe_unused]] celerity::id<3> id(1, 2, 3);
-	[[maybe_unused]] celerity::range<3> range(1, 2, 3);
-	[[maybe_unused]] celerity::subrange<3> subrange(celerity::id(1, 2, 3), celerity::range(4, 5, 6));
-	[[maybe_unused]] celerity::chunk<3> chunk(celerity::id(1, 2, 3), celerity::range(4, 5, 6), celerity::range(7, 8, 9));
-	[[maybe_unused]] celerity::nd_range<3> nd_range(celerity::range(2, 4, 6), celerity::range(1, 2, 3), celerity::id(7, 8, 9));
-	[[maybe_unused]] celerity::detail::box<3> box(celerity::id(1, 2, 3), celerity::id(4, 5, 6));
-	[[maybe_unused]] celerity::detail::region<3> empty_region;
-	[[maybe_unused]] celerity::detail::region<3> region({
+	[[maybe_unused]] const celerity::id<3> id(1, 2, 3);
+	[[maybe_unused]] const celerity::range<3> range(1, 2, 3);
+	[[maybe_unused]] const celerity::subrange<3> subrange(celerity::id(1, 2, 3), celerity::range(4, 5, 6));
+	[[maybe_unused]] const celerity::chunk<3> chunk(celerity::id(1, 2, 3), celerity::range(4, 5, 6), celerity::range(7, 8, 9));
+	[[maybe_unused]] const celerity::nd_range<3> nd_range(celerity::range(2, 4, 6), celerity::range(1, 2, 3), celerity::id(7, 8, 9));
+	[[maybe_unused]] const celerity::detail::box<3> box(celerity::id(1, 2, 3), celerity::id(4, 5, 6));
+	[[maybe_unused]] const celerity::detail::region<3> empty_region;
+	[[maybe_unused]] const celerity::detail::region<3> region({
 	    celerity::detail::box(celerity::id(1, 2, 3), celerity::id(4, 5, 6)),
 	    celerity::detail::box(celerity::id(11, 2, 3), celerity::id(14, 5, 6)),
 	    celerity::detail::box(celerity::id(21, 2, 3), celerity::id(24, 5, 6)),
@@ -44,12 +44,12 @@ int main() {
 	region_map.update_box(celerity::detail::box<3>({1, 1, 1}, {3, 3, 3}), 69);
 	region_map.update_box(celerity::detail::box<3>({1, 1, 1}, {2, 2, 2}), 1337);
 
-	[[maybe_unused]] celerity::detail::region_map<int> region_map_0d(celerity::range<3>(1, 1, 1), 42);
+	[[maybe_unused]] const celerity::detail::region_map<int> region_map_0d(celerity::range<3>(1, 1, 1), 42);
 
-	[[maybe_unused]] celerity::detail::write_command_state wcs_fresh(epoch_cmd.get());
+	[[maybe_unused]] const celerity::detail::write_command_state wcs_fresh(epoch_cmd.get());
 	[[maybe_unused]] celerity::detail::write_command_state wcs_stale(epoch_cmd.get());
 	wcs_stale.mark_as_stale();
-	[[maybe_unused]] celerity::detail::write_command_state wcs_replicated(epoch_cmd.get(), true /* replicated */);
+	[[maybe_unused]] const celerity::detail::write_command_state wcs_replicated(epoch_cmd.get(), true /* replicated */);
 
 	// tell GDB to break here so we can examine locals
 	__builtin_trap();

--- a/test/device_selection_tests.cc
+++ b/test/device_selection_tests.cc
@@ -457,7 +457,7 @@ TEST_CASE("select_backend picks highest-priority available specialized backend",
 	    mock_device(0, platform, type_and_name{sycl::info::device_type::gpu, "gpu0"}),
 	    mock_device(1, platform, type_and_name{sycl::info::device_type::gpu, "gpu1"}),
 	};
-	mock_backend_enumerator enumerator{{mock_backend_type::generic1, mock_backend_type::generic2, mock_backend_type::specialized2},
+	const mock_backend_enumerator enumerator{{mock_backend_type::generic1, mock_backend_type::generic2, mock_backend_type::specialized2},
 	    {
 	        {devices.at(0), {mock_backend_type::generic1, mock_backend_type::specialized1, mock_backend_type::specialized2}},
 	        {devices.at(1), {mock_backend_type::generic1, mock_backend_type::specialized1, mock_backend_type::specialized2}},
@@ -479,7 +479,7 @@ TEST_CASE("select_backend picks highest-priority available generic backend if th
 	    mock_device(0, platform, type_and_name{sycl::info::device_type::gpu, "gpu0"}),
 	    mock_device(1, platform, type_and_name{sycl::info::device_type::gpu, "gpu1"}),
 	};
-	mock_backend_enumerator enumerator{
+	const mock_backend_enumerator enumerator{
 	    {mock_backend_type::generic1, mock_backend_type::generic2, mock_backend_type::specialized1, mock_backend_type::specialized2},
 	    {
 	        {devices.at(0), {mock_backend_type::generic1, mock_backend_type::generic2, mock_backend_type::specialized1}},
@@ -501,7 +501,7 @@ TEST_CASE("select_backend picks a generic backend if no compatible specializatio
 	    mock_device(0, platform, type_and_name{sycl::info::device_type::gpu, "gpu0"}),
 	    mock_device(1, platform, type_and_name{sycl::info::device_type::gpu, "gpu1"}),
 	};
-	mock_backend_enumerator enumerator{{mock_backend_type::generic1, mock_backend_type::generic2},
+	const mock_backend_enumerator enumerator{{mock_backend_type::generic1, mock_backend_type::generic2},
 	    {
 	        {devices.at(0), {mock_backend_type::generic2, mock_backend_type::specialized1, mock_backend_type::specialized2}},
 	        {devices.at(1), {mock_backend_type::generic2, mock_backend_type::specialized1, mock_backend_type::specialized2}},

--- a/test/graph_test_utils.h
+++ b/test/graph_test_utils.h
@@ -140,7 +140,6 @@ class task_builder {
 	}
 
 	step master_node_host_task() {
-		std::deque<action> actions;
 		return step(m_tctx, [](handler& cgh) { cgh.host_task(on_master_node, [] {}); });
 	}
 

--- a/test/print_graph_tests.cc
+++ b/test/print_graph_tests.cc
@@ -61,7 +61,7 @@ int count_occurences(const std::string& str, const std::string& substr) {
 } // namespace
 
 TEST_CASE("command-graph printing is unchanged", "[print_graph][command-graph]") {
-	size_t num_nodes = 4;
+	const size_t num_nodes = 4;
 	cdag_test_context cctx(num_nodes);
 
 	auto buf_0 = cctx.create_buffer(range(1));

--- a/test/range_mapper_tests.cc
+++ b/test/range_mapper_tests.cc
@@ -85,21 +85,21 @@ subrange<Dims> rm_result_to_subrange(const region<Dims>& r) {
 
 TEST_CASE("range mapper results are clamped to buffer range", "[range-mapper]") {
 	const auto rmfn = [](chunk<3>) { return subrange<3>{{0, 100, 127}, {256, 64, 32}}; };
-	range_mapper rm{rmfn, range<3>{128, 128, 128}};
+	const range_mapper rm{rmfn, range<3>{128, 128, 128}};
 	auto sr = rm_result_to_subrange(rm.map_3(chunk<3>{}));
 	REQUIRE(sr.offset == id<3>{0, 100, 127});
 	REQUIRE(sr.range == range<3>{128, 28, 1});
 }
 
 TEST_CASE("one_to_one built-in range mapper behaves as expected", "[range-mapper]") {
-	range_mapper rm{acc::one_to_one{}, range<2>{128, 128}};
+	const range_mapper rm{acc::one_to_one{}, range<2>{128, 128}};
 	auto sr = rm_result_to_subrange(rm.map_2(chunk<2>{{64, 32}, {32, 4}, {128, 128}}));
 	REQUIRE(sr.offset == id<2>{64, 32});
 	REQUIRE(sr.range == range<2>{32, 4});
 }
 
 TEST_CASE("fixed built-in range mapper behaves as expected", "[range-mapper]") {
-	range_mapper rm{acc::fixed<1>({{3}, {97}}), range<1>{128}};
+	const range_mapper rm{acc::fixed<1>({{3}, {97}}), range<1>{128}};
 	auto sr = rm_result_to_subrange(rm.map_1(chunk<2>{{64, 32}, {32, 4}, {128, 128}}));
 	REQUIRE(sr.offset == id<1>{3});
 	REQUIRE(sr.range == range<1>{97});
@@ -107,19 +107,19 @@ TEST_CASE("fixed built-in range mapper behaves as expected", "[range-mapper]") {
 
 TEST_CASE("slice built-in range mapper behaves as expected", "[range-mapper]") {
 	{
-		range_mapper rm{acc::slice<3>(0), range<3>{128, 128, 128}};
+		const range_mapper rm{acc::slice<3>(0), range<3>{128, 128, 128}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<3>{{32, 32, 32}, {32, 32, 32}, {128, 128, 128}}));
 		REQUIRE(sr.offset == id<3>{0, 32, 32});
 		REQUIRE(sr.range == range<3>{128, 32, 32});
 	}
 	{
-		range_mapper rm{acc::slice<3>(1), range<3>{128, 128, 128}};
+		const range_mapper rm{acc::slice<3>(1), range<3>{128, 128, 128}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<3>{{32, 32, 32}, {32, 32, 32}, {128, 128, 128}}));
 		REQUIRE(sr.offset == id<3>{32, 0, 32});
 		REQUIRE(sr.range == range<3>{32, 128, 32});
 	}
 	{
-		range_mapper rm{acc::slice<3>(2), range<3>{128, 128, 128}};
+		const range_mapper rm{acc::slice<3>(2), range<3>{128, 128, 128}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<3>{{32, 32, 32}, {32, 32, 32}, {128, 128, 128}}));
 		REQUIRE(sr.offset == id<3>{32, 32, 0});
 		REQUIRE(sr.range == range<3>{32, 32, 128});
@@ -128,19 +128,19 @@ TEST_CASE("slice built-in range mapper behaves as expected", "[range-mapper]") {
 
 TEST_CASE("all built-in range mapper behaves as expected", "[range-mapper]") {
 	{
-		range_mapper rm{acc::all{}, range<1>{128}};
+		const range_mapper rm{acc::all{}, range<1>{128}};
 		auto sr = rm_result_to_subrange(rm.map_1(chunk<1>{}));
 		REQUIRE(sr.offset == id<1>{0});
 		REQUIRE(sr.range == range<1>{128});
 	}
 	{
-		range_mapper rm{acc::all{}, range<2>{128, 64}};
+		const range_mapper rm{acc::all{}, range<2>{128, 64}};
 		auto sr = rm_result_to_subrange(rm.map_2(chunk<1>{}));
 		REQUIRE(sr.offset == id<2>{0, 0});
 		REQUIRE(sr.range == range<2>{128, 64});
 	}
 	{
-		range_mapper rm{acc::all{}, range<3>{128, 64, 32}};
+		const range_mapper rm{acc::all{}, range<3>{128, 64, 32}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<1>{}));
 		REQUIRE(sr.offset == id<3>{0, 0, 0});
 		REQUIRE(sr.range == range<3>{128, 64, 32});
@@ -150,17 +150,17 @@ TEST_CASE("all built-in range mapper behaves as expected", "[range-mapper]") {
 TEST_CASE("neighborhood built-in range mapper behaves as expected", "[range-mapper]") {
 	SECTION("with shape = bounding_box") {
 		{
-			range_mapper rm{acc::neighborhood({10}), range<1>{128}};
+			const range_mapper rm{acc::neighborhood({10}), range<1>{128}};
 			const auto r = rm.map_1(chunk<1>{{15}, {10}, {128}});
 			CHECK(r == box<1>(5, 35));
 		}
 		{
-			range_mapper rm{acc::neighborhood({10, 10}), range<2>{128, 128}};
+			const range_mapper rm{acc::neighborhood({10, 10}), range<2>{128, 128}};
 			const auto r = rm.map_2(chunk<2>{{5, 100}, {10, 20}, {128, 128}});
 			CHECK(r == box<2>({0, 90}, {25, 128}));
 		}
 		{
-			range_mapper rm{acc::neighborhood({3, 4, 5}), range<3>{128, 128, 128}};
+			const range_mapper rm{acc::neighborhood({3, 4, 5}), range<3>{128, 128, 128}};
 			const auto r = rm.map_3(chunk<3>{{3, 4, 5}, {1, 1, 1}, {128, 128, 128}});
 			CHECK(r == box<3>({0, 0, 0}, {7, 9, 11}));
 		}
@@ -168,17 +168,17 @@ TEST_CASE("neighborhood built-in range mapper behaves as expected", "[range-mapp
 
 	SECTION("with shape = along_axes") {
 		{
-			range_mapper rm{acc::neighborhood({10}, neighborhood_shape::along_axes), range<1>{128}};
+			const range_mapper rm{acc::neighborhood({10}, neighborhood_shape::along_axes), range<1>{128}};
 			const auto r = rm.map_1(chunk<1>{{15}, {10}, {128}});
 			CHECK(r == box<1>({5}, {35}));
 		}
 		{
-			range_mapper rm{acc::neighborhood({10, 10}, neighborhood_shape::along_axes), range<2>{128, 128}};
+			const range_mapper rm{acc::neighborhood({10, 10}, neighborhood_shape::along_axes), range<2>{128, 128}};
 			const auto r = rm.map_2(chunk<2>{{5, 100}, {10, 20}, {128, 128}});
 			CHECK(r == region<2>({box<2>({0, 100}, {25, 120}), box<2>({5, 90}, {15, 128})}));
 		}
 		{
-			range_mapper rm{acc::neighborhood({3, 4, 5}, neighborhood_shape::along_axes), range<3>{128, 128, 128}};
+			const range_mapper rm{acc::neighborhood({3, 4, 5}, neighborhood_shape::along_axes), range<3>{128, 128, 128}};
 			const auto r = rm.map_3(chunk<3>{{3, 4, 5}, {1, 1, 1}, {128, 128, 128}});
 			CHECK(r == region<3>({box<3>({0, 4, 5}, {7, 5, 6}), box<3>({3, 0, 5}, {4, 9, 6}), box<3>({3, 4, 0}, {4, 5, 11})}));
 		}
@@ -187,43 +187,43 @@ TEST_CASE("neighborhood built-in range mapper behaves as expected", "[range-mapp
 
 TEST_CASE("even_split built-in range mapper behaves as expected", "[range-mapper]") {
 	{
-		range_mapper rm{even_split<3>(), range<3>{128, 345, 678}};
+		const range_mapper rm{even_split<3>(), range<3>{128, 345, 678}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<1>{{0}, {1}, {8}}));
 		REQUIRE(sr.offset == id<3>{0, 0, 0});
 		REQUIRE(sr.range == range<3>{16, 345, 678});
 	}
 	{
-		range_mapper rm{even_split<3>(), range<3>{128, 345, 678}};
+		const range_mapper rm{even_split<3>(), range<3>{128, 345, 678}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<1>{{4}, {2}, {8}}));
 		REQUIRE(sr.offset == id<3>{64, 0, 0});
 		REQUIRE(sr.range == range<3>{32, 345, 678});
 	}
 	{
-		range_mapper rm{even_split<3>(), range<3>{131, 992, 613}};
+		const range_mapper rm{even_split<3>(), range<3>{131, 992, 613}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<1>{{5}, {2}, {7}}));
 		REQUIRE(sr.offset == id<3>{95, 0, 0});
 		REQUIRE(sr.range == range<3>{36, 992, 613});
 	}
 	{
-		range_mapper rm{even_split<3>(range<3>(10, 1, 1)), range<3>{128, 345, 678}};
+		const range_mapper rm{even_split<3>(range<3>(10, 1, 1)), range<3>{128, 345, 678}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<1>{{0}, {1}, {8}}));
 		REQUIRE(sr.offset == id<3>{0, 0, 0});
 		REQUIRE(sr.range == range<3>{20, 345, 678});
 	}
 	{
-		range_mapper rm{even_split<3>(range<3>(10, 1, 1)), range<3>{131, 992, 613}};
+		const range_mapper rm{even_split<3>(range<3>(10, 1, 1)), range<3>{131, 992, 613}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<1>{{0}, {1}, {7}}));
 		REQUIRE(sr.offset == id<3>{0, 0, 0});
 		REQUIRE(sr.range == range<3>{20, 992, 613});
 	}
 	{
-		range_mapper rm{even_split<3>(range<3>(10, 1, 1)), range<3>{131, 992, 613}};
+		const range_mapper rm{even_split<3>(range<3>(10, 1, 1)), range<3>{131, 992, 613}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<1>{{5}, {2}, {7}}));
 		REQUIRE(sr.offset == id<3>{100, 0, 0});
 		REQUIRE(sr.range == range<3>{31, 992, 613});
 	}
 	{
-		range_mapper rm{even_split<3>(range<3>(10, 1, 1)), range<3>{236, 992, 613}};
+		const range_mapper rm{even_split<3>(range<3>(10, 1, 1)), range<3>{236, 992, 613}};
 		auto sr = rm_result_to_subrange(rm.map_3(chunk<1>{{6}, {1}, {7}}));
 		REQUIRE(sr.offset == id<3>{200, 0, 0});
 		REQUIRE(sr.range == range<3>{36, 992, 613});

--- a/test/receive_arbiter_tests.cc
+++ b/test/receive_arbiter_tests.cc
@@ -40,7 +40,7 @@ class mock_recv_communicator : public communicator {
 	[[nodiscard]] async_event receive_payload(const node_id from, const message_id msgid, void* const base, const stride& stride) override {
 		const auto key = std::pair(from, msgid);
 		REQUIRE(m_pending_recvs.count(key) == 0);
-		completion_flag flag = std::make_shared<bool>(false);
+		const completion_flag flag = std::make_shared<bool>(false);
 		m_pending_recvs.emplace(key, std::tuple(base, stride, flag));
 		return make_async_event<mock_event>(flag);
 	}

--- a/test/region_map_tests.cc
+++ b/test/region_map_tests.cc
@@ -184,7 +184,7 @@ void draw(const region_map_impl<ValueType, 2>& rm) {
 TEST_CASE("region_map::try_merge does not attempt to merge intermediate results that no longer exist", "[region_map]") {
 	region_map_impl<int, 2> rm(box<2>::full_range({99, 99}), -1);
 
-	std::vector<std::pair<box<2>, int>> entries = {
+	const std::vector<std::pair<box<2>, int>> entries = {
 	    // These first three entries will be merged
 	    {{{0, 0}, {33, 66}}, 1},
 	    {{{33, 0}, {66, 66}}, 1},
@@ -235,7 +235,7 @@ TEST_CASE("region_map can be moved", "[region_map]") {
 
 TEST_CASE("region_map handles basic operations in 0D", "[region_map]") {
 	const int default_value = -1;
-	region_map_impl<int, 0> rm{{}, default_value};
+	const region_map_impl<int, 0> rm{{}, default_value};
 
 	SECTION("query default value") {
 		const auto results = rm.get_region_values({0, 1});
@@ -791,12 +791,12 @@ TEST_CASE("inserting consecutive boxes results in zero overlap", "[region_map][p
 
 TEST_CASE("query regions are clamped from both sides in region maps with non-zero offset", "[region_map]") {
 	const auto region_box = box<3>({1, 2, 3}, {7, 9, 11});
-	region_map<int> rm(region_box, 42);
+	const region_map<int> rm(region_box, 42);
 	CHECK(rm.get_region_values(box<3>::full_range({20, 19, 18})) == std::vector{std::pair{region_box, 42}});
 }
 
 TEMPLATE_TEST_CASE_SIG("get_region_values(<empty-region>) returns no boxes", "[region_map]", ((int Dims), Dims), 0, 1, 2, 3) {
-	region_map<int> rm(range_cast<3>(test_utils::truncate_range<Dims>({2, 3, 4})), -1);
+	const region_map<int> rm(range_cast<3>(test_utils::truncate_range<Dims>({2, 3, 4})), -1);
 	CHECK(rm.get_region_values(box<3>()).empty());
 	CHECK(rm.get_region_values(region<3>()).empty());
 }

--- a/test/runtime_deprecation_tests.cc
+++ b/test/runtime_deprecation_tests.cc
@@ -31,8 +31,7 @@ namespace detail {
 	}
 
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "an explicit device can be provided to distr_queue", "[deprecated][distr_queue]") {
-		sycl::default_selector selector;
-		sycl::device device{selector};
+		sycl::device device;
 
 		SECTION("before the runtime is initialized") {
 			REQUIRE_FALSE(runtime::has_instance());
@@ -83,7 +82,7 @@ namespace detail {
 
 		experimental::buffer_snapshot<int, 1> full_snapshot = experimental::fence(q, buf).get();
 		experimental::buffer_snapshot<int, 1> partial_snapshot = experimental::fence(q, buf, subrange<1>(8, 8)).get();
-		int ho_value = experimental::fence(q, ho).get();
+		const int ho_value = experimental::fence(q, ho).get();
 
 		CHECK(full_snapshot.get_range() == range<1>(16));
 		CHECK(std::equal(init.begin(), init.end(), full_snapshot.get_data()));

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -83,8 +83,8 @@ namespace detail {
 		task_manager tm{1, tdag, nullptr, &delegate};
 		tm.generate_epoch_task(epoch_action::init);
 		CHECK(delegate.counter == 1);
-		range<2> gs = {1, 1};
-		id<2> go = {};
+		const range<2> gs = {1, 1};
+		const id<2> go = {};
 		tm.submit_command_group([=](handler& cgh) { cgh.parallel_for<class kernel>(gs, go, [](auto) {}); });
 		CHECK(delegate.counter == 2);
 		tm.submit_command_group([](handler& cgh) { cgh.host_task(on_master_node, [] {}); });
@@ -126,13 +126,13 @@ namespace detail {
 		std::vector<buffer_access> accs;
 		accs.push_back(buffer_access{0, access_mode::read, std::make_unique<range_mapper<2, fixed<2>>>(subrange<2>{{3, 0}, {10, 20}}, range<2>{30, 30})});
 		accs.push_back(buffer_access{0, access_mode::read, std::make_unique<range_mapper<2, fixed<2>>>(subrange<2>{{10, 0}, {7, 20}}, range<2>{30, 30})});
-		buffer_access_map bam{std::move(accs), task_geometry{2, {100, 100, 1}, {}, {}}};
+		const buffer_access_map bam{std::move(accs), task_geometry{2, {100, 100, 1}, {}, {}}};
 		const auto req = bam.compute_consumed_region(0, subrange<3>({0, 0, 0}, {100, 100, 1}));
 		CHECK(req == box(subrange<3>({3, 0, 0}, {14, 20, 1})));
 	}
 
 	TEST_CASE("tasks gracefully handle get_requirements() calls for buffers they don't access", "[task]") {
-		buffer_access_map bam;
+		const buffer_access_map bam;
 		const auto req = bam.compute_consumed_region(0, subrange<3>({0, 0, 0}, {100, 1, 1}));
 		CHECK(req == box<3>());
 	}
@@ -836,49 +836,41 @@ namespace detail {
 
 		const std::string error_string{"Failed to parse/validate environment variables."};
 		{
-			std::unordered_map<std::string, std::string> invalid_test_env_var{{"CELERITY_LOG_LEVEL", "a"}};
-			const auto test_env = env::scoped_test_environment(invalid_test_env_var);
+			env::scoped_test_environment ste("CELERITY_LOG_LEVEL", "a");
 			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
 		}
 
 		{
-			std::unordered_map<std::string, std::string> invalid_test_env_var{{"CELERITY_GRAPH_PRINT_MAX_VERTS", "a"}};
-			const auto test_env = env::scoped_test_environment(invalid_test_env_var);
+			env::scoped_test_environment ste("CELERITY_GRAPH_PRINT_MAX_VERTS", "a");
 			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
 		}
 
 		{
-			std::unordered_map<std::string, std::string> invalid_test_env_var{{"CELERITY_DEVICES", "a"}};
-			const auto test_env = env::scoped_test_environment(invalid_test_env_var);
+			env::scoped_test_environment ste("CELERITY_DEVICES", "a");
 			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
 		}
 
 		{
-			std::unordered_map<std::string, std::string> invalid_test_env_var{{"CELERITY_DRY_RUN_NODES", "a"}};
-			const auto test_env = env::scoped_test_environment(invalid_test_env_var);
+			env::scoped_test_environment ste("CELERITY_DRY_RUN_NODES", "a");
 			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
 		}
 
 		{
-			std::unordered_map<std::string, std::string> invalid_test_env_var{{"CELERITY_PROFILE_KERNEL", "a"}};
-			const auto test_env = env::scoped_test_environment(invalid_test_env_var);
+			env::scoped_test_environment ste("CELERITY_PROFILE_KERNEL", "a");
 			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
 		}
 		{
-			std::unordered_map<std::string, std::string> invalid_test_env_var{{"CELERITY_FORCE_WG", "a"}};
-			const auto test_env = env::scoped_test_environment(invalid_test_env_var);
-			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
-		}
-
-		{
-			std::unordered_map<std::string, std::string> invalid_test_env_var{{"CELERITY_PROFILE_OCL", "a"}};
-			const auto test_env = env::scoped_test_environment(invalid_test_env_var);
+			env::scoped_test_environment ste("CELERITY_FORCE_WG", "a");
 			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
 		}
 
 		{
-			std::unordered_map<std::string, std::string> invalid_test_env_var{{"CELERITY_TRACY", "foo"}};
-			const auto test_env = env::scoped_test_environment(invalid_test_env_var);
+			env::scoped_test_environment ste("CELERITY_PROFILE_OCL", "a");
+			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
+		}
+
+		{
+			env::scoped_test_environment ste("CELERITY_TRACY", "foo");
 			CHECK_THROWS_WITH((celerity::detail::config(nullptr, nullptr)), error_string);
 		}
 	}

--- a/test/system/distr_tests.cc
+++ b/test/system/distr_tests.cc
@@ -216,7 +216,7 @@ namespace detail {
 					{
 						size_t relative = global_linear_id;
 						for(int nd = 0; nd < Dims; ++nd) {
-							int d = Dims - 1 - nd;
+							const int d = Dims - 1 - nd;
 							global_id[d] = relative % global_range[d];
 							relative /= global_range[d];
 						}

--- a/test/system_benchmarks.cc
+++ b/test/system_benchmarks.cc
@@ -215,7 +215,6 @@ void run_rsim_benchmark(const size_t n_tris, const size_t num_iter) {
 
 				cgh.parallel_for(kij_size, [=](item<2> item) {
 					float val = 0.f;
-					float included_items = 0.f;
 					for(size_t i = 0; i < t; ++i) {
 						val += read_rad[{i, item.get_id(0)}] * read_kij[{item.get_id(0), item.get_id(1)}];
 					}

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -391,24 +391,24 @@ namespace detail {
 		auto buf_a = tt.mbf.create_buffer(range<1>(128));
 		auto buf_b = tt.mbf.create_buffer(range<1>(128));
 
-		task_id tid_1 = test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) {
+		const task_id tid_1 = test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) {
 			buf_a.get_access<access_mode::discard_write>(cgh, fixed<1>({0, 64}));
 			buf_b.get_access<access_mode::discard_write>(cgh, fixed<1>({0, 128}));
 		});
-		task_id tid_2 =
+		const task_id tid_2 =
 		    test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) { buf_a.get_access<access_mode::discard_write>(cgh, fixed<1>({64, 64})); });
-		[[maybe_unused]] task_id tid_3 =
+		[[maybe_unused]] const task_id tid_3 =
 		    test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) { buf_a.get_access<access_mode::read_write>(cgh, fixed<1>({32, 64})); });
-		task_id tid_4 =
+		const task_id tid_4 =
 		    test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) { buf_a.get_access<access_mode::read_write>(cgh, fixed<1>({32, 64})); });
 
 		const auto horizon = task_manager_testspy::get_current_horizon(tt.tm);
 		CHECK(test_utils::get_num_live_horizons(tt.tdag) == 1);
 		CHECK(horizon != nullptr);
 
-		[[maybe_unused]] task_id tid_6 =
+		[[maybe_unused]] const task_id tid_6 =
 		    test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) { buf_b.get_access<access_mode::read_write>(cgh, fixed<1>({0, 128})); });
-		[[maybe_unused]] task_id tid_7 =
+		[[maybe_unused]] const task_id tid_7 =
 		    test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) { buf_b.get_access<access_mode::read_write>(cgh, fixed<1>({0, 128})); });
 
 		{
@@ -419,7 +419,7 @@ namespace detail {
 			CHECK(region_map_a.get_region_values(make_region(32, 96)).front().second == test_utils::get_task(tt.tdag, tid_4));
 		}
 
-		[[maybe_unused]] task_id tid_8 =
+		[[maybe_unused]] const task_id tid_8 =
 		    test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) { buf_b.get_access<access_mode::read_write>(cgh, fixed<1>({0, 128})); });
 
 		CHECK(test_utils::get_num_live_horizons(tt.tdag) == 2);
@@ -430,7 +430,7 @@ namespace detail {
 			CHECK(region_map_a.get_region_values(make_region(0, 128)).front().second == horizon);
 		}
 
-		task_id tid_9 =
+		const task_id tid_9 =
 		    test_utils::add_host_task(tt.tm, on_master_node, [&](handler& cgh) { buf_a.get_access<access_mode::read_write>(cgh, fixed<1>({64, 64})); });
 
 		{


### PR DESCRIPTION
Resolves #127.

There's two lints we would like to have but can't enable fully due to FPs:
- `misc-const-correctness` will suggest `const accessor` and `const std::lock_guard`, which is just noise. I've enabled this in the runtime, but disabled it for examples and tests - we don't constuct too many accessors in runtime code itself.
- `misc-include-cleaner` doesn't understand "interface headers" like `<sycl/sycl.hpp>` and will insist we include `<hipSYCL/sycl/handler.hpp>` et al. It also removes includes that are necessary for trait implementations, such as those of `fmt::formatter`.

I've manually performed autofixes for both these lints and added sensible corrections resulting from them as individual commits in this PR to clean up the codebase somewhat.

I also used the include-cleaner mayhem as an opportunity to set a consistent `#include` schema:

```c++
#pragma once // ONLY in my_interface.h
#include "my_interface.h" // ONLY in my_interface.cc

// 1 blank line, then all other headers form my module
#include "sibling_header_1.h"
#include "sibling_header_2.h"

// 1 blank line, then everything from the stdlib
#include <stdlib_header>
#include <stdlib_header_2>

// 1 blank line, then all 3rdparty deps
#include <3rdparty1/header.h>
#include <3rdparty2/header.h>

// 1 blank line, then any conditional includes (and maybe defines)
#ifdef ANY_CONDITIONAL_INCLUDES
#include <whatever.h>
#endif


// 2 blank lines, then the first actual token in the file
namespace celerity::detail {
...
```

I'm including my own headers before the stdlib or 3rdparty dependencies, because this is more likely to lead to a compiler error when another header forgets to include something. clang-format is smart enough to alphabetically sort includes within those groups.

I didn't bother with updating includes in tests in this PR.