### PR TITLE
Change split functions to work on box instead of chunk

### DIFF
--- a/include/command_graph_generator.h
+++ b/include/command_graph_generator.h
@@ -217,7 +217,7 @@ class command_graph_generator {
 
 	struct assigned_chunk {
 		node_id executed_on = -1;
-		chunk<3> chnk;
+		box<3> chnk;
 	};
 
 	struct buffer_requirements {
@@ -239,7 +239,7 @@ class command_graph_generator {
 
 	std::vector<assigned_chunk> split_task_and_assign_chunks(const task& tsk) const;
 
-	buffer_requirements_list get_buffer_requirements_for_mapped_access(const task& tsk, const subrange<3>& sr) const;
+	buffer_requirements_list get_buffer_requirements_for_mapped_access(const task& tsk, const box<3>& box) const;
 
 	assigned_chunks_with_requirements compute_per_chunk_requirements(const task& tsk, const std::vector<assigned_chunk>& chunks) const;
 

--- a/include/split.h
+++ b/include/split.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "grid.h"
 #include "ranges.h"
 
 #include <cstddef>
@@ -8,7 +9,7 @@
 
 namespace celerity::detail {
 
-std::vector<chunk<3>> split_1d(const chunk<3>& full_chunk, const range<3>& granularity, const size_t num_chunks);
-std::vector<chunk<3>> split_2d(const chunk<3>& full_chunk, const range<3>& granularity, const size_t num_chunks);
+std::vector<box<3>> split_1d(const box<3>& full_box, const range<3>& granularity, const size_t num_boxs);
+std::vector<box<3>> split_2d(const box<3>& full_box, const range<3>& granularity, const size_t num_boxs);
 
 } // namespace celerity::detail

--- a/src/command_graph_generator.cc
+++ b/src/command_graph_generator.cc
@@ -117,11 +117,9 @@ std::vector<const command*> command_graph_generator::build_task(const task& tsk)
 }
 
 void command_graph_generator::report_overlapping_writes(const task& tsk, const box_vector<3>& local_chunks) const {
-	const chunk<3> full_chunk{tsk.get_global_offset(), tsk.get_global_size(), tsk.get_global_size()};
-
 	// Since this check is run distributed on every node, we avoid quadratic behavior by only checking for conflicts between all local chunks and the
 	// region-union of remote chunks. This way, every conflict will be reported by at least one node.
-	const box<3> global_chunk(subrange(full_chunk.offset, full_chunk.range));
+	const box<3> global_chunk(subrange(tsk.get_global_offset(), tsk.get_global_size()));
 	auto remote_chunks = region_difference(global_chunk, region(box_vector<3>(local_chunks))).into_boxes();
 
 	// detect_overlapping_writes takes a single box_vector, so we concatenate local and global chunks (the order does not matter)

--- a/src/instruction_graph_generator.cc
+++ b/src/instruction_graph_generator.cc
@@ -1502,12 +1502,11 @@ std::vector<localized_chunk> generator_impl::split_task_execution_range(const ex
 	    tsk.has_variable_split() && tsk.get_side_effect_map().empty() && tsk.get_collective_group_id() == non_collective_group_id;
 	const auto split = tsk.get_hint<experimental::hints::split_2d>() != nullptr ? split_2d : split_1d;
 
-	const auto command_sr = ecmd.get_execution_range();
-	const auto command_chunk = chunk<3>(command_sr.offset, command_sr.range, tsk.get_global_size());
+	const auto command_chunk = box<3>(ecmd.get_execution_range());
 
 	// As a heuristic to keep inter-device communication to a minimum, we split the execution range twice when oversubscription is active: Once to obtain
 	// contiguous chunks per device, and one more (below) to subdivide the ranges on each device (which can help with computation-communication overlap).
-	std::vector<chunk<3>> coarse_chunks;
+	std::vector<box<3>> coarse_chunks;
 	if(is_splittable_locally && tsk.get_execution_target() == execution_target::device) {
 		coarse_chunks = split(command_chunk, tsk.get_granularity(), m_system.devices.size());
 	} else {
@@ -1537,7 +1536,7 @@ std::vector<localized_chunk> generator_impl::split_task_execution_range(const ex
 	for(size_t coarse_idx = 0; coarse_idx < coarse_chunks.size(); ++coarse_idx) {
 		for(const auto& fine_chunk : split(coarse_chunks[coarse_idx], tsk.get_granularity(), oversubscribe_factor)) {
 			auto& localized_chunk = concurrent_chunks.emplace_back();
-			localized_chunk.execution_range = box(subrange(fine_chunk.offset, fine_chunk.range));
+			localized_chunk.execution_range = fine_chunk;
 			if(tsk.get_execution_target() == execution_target::device) {
 				assert(coarse_idx < m_system.devices.size());
 				localized_chunk.memory_id = m_system.devices[coarse_idx].native_memory;


### PR DESCRIPTION
`chunk` is a purely user-facing type (and of questionable usefulness at that), and since all of our internal tracking is built around `box`, splitting should follow suit.