### PR TITLE
Update libenvpp version to 1.5, remove obsolete code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ macro(fetch_content_from_submodule DEPNAME RELPATH)
   #   - another depencency of celerity-runtime that it transitively shares a depencency with (SimSYCL -> libenvpp)
   # The top-level CMake project must ensure that there are no conflicts between dependency versions in this case.
   if(${DEPNAME}_FOUND)
-    message(STATUS "Using system ${DEPNAME} in ${${DEPNAME}_DIR}")
+    message(STATUS "Using existing ${DEPNAME} in ${${DEPNAME}_DIR}, please ensure that the version (${${DEPNAME}_VERSION}) is compatible")
     set(CELERITY_DETAIL_USE_SYSTEM_${DEPNAME} ON)
   else()
     message(STATUS "Fetching ${DEPNAME} from submodule")

--- a/include/tracy.h
+++ b/include/tracy.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "version.h"
+#include "version.h" // required for CELERITY_TRACY_SUPPORT
 
 #if CELERITY_TRACY_SUPPORT
 


### PR DESCRIPTION
Very satisfying.
The [new release of libenvpp](https://github.com/ph3at/libenvpp/releases/tag/v1.5.0) does basic option parsing for us.
Also removed 3 completely unused functions from utils, and simplified some of the rest thanks to our switch to C++20.

Drive-by: 
```cpp
#include "version.h" // required for CELERITY_TRACY_SUPPORT
```
in `tracy.h` to document this unusual header ordering.