### PR TITLE
SimSYCL is now thread-safe; remove workarounds

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -70,14 +70,6 @@ namespace detail {
 			if(has_profile_kernel) { m_enable_device_profiling = *has_profile_kernel; }
 
 			m_enable_backend_device_submission_threads = parsed_and_validated_envs.get_or(env_backend_device_submission_threads, true);
-#if CELERITY_WORKAROUND(SIMSYCL)
-			// SimSYCL is not thread safe
-			if(m_enable_backend_device_submission_threads) {
-				CELERITY_WARN("CELERITY_BACKEND_DEVICE_SUBMISSION_THREADS=on is not supported with SimSYCL. Disabling worker threads.");
-				m_enable_backend_device_submission_threads = false;
-			}
-#endif // CELERITY_WORKAROUND(SIMSYCL)
-
 			m_thread_pinning_config = parsed_and_validated_envs.get_or(env_thread_pinning, {});
 
 			const auto dry_run_num_nodes = parsed_and_validated_envs.get(env_dry_run_num_nodes);

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -233,12 +233,10 @@ namespace celerity::test_utils_detail {
 
 // These error and warning messages will appear depending on the system the (runtime) tests are executed on, so we must not fail tests because of them.
 
-const char* const expected_runtime_init_warnings_regex =
-    "Celerity has detected that only .* logical cores are available to this process.*|"
-    "Celerity detected more than one node \\(MPI rank\\) on this host, which is not recommended.*|"
-    "Instrumentation for profiling with Tracy is enabled\\. Performance may be negatively impacted\\.|"
-    "\\[executor\\] no progress for .* seconds, potentially stuck.*|"
-    "CELERITY_BACKEND_DEVICE_SUBMISSION_THREADS=on is not supported with SimSYCL\\. Disabling worker threads\\.";
+const char* const expected_runtime_init_warnings_regex = "Celerity has detected that only .* logical cores are available to this process.*|"
+                                                         "Celerity detected more than one node \\(MPI rank\\) on this host, which is not recommended.*|"
+                                                         "Instrumentation for profiling with Tracy is enabled\\. Performance may be negatively impacted\\.|"
+                                                         "\\[executor\\] no progress for .* seconds, potentially stuck.*";
 
 const char* const expected_device_enumeration_warnings_regex = "Found fewer devices .* than local nodes .*, multiple nodes will use the same device.*";
 


### PR DESCRIPTION
Since celerity/SimSYCL#14 is now merged, we don't need explicit threading workarounds in the backend anymore.