### PR TITLE
Simplify feature macros

### DIFF
--- a/include/handler.h
+++ b/include/handler.h
@@ -219,12 +219,8 @@ namespace detail {
 
 	template <typename KernelName, typename... Params>
 	inline void invoke_sycl_parallel_for(sycl::handler& cgh, Params&&... args) {
-		static_assert(CELERITY_FEATURE_UNNAMED_KERNELS || !is_unnamed_kernel<KernelName>,
-		    "Your SYCL implementation does not support unnamed kernels, add a kernel name template parameter to this parallel_for invocation");
 		if constexpr(detail::is_unnamed_kernel<KernelName>) {
-#if CELERITY_FEATURE_UNNAMED_KERNELS // see static_assert above
 			cgh.parallel_for(std::forward<Params>(args)...);
-#endif
 		} else {
 			cgh.parallel_for<KernelName>(std::forward<Params>(args)...);
 		}

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -329,8 +329,6 @@ namespace detail {
 		});
 	}
 
-#if CELERITY_FEATURE_UNNAMED_KERNELS
-
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "handler::parallel_for kernel names are optional", "[handler][reduction]") {
 		queue q;
 
@@ -361,8 +359,6 @@ namespace detail {
 			    [=](nd_item<1> item, auto& r) { r += static_cast<int>(item.get_global_linear_id()); });
 		});
 	}
-
-#endif
 
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "handler throws when accessor target does not match command type", "[handler]") {
 		queue q;

--- a/test/runtime_tests.cc
+++ b/test/runtime_tests.cc
@@ -366,7 +366,7 @@ namespace detail {
 		buffer<size_t, 1> buf1{1};
 
 		SECTION("capturing host accessor into device kernel") {
-#if !defined(__SYCL_COMPILER_VERSION) // TODO: This may break when using AdaptiveCpp w/ DPC++ as compiler
+#if !CELERITY_SYCL_IS_DPCPP
 			CHECK_THROWS_WITH(([&] {
 				q.submit([&](handler& cgh) {
 					accessor acc0{buf1, cgh, one_to_one{}, write_only_host_task};
@@ -400,7 +400,7 @@ namespace detail {
 
 	TEST_CASE_METHOD(test_utils::runtime_fixture, "handler throws when accessing host objects within device tasks", "[handler]") {
 		queue q;
-#if !defined(__SYCL_COMPILER_VERSION) // TODO: This may break when using AdaptiveCpp w/ DPC++ as compiler
+#if !CELERITY_SYCL_IS_DPCPP
 		experimental::host_object<size_t> ho;
 
 		CHECK_THROWS_WITH(([&] {
@@ -427,7 +427,7 @@ namespace detail {
 				accessor acc0{buf0, cgh, one_to_one{}, write_only};
 				accessor acc1{buf1, cgh, one_to_one{}, write_only};
 				// DPC++ has its own compile-time check for this, so we can't actually capture anything by reference
-#if !defined(__SYCL_COMPILER_VERSION) // TODO: This may break when using AdaptiveCpp w/ DPC++ as compiler
+#if !CELERITY_SYCL_IS_DPCPP
 				cgh.parallel_for(range<1>(1), [acc0, &acc1 /* oops */](item<1>) {
 					(void)acc0;
 					(void)acc1;


### PR DESCRIPTION
Two very simple fixes around feature / environment macros:

- `CELERITY_FEATURE_UNNAMED_KERNELS` is unconditionally true and only exists for backwards compatibility in applications, so we can remove all branches in our code on this constant (was needed for ComputeCpp)
- `runtime_test` used `defined(__SYCL_COMPILER_VERSION)` to check for DPC++, but we have the `SYCL_IS_*` macros now.