### PR TITLE
Minor improvements to CI stability + Tracy/OOB build fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Host-initialized buffers will not read from user-provided memory after the last reference to the buffer has been dropped (#283)
+- Fix a build issue with (rare) configurations which enable both Tracy and OOB-checks (#331)
 
 ### Deprecated
 

--- a/src/live_executor.cc
+++ b/src/live_executor.cc
@@ -492,7 +492,7 @@ void executor_impl::retire_async_instruction(const instruction_id iid, async_ins
 
 #if CELERITY_ACCESSOR_BOUNDARY_CHECK
 	if(async.oob_info != nullptr) {
-		CELERITY_DETAIL_TRACY_ZONE_SCOPED_V("executor::oob_check", Red, "I{} bounds check", iid);
+		CELERITY_DETAIL_TRACY_ZONE_SCOPED_V("executor::oob_check", executor_oob_check, "I{} bounds check", iid);
 		const auto& oob_info = *async.oob_info;
 		for(size_t i = 0; i < oob_info.accessors.size(); ++i) {
 			if(const auto oob_box = oob_info.illegal_access_bounding_boxes[i].into_box(); !oob_box.empty()) {

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -235,8 +235,7 @@ namespace celerity::test_utils_detail {
 
 const char* const expected_runtime_init_warnings_regex = "Celerity has detected that only .* logical cores are available to this process.*|"
                                                          "Celerity detected more than one node \\(MPI rank\\) on this host, which is not recommended.*|"
-                                                         "Instrumentation for profiling with Tracy is enabled\\. Performance may be negatively impacted\\.|"
-                                                         "\\[executor\\] no progress for .* seconds, potentially stuck.*";
+                                                         "Instrumentation for profiling with Tracy is enabled\\. Performance may be negatively impacted\\.|";
 
 const char* const expected_device_enumeration_warnings_regex = "Found fewer devices .* than local nodes .*, multiple nodes will use the same device.*";
 
@@ -246,6 +245,8 @@ const char* const expected_backend_fallback_warnings_regex =
 
 const char* const expected_dry_run_executor_warnings_regex = "Encountered a \"fence\" command while \"CELERITY_DRY_RUN_NODES\" is set. The result of this "
                                                              "operation will not match the expected output of an actual run.";
+
+const char* const expected_executor_progress_warnings_regex = "\\[executor\\] no progress for .* s, might be stuck.*";
 
 } // namespace celerity::test_utils_detail
 
@@ -281,6 +282,11 @@ runtime_fixture::runtime_fixture() {
 	allow_higher_level_log_messages(spdlog::level::warn, test_utils_detail::expected_runtime_init_warnings_regex);
 	allow_higher_level_log_messages(spdlog::level::warn, test_utils_detail::expected_device_enumeration_warnings_regex);
 	allow_higher_level_log_messages(spdlog::level::warn, test_utils_detail::expected_backend_fallback_warnings_regex);
+
+	// in debug builds, allow executor "stuck" warnings to avoid spurious test failures due to slow execution
+#if CELERITY_DETAIL_ENABLE_DEBUG
+	allow_higher_level_log_messages(spdlog::level::warn, test_utils_detail::expected_executor_progress_warnings_regex);
+#endif
 }
 
 runtime_fixture::~runtime_fixture() {


### PR DESCRIPTION
Several recent CI debug runs failed spuriously due to the executor progress warning.

We already had code to ignore it, but it was apparently outdated (see changes).
Instead of applying the fixed version indiscriminately, it is now only applied in debug builds.

This also includes a build fix for the uncommon Tracy + OOB Check configuration as a drive-by.