### PR TITLE
Improve wording of uninitialized read warning

### DIFF
--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -883,22 +883,39 @@ namespace detail {
 
 		std::string expected_warning_message;
 
-		SECTION("in device kernels") {
+		SECTION("in device kernels, pure consumer mode") {
 			q.submit([&](handler& cgh) {
 				accessor acc(buf, cgh, celerity::access::all(), celerity::read_only);
 				cgh.parallel_for(range(1), [=](item<1>) { (void)acc; });
 			});
-			expected_warning_message = "Device kernel T1 declares a reading access on uninitialized B0 {[0,0,0] - [1,1,1]}. Make sure to construct the "
-			                           "accessor with no_init if possible.";
+			expected_warning_message = "Device kernel T1 declares a reading access on uninitialized B0 {[0,0,0] - [1,1,1]}.";
 		}
 
-		SECTION("in host tasks") {
+		SECTION("in device kernels, producer mode") {
+			q.submit([&](handler& cgh) {
+				accessor acc(buf, cgh, celerity::access::all(), celerity::write_only);
+				cgh.parallel_for(range(1), [=](item<1>) { (void)acc; });
+			});
+			expected_warning_message = "Device kernel T1 declares a consuming access on uninitialized B0 {[0,0,0] - [1,1,1]}. Make sure to construct the "
+			                           "accessor with no_init if this was unintentional.";
+		}
+
+		SECTION("in host tasks, pure consumer mode") {
 			q.submit([&](handler& cgh) {
 				accessor acc(buf, cgh, celerity::access::all(), celerity::read_only_host_task);
 				cgh.host_task(on_master_node, [=] { (void)acc; });
 			});
-			expected_warning_message = "Master-node host task T1 declares a reading access on uninitialized B0 {[0,0,0] - [1,1,1]}. Make sure to construct the "
-			                           "accessor with no_init if possible.";
+			expected_warning_message = "Master-node host task T1 declares a reading access on uninitialized B0 {[0,0,0] - [1,1,1]}.";
+		}
+
+		SECTION("in host tasks, producer mode") {
+			q.submit([&](handler& cgh) {
+				accessor acc(buf, cgh, celerity::access::all(), celerity::write_only_host_task);
+				cgh.host_task(on_master_node, [=] { (void)acc; });
+			});
+			expected_warning_message =
+			    "Master-node host task T1 declares a consuming access on uninitialized B0 {[0,0,0] - [1,1,1]}. Make sure to construct the "
+			    "accessor with no_init if this was unintentional.";
 		}
 
 		q.wait();

--- a/test/task_graph_tests.cc
+++ b/test/task_graph_tests.cc
@@ -766,8 +766,7 @@ namespace detail {
 
 			CHECK_THROWS_WITH((test_utils::add_compute_task(
 			                      tt.tm, [&](handler& cgh) { debug::set_task_name(cgh, "uninit_read"), buf.get_access<access_mode::read>(cgh, all{}); })),
-			    "Device kernel T1 \"uninit_read\" declares a reading access on uninitialized B0 {[0,0,0] - [1,1,1]}. Make sure to construct the accessor with "
-			    "no_init if possible.");
+			    "Device kernel T1 \"uninit_read\" declares a reading access on uninitialized B0 {[0,0,0] - [1,1,1]}.");
 		}
 
 		SECTION("on a partially initialized buffer") {
@@ -776,10 +775,9 @@ namespace detail {
 			    tt.tm, [&](handler& cgh) { buf.get_access<access_mode::discard_write>(cgh, fixed<2>({{0, 0}, {32, 32}})); });
 
 			CHECK_THROWS_WITH((test_utils::add_compute_task(
-			                      tt.tm, [&](handler& cgh) { debug::set_task_name(cgh, "uninit_read"), buf.get_access<access_mode::read>(cgh, all{}); })),
-			    "Device kernel T2 \"uninit_read\" declares a reading access on uninitialized B0 {[0,32,0] - [32,64,1], [32,0,0] - [64,64,1]}. Make sure to "
-			    "construct "
-			    "the accessor with no_init if possible.");
+			                      tt.tm, [&](handler& cgh) { debug::set_task_name(cgh, "uninit_read"), buf.get_access<access_mode::write>(cgh, all{}); })),
+			    "Device kernel T2 \"uninit_read\" declares a consuming access on uninitialized B0 {[0,32,0] - [32,64,1], [32,0,0] - [64,64,1]}. Make sure to "
+			    "construct the accessor with no_init if this was unintentional.");
 		}
 	}
 


### PR DESCRIPTION
The previous warning suggested to use `no_init` even for pure-consumer (`read_only`) accesses, which never made any sense.