### PR TITLE
Fix: undefined buffer_snapshot move assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [WIP]
+
+This release is WIP
+
+### Fixed
+- Fix a missing return statement for the `buffer_snapshot` move assignment operator (#335)
+
 ## [0.7.0] - 2025-08-18
 
 This release includes changes that may require adjustments when upgrading:

--- a/include/fence.h
+++ b/include/fence.h
@@ -36,6 +36,7 @@ class buffer_snapshot {
 	buffer_snapshot& operator=(buffer_snapshot&& other) noexcept {
 		m_subrange = other.m_subrange, other.m_subrange = {};
 		m_data = std::move(other.m_data);
+		return *this;
 	}
 
 	id<Dims> get_offset() const { return m_subrange.offset; }


### PR DESCRIPTION
This fixes a problem I came across while porting Celerity to Windows. The move assignment operator never returned `*this`, which resulted in really weird bugs on Windows.