### PR TITLE
Exclude src/testspy from coverage

### DIFF
--- a/ci/capture-coverage.sh
+++ b/ci/capture-coverage.sh
@@ -12,7 +12,7 @@ exec fastcov \
 	--search-directory "$BUILD_DIR" \
 	--process-gcno \
 	--include "$SOURCE_DIR/include" "$SOURCE_DIR/src" \
-	--exclude "$SOURCE_DIR/src/catch2" \
+	--exclude "$SOURCE_DIR/src/catch2" "$SOURCE_DIR/src/testspy" \
 	--branch-coverage \
 	--exclude-br-lines-starting-with assert CELERITY_DETAIL_ASSERT_ON_HOST \
 	--lcov \

--- a/include/distr_queue.h
+++ b/include/distr_queue.h
@@ -150,7 +150,7 @@ class [[deprecated("Use celerity::queue instead")]] distr_queue {
 
 			// ~distr_queue() guarantees that all operations on that particular queue have finished executing, which we simply guarantee by waiting on all
 			// operations on all live queues.
-			if(detail::runtime::has_instance()) { detail::runtime::get_instance().sync(detail::epoch_action::none); }
+			detail::runtime::get_instance().sync(detail::epoch_action::none);
 		}
 	};
 

--- a/include/queue.h
+++ b/include/queue.h
@@ -112,7 +112,7 @@ class queue {
 
 			// ~queue() guarantees that all operations on that particular queue have finished executing, which we simply guarantee by waiting on all operations
 			// on all live queues.
-			if(detail::runtime::has_instance()) { detail::runtime::get_instance().sync(detail::epoch_action::none); }
+			detail::runtime::get_instance().sync(detail::epoch_action::none);
 		}
 	};
 


### PR DESCRIPTION
Since #308, scheduler / runtime testspies are located in `src`, which was included in coverage reports. Since it's test code, it shouldn't be.

I've also removed one leftover branch from #283 I found in the coverage report.